### PR TITLE
Fix decoding uppercase letters, special keys. US key board.

### DIFF
--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -131,7 +131,9 @@ class VNCDoToolClient(rfb.RFBClient):
     cmask = None
 
     def _decodeKey(self, key):
-        if self.factory.force_caps and key.isupper():
+        if (self.factory.force_caps and key.isalpha() and key.islower()) \
+                or (key.isupper()) \
+                or (key in "~!@#$%^&*()_+{}|:\"<>?"):
             key = 'shift-%c' % key
 
         if len(key) == 1:

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -102,6 +102,8 @@ KEYMAP = {
     'kpenter': rfb.KEY_KP_Enter,
 }
 
+SPECIAL_KEYS_US = "~!@#$%^&*()_+{}|:\"<>?"
+
 # Enable using vncdotool without PIL. Of course capture and expect
 # won't work but at least we can still offer key, type, press and
 # move.
@@ -133,7 +135,7 @@ class VNCDoToolClient(rfb.RFBClient):
     def _decodeKey(self, key):
         if (self.factory.force_caps and key.isalpha() and key.islower()) \
                 or (key.isupper()) \
-                or (key in "~!@#$%^&*()_+{}|:\"<>?"):
+                or (key in SPECIAL_KEYS_US):
             key = 'shift-%c' % key
 
         if len(key) == 1:


### PR DESCRIPTION
I would like to suggest this little fix.

Bug: decodeKey function worked in wrong way for special keys (~!@# and so on). and for lower case letters.

This little change is based on the follow principle:
1. CAPS_LOCK affects only letters. 
2. if CAPS_LOCK is true, then it affects letters as follows: lower case letters become uppercase and uppercase letters become lowercase
3. key.isupper() returns true only for uppercase letters (AQWEDF). For special keys, it returns false.
4. There are special keys, which we can type without holding SHIFT, and there are which require holding SHIFT. As I mentioned,  key.isupper()  does not return true for special keys typed with holding key. That's why we should have a list of special keys which must be typed with holding SHIFT.  Of course, it depends on keyboard layout, but I imply the US keyboard layout. The adjustment for other keyboards could be done later, if it will be required.

 