### PR TITLE
Add a 'typefile' command

### DIFF
--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -87,6 +87,7 @@ class VNCDoToolOptionParser(optparse.OptionParser):
             'Common Commands (CMD):',
             '  key KEY\t\tsend KEY to server, alphanumeric or keysym: ctrl-c, del',
             '  type TEXT\t\tsend alphanumeric string of TEXT',
+            '  typefile FILENAME\t\ttype out the contents of FILENAME',
             '  move X Y\t\tmove the mouse cursor to position X,Y',
             '  click BUTTON\t\tsend a mouse BUTTON click',
             '  capture FILE\t\tsave current screen as FILE',
@@ -143,6 +144,19 @@ def build_command_list(factory, args, delay=None, warp=1.0):
                 factory.deferred.addCallback(client.keyPress, key)
                 if delay:
                     factory.deferred.addCallback(client.pause, delay)
+        elif cmd == 'typefile':
+            with open(args.pop(0)) as f:
+                content = f.read()
+                for key in content:
+                    if key == '\r':
+                        continue
+                    if key == '\n':
+                        key = 'enter'
+                    if key == '\t':
+                        key = 'tab'
+                    factory.deferred.addCallback(client.keyPress, key)
+                    if delay:
+                        factory.deferred.addCallback(client.pause, delay)
         elif cmd == 'capture':
             filename = args.pop(0)
             imgformat = os.path.splitext(filename)[1][1:]


### PR DESCRIPTION
This enables a commandline like:

vncdo -s server -p password typefile abc.txt

to type the contents of abc.txt into the target server

Limitations:

This is only intended to support typeable characters, so trying to type a binary file
will fail.

This required adding of mappings for \n and \t to the relevant keys, which was enough
for my requirements, but there may be others that need to be added for full coverage.
