### PR TITLE
provide default for verbose option, fixes #78

### DIFF
--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -199,7 +199,6 @@ class TestParseHost(object):
         assert port == 1111
 
 
-
 class TestVNCDoCLIClient(unittest.TestCase):
 
     def setUp(self):

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -236,7 +236,7 @@ def add_standard_options(parser):
     parser.add_option('--logfile', action='store', metavar='FILE',
         help='output logging information to FILE')
 
-    parser.add_option('-v', '--verbose', action='count',
+    parser.add_option('-v', '--verbose', action='count', default=0,
         help='increase verbosity, use multple times')
 
     return parser


### PR DESCRIPTION
Looks like py2 defaults counts to 0 but 3.x sets None