### PR TITLE
Provide HTML doc pages via package python-vncdotool-doc

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,3 +21,8 @@ Package: vnclogd
 Architecture: all
 Depends: python-vncdotool
 Description: Daemon to record VNC sessions for playback with vncdotool
+
+Package: python-vncdotool-doc
+Architecture: all
+Description: Documentation for the vncdotool package
+

--- a/debian/python-vncdotool-doc.install
+++ b/debian/python-vncdotool-doc.install
@@ -1,0 +1,1 @@
+docs/_build/html/*	usr/share/doc/python-vncdotool/


### PR DESCRIPTION
You could provide the HTML documentation via an additional package python-vncdotool-doc. I added the package in this commit here.