### PR TITLE
Implemented DesktopSize Pseudo-Encoding.

### DIFF
--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -412,6 +412,11 @@ class VNCDoToolClient(rfb.RFBClient):
         y = self.y - self.cfocus[1]
         self.screen.paste(self.cursor, (x, y), self.cmask)
 
+    def updateDesktopSize(self, width, height):
+        new_screen = Image.new("RGB", (width, height), "black")
+        new_screen.paste(self.screen, (0, 0))
+        self.screen = new_screen
+
 
 class VNCDoToolFactory(rfb.RFBFactory):
     password = None

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -37,6 +37,7 @@ ZLIBHEX_ENCODING =              8
 ZRLE_ENCODING =                 16
 #0xffffff00 to 0xffffffff tight options
 PSEUDO_CURSOR_ENCODING =        -239
+PSEUDO_DESKTOP_SIZE_ENCODING =  -223
 
 #keycodes
 #for KeyEvent()
@@ -265,6 +266,8 @@ class RFBClient(Protocol):
                 length = width * height * self.bypp
                 length += int(math.floor((width + 7.0) / 8)) * height
                 self.expect(self._handleDecodePsuedoCursor, length, x, y, width, height)
+            elif encoding == PSEUDO_DESKTOP_SIZE_ENCODING:
+                self._handleDecodeDesktopSize(width, height)
             else:
                 log.msg("unknown encoding received (encoding %d)" % encoding)
                 self._doConnection()
@@ -453,6 +456,11 @@ class RFBClient(Protocol):
         self.updateCursor(x, y, width, height, image, mask)
         self._doConnection()
 
+    # --- Pseudo Desktop Size Encoding
+    def _handleDecodeDesktopSize(self, width, height):
+        self.updateDesktopSize(width, height)
+        self._doConnection()
+
     # ---  other server messages
 
     def _handleServerCutText(self, block):
@@ -588,6 +596,9 @@ class RFBClient(Protocol):
     def updateCursor(self, x, y, width, height, image, mask):
         """ New cursor, focuses at (x, y)
         """
+
+    def updateDesktopSize(width, height):
+        """ New desktop size of width*height. """
 
     def bell(self):
         """bell"""


### PR DESCRIPTION
Hi sibson,
I've added the DesktopSize Pseudo-Encoding [specified in the RFB protocol](https://tools.ietf.org/html/rfc6143#section-7.8.2). As [suggested](http://vncdotool.readthedocs.io/en/latest/rfbproto.html?highlight=size#client-semantics) the data of the previous frambuffer is retained. Feel free to merge :)

