### PR TITLE
Added the DesktopSize Pseudo-Encoding as default.

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -40,7 +40,7 @@ class TestVNCDoToolClient(TestCase):
         cli.vncConnectionMade()
         factory = cli.factory
         factory.clientConnectionMade.assert_called_once_with(cli)
-        self.client.setEncodings.assert_called_once_with([client.rfb.RAW_ENCODING, client.rfb.PSEUDO_CURSOR_ENCODING])
+        self.client.setEncodings.assert_called_once_with([client.rfb.RAW_ENCODING, client.rfb.PSEUDO_CURSOR_ENCODING, client.rfb.PSEUDO_DESKTOP_SIZE_ENCODING])
 
     def test_keyPress_single_alpha(self):
         cli = self.client

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -344,7 +344,9 @@ class VNCDoToolClient(rfb.RFBClient):
 
     def vncConnectionMade(self):
         self.setPixelFormat()
-        encodings = [rfb.RAW_ENCODING, rfb.PSEUDO_DESKTOP_SIZE_ENCODING]
+        encodings = [rfb.RAW_ENCODING]
+        if not self.factory.disable_desktop_resizing:
+            encodings.append(rfb.PSEUDO_DESKTOP_SIZE_ENCODING)
         if self.factory.pseudocursor or self.factory.nocursor:
             encodings.append(rfb.PSEUDO_CURSOR_ENCODING)
         self.setEncodings(encodings)
@@ -424,6 +426,7 @@ class VNCDoToolFactory(rfb.RFBFactory):
     protocol = VNCDoToolClient
     shared = True
 
+    disable_desktop_resizing = False
     pseudocursor = False
     nocursor = False
     force_caps = False

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -344,7 +344,7 @@ class VNCDoToolClient(rfb.RFBClient):
 
     def vncConnectionMade(self):
         self.setPixelFormat()
-        encodings = [rfb.RAW_ENCODING]
+        encodings = [rfb.RAW_ENCODING, rfb.PSEUDO_DESKTOP_SIZE_ENCODING]
         if self.factory.pseudocursor or self.factory.nocursor:
             encodings.append(rfb.PSEUDO_CURSOR_ENCODING)
         self.setEncodings(encodings)

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -358,6 +358,9 @@ def vncdo():
         default=os.environ.get('VNCDOTOOL_DELAY', 10), type='int',
         help='delay MILLISECONDS between actions [%defaultms]')
 
+    op.add_option('--disable-desktop-resizing', action='store_true',
+        help="don't tell the vnc-server to use DesktopSize Pseudo-Encoding")
+
     op.add_option('--force-caps', action='store_true',
         help='for non-compliant servers, send shift-LETTER, ensures capitalization works')
 
@@ -385,6 +388,9 @@ def vncdo():
 
     factory = build_tool(options, args)
     factory.password = options.password
+
+    if options.disable_desktop_resizing:
+        factory.disable_desktop_resizing = True
 
     if options.localcursor:
         factory.pseudocursor = True


### PR DESCRIPTION
As discussed in #87 vncdotool will now signal that it supports the DesktopSize Pseudo-Encoding to
the server by default.