### PR TITLE
Fix vncdotool for Python 2

### DIFF
--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -141,7 +141,7 @@ class RFBClient(Protocol):
             log.msg("Using protocol version %.3f" % version)
             parts = str(version).split('.')
             self.transport.write(
-                bytes("RFB %03d.%03d\n" % (int(parts[0]), int(parts[1])), 'ascii'))
+                bytes(b"RFB %03d.%03d\n" % (int(parts[0]), int(parts[1]))))
             self._packet[:] = [buffer]
             self._packet_len = len(buffer)
             self._handler = self._handleExpected


### PR DESCRIPTION
Altered the code, so that it works both for Python 2 and Python 3. bytes
in Python 2 is just an alias for str, so it has no second positional
"encoding" argument.

This fixes #97

Signed-off-by: Vitaly Ostrosablin <vostrosablin@virtuozzo.com>