### PR TITLE
Fix password check with XTightVNC server and updating the first screen

### DIFF
--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -417,7 +417,8 @@ class VNCDoToolClient(rfb.RFBClient):
 
     def updateDesktopSize(self, width, height):
         new_screen = Image.new("RGB", (width, height), "black")
-        new_screen.paste(self.screen, (0, 0))
+        if self.screen:
+            new_screen.paste(self.screen, (0, 0))
         self.screen = new_screen
 
 

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -631,8 +631,8 @@ class RFBDes(pyDes.des):
             for i in range(8):
                 if bsrc & (1 << i):
                     btgt = btgt | (1 << 7-i)
-            newkey.append(btgt)
-        super(RFBDes, self).setKey(bytes(newkey))
+            newkey.append(chr(btgt))
+        super(RFBDes, self).setKey(newkey)
 
 
 # --- test code only, see vncviewer.py


### PR DESCRIPTION
I could not get connection and screenshot working without these fixes with a XTightVNC server that requires password.

First issue: server closed connection right after client sent the password. This got fixed by changing the password code back to what is used to be commit 659a9e3.

Second issue: getting the first screenshot failed to a PIL error. This got fixed by not trying to update non-existing screenshot.
