### PR TITLE
Add support for UNIX sockets

### DIFF
--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -1,6 +1,6 @@
-
 from vncdotool import command
 
+import socket
 import unittest
 
 from . import mock
@@ -153,15 +153,17 @@ class TestBuildCommandList(unittest.TestCase):
         self.assertEqual(self.deferred.addCallback.call_args_list, expected)
 
 
-class TestParseHost(object):
-
+class TestParseServer(object):
     def setUp(self):
-        self.isolation = mock.isolate.object(command.parse_host)
+        self.isolation = mock.isolate.object(command.parse_server)
         self.isolation.start()
         self.options = mock.Mock()
         self.options.server = '127.0.0.1'
         parse_args = command.VNCDoToolOptionParser.return_value.parse_args
         parse_args.return_value = (self.options, [])
+        command.socket.AF_INET = socket.AF_INET
+        command.socket.AF_UNIX = socket.AF_UNIX
+        command.os.path.exists.return_value = False
 
     def tearDown(self):
         if self.isolation:
@@ -169,34 +171,47 @@ class TestParseHost(object):
             self.isolation = None
 
     def test_default(self):
-        host, port = command.parse_host('')
+        family, host, port = command.parse_server('')
+        assert family == socket.AF_INET
         assert host == '127.0.0.1'
         assert port == 5900
 
     def test_host_display(self):
-        host, port = command.parse_host('10.11.12.13:10')
+        family, host, port = command.parse_server('10.11.12.13:10')
+        assert family == socket.AF_INET
         assert host == '10.11.12.13'
         assert port == 5910
 
     def test_host_port(self):
-        host, port = command.parse_host('10.11.12.13::4444')
+        family, host, port = command.parse_server('10.11.12.13::4444')
+        assert family == socket.AF_INET
         assert host == '10.11.12.13'
         assert port == 4444
 
     def test_just_host(self):
-        host, port = command.parse_host('10.11.12.13')
+        family, host, port = command.parse_server('10.11.12.13')
+        assert family == socket.AF_INET
         assert host == '10.11.12.13'
         assert port == 5900
 
     def test_just_display(self):
-        host, port = command.parse_host(':10')
+        family, host, port = command.parse_server(':10')
+        assert family == socket.AF_INET
         assert host == '127.0.0.1'
         assert port == 5910
 
     def test_just_port(self):
-        host, port = command.parse_host('::1111')
+        family, host, port = command.parse_server('::1111')
+        assert family == socket.AF_INET
         assert host == '127.0.0.1'
         assert port == 1111
+
+    def test_unix_socket(self):
+        command.os.path.exists.return_value = True
+        family, host, port = command.parse_server('/some/path/unix.skt')
+        assert family == socket.AF_UNIX
+        assert host == '/some/path/unix.skt'
+        assert port == 5900
 
 
 class TestVNCDoCLIClient(unittest.TestCase):

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -12,6 +12,7 @@ from twisted.internet import reactor
 
 import math
 import time
+import socket
 import logging
 
 log = logging.getLogger('vncdotool.client')
@@ -137,7 +138,9 @@ class VNCDoToolClient(rfb.RFBClient):
 
     def connectionMade(self):
         rfb.RFBClient.connectionMade(self)
-        self.transport.setTcpNoDelay(True)
+
+        if self.transport.addressFamily == socket.AF_INET:
+            self.transport.setTcpNoDelay(True)
 
     def _decodeKey(self, key):
         if self.factory.force_caps:

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -447,3 +447,10 @@ class VNCDoToolFactory(rfb.RFBFactory):
 
     def clientConnectionMade(self, protocol):
         self.deferred.callback(protocol)
+
+
+def factory_connect(factory, host, port, family):
+    if family == socket.AF_INET:
+        reactor.connectTCP(host, port, factory)
+    elif family == socket.AF_UNIX:
+        reactor.connectUNIX(host, factory)

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -20,7 +20,7 @@ from twisted.internet import reactor, protocol
 from twisted.internet.error import ConnectionDone
 from twisted.python.failure import Failure
 
-from .client import VNCDoToolFactory, VNCDoToolClient
+from .client import VNCDoToolFactory, VNCDoToolClient, factory_connect
 from .loggingproxy import VNCLoggingServerFactory
 
 
@@ -222,11 +222,7 @@ def build_tool(options, args):
 
     build_command_list(factory, args, options.delay, options.warp)
 
-    # connect
-    if options.address_family == socket.AF_INET:
-        reactor.connectTCP(options.host, int(options.port), factory)
-    elif options.address_family == socket.AF_UNIX:
-        reactor.connectUNIX(options.host, int(options.port))
+    factory_connect(factory, options.host, options.port, options.address_family)
     reactor.exit_status = 1
 
     # close the connection when we're done


### PR DESCRIPTION
Few VNC server implementations support UNIX socket transport.

UNIX sockets are simpler and faster than TCP sockets but they work
only on the local host.

Signed-off-by: Matteo Cafasso <noxdafox@gmail.com>