### PR TITLE
Add introspection support for Client API

### DIFF
--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -114,6 +114,9 @@ class ThreadedVNCClientProxy(object):
 
         return proxy_call
 
+    def __dir__(self):
+        return dir(self.__class__) + dir(self.factory.protocol)
+
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
The `__getattr__` protocol adds a level of indirection to the API calls
effectively obfuscating the wrapped API.

The `__dir__` protocol instructs the interpreter on how to correctly
introspect the wrapper class.

This enables the traditional `<.>` + `<TAB>` completion in Python REPL
consoles such as IPython.

Signed-off-by: Matteo Cafasso <noxdafox@gmail.com>