### PR TITLE
 Fix password feature on Python 3 (broken in 97816c3) 

### DIFF
--- a/vncdotool/pyDes.py
+++ b/vncdotool/pyDes.py
@@ -415,7 +415,7 @@ class des(_baseDes):
 
 	def __String_to_BitList(self, data):
 		"""Turn the string data, into a list of bits (1, 0)'s"""
-		if _pythonMajorVersion < 3:
+		if isinstance(data[0], str):
 			# Turn the strings into integers. Python 3 uses a bytes
 			# class, which already has this behaviour.
 			data = [ord(c) for c in data]


### PR DESCRIPTION
Neither bytes nor string work as a password on Python 3 without this change. String blows up in this method, while bytes blows up in rfb.py.