### PR TITLE
issue #108: raise timeouts as TimeoutError

### DIFF
--- a/docs/library.rst
+++ b/docs/library.rst
@@ -24,7 +24,7 @@ It is possible to set a per-client timeout in seconds to prevent calls from bloc
     client.timeout = 10
     try:
         client.captureScreen('screenshot.png')
-    except VNCDoException:
+    except TimeoutError:
         print('Timeout when capturing screen')
 
 In case of too many timeout errors, it is recommended to reset the client connection via the `disconnect` and `connect` methods.

--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -4,6 +4,7 @@ This feature is under developemental, you're help testing and
 debugging is appreciated.
 """
 
+import sys
 import socket
 import threading
 try:
@@ -29,6 +30,11 @@ _THREAD = None
 
 class VNCDoException(Exception):
     pass
+
+
+if sys.version_info.major == 2:
+    class TimeoutError(OSError):
+        pass
 
 
 def connect(server, password=None):
@@ -122,7 +128,7 @@ class ThreadedVNCClientProxy(object):
             try:
                 result = self.queue.get(timeout=self._timeout)
             except queue.Empty:
-                raise VNCDoException("Timeout of waiting for client response")
+                raise TimeoutError("Timeout while waiting for client response")
 
             if isinstance(result, Failure):
                 raise VNCDoException(result)


### PR DESCRIPTION
On Python2 define the TimeoutError exception as missing.

Signed-off-by: Matteo Cafasso <noxdafox@gmail.com>