### PR TITLE
Attempt to determine the correct image mode from the pixel format

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -37,6 +37,7 @@ class TestVNCDoToolClient(TestCase):
 
     def test_vncConnectionMade(self):
         cli = self.client
+        cli._handleServerInit(b" " * 24)
         cli.vncConnectionMade()
         factory = cli.factory
         factory.clientConnectionMade.assert_called_once_with(cli)
@@ -65,6 +66,7 @@ class TestVNCDoToolClient(TestCase):
 
     def test_captureScreen(self):
         cli = self.client
+        cli._handleServerInit(b" " * 24)
         cli.vncConnectionMade()
         fname = 'foo.png'
 
@@ -84,6 +86,7 @@ class TestVNCDoToolClient(TestCase):
         self._tryPIL()
 
         cli = self.client
+        cli._handleServerInit(b" " * 24)
         cli.vncConnectionMade()
         cli.screen = mock.Mock()
         cli.screen.size = (1024, 768)

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -129,6 +129,7 @@ class VNCDoToolClient(rfb.RFBClient):
     y = 0
     buttons = 0
     screen = None
+    image_mode = "RGBX"
     deferred = None
 
     cursor = None
@@ -336,6 +337,22 @@ class VNCDoToolClient(rfb.RFBClient):
 
         return self
 
+    def setImageMode(self):
+        """ Extracts color ordering and 24 vs. 32 bpp info out of the pixel format information
+        """
+        if (self.truecolor and (not self.bigendian) and self.depth == 24
+                and self.redmax == 255 and self.greenmax == 255 and self.bluemax == 255):
+
+            pixel = ["X"] * self.bypp
+            offsets = [offset // 8 for offset in (self.redshift, self.greenshift, self.blueshift)]
+            for offset, color in zip(offsets, "RGB"):
+                pixel[offset] = color
+            self.image_mode = "".join(pixel)
+
+            return True
+        else:
+            return False
+
     #
     # base customizations
     #
@@ -347,7 +364,9 @@ class VNCDoToolClient(rfb.RFBClient):
         self.sendPassword(self.factory.password)
 
     def vncConnectionMade(self):
-        self.setPixelFormat()
+        if not self.setImageMode():
+            self.setPixelFormat()
+
         encodings = [self.encoding]
         if self.factory.pseudocursor or self.factory.nocursor:
             encodings.append(rfb.PSEUDO_CURSOR_ENCODING)
@@ -372,7 +391,7 @@ class VNCDoToolClient(rfb.RFBClient):
             return
 
         size = (width, height)
-        update = Image.frombytes('RGB', size, data, 'raw', 'RGBX')
+        update = Image.frombytes('RGB', size, data, 'raw', self.image_mode)
         if not self.screen:
             self.screen = update
         # track upward screen resizes, often occurs during os boot of VMs

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -348,10 +348,8 @@ class VNCDoToolClient(rfb.RFBClient):
             for offset, color in zip(offsets, "RGB"):
                 pixel[offset] = color
             self.image_mode = "".join(pixel)
-
-            return True
         else:
-            return False
+            self.setPixelFormat()
 
     #
     # base customizations
@@ -364,9 +362,7 @@ class VNCDoToolClient(rfb.RFBClient):
         self.sendPassword(self.factory.password)
 
     def vncConnectionMade(self):
-        if not self.setImageMode():
-            self.setPixelFormat()
-
+        self.setImageMode()
         encodings = [self.encoding]
         if self.factory.pseudocursor or self.factory.nocursor:
             encodings.append(rfb.PSEUDO_CURSOR_ENCODING)


### PR DESCRIPTION
VMWare's built-in VNC server seems to ignore `SetPixelFormat` messages.
However, it does correctly indicate the pixel format it uses in the
`ServerInit` message.

This commit attempts to use the pixel format info from that initial
message to derive the correct image mode to use for PIL. If that fails,
it falls back to the previous behavior of setting the pixel format to
the `rfb.py` default of `RGBX`.

This was the least-hacky way I could think of to fix VMWare screenshots,
while potentially giving some benefit to other implementations (skipping
the often unnecessary, if harmless, `SetPixelFormat` message).