### PR TITLE
Separate refreshing the screen from saving a screenshot

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -69,8 +69,7 @@ class TestVNCDoToolClient(TestCase):
         fname = 'foo.png'
 
         d = cli.captureScreen(fname)
-        d.addCallback.assert_a_call_exists_with(cli._captureSave, fname)
-        d.addCallback.assert_a_call_exists
+        d.addCallback.assert_called_once_with(cli._captureSave, fname)
         assert cli.framebufferUpdateRequest.called
 
     def test_captureSave(self):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -105,20 +105,20 @@ class TestVNCDoToolClient(TestCase):
         cli = self.client
         d = cli.deferred = mock.Mock()
         cli.expected = [2, 2, 2]
-        image = mock.Mock()
-        image.histogram.return_value = [1, 2, 3]
-        image.crop.return_value = image
-        result = cli._expectCompare(image, None, 5)
+        cli.screen = mock.Mock()
+        cli.screen.histogram.return_value = [1, 2, 3]
+        cli.screen.crop.return_value = cli.screen
+        result = cli._expectCompare(cli, None, 5)
         assert result == cli
 
     def test_expectCompareExactSuccess(self):
         cli = self.client
         d = cli.deferred = mock.Mock()
         cli.expected = [2, 2, 2]
-        image = mock.Mock()
-        image.histogram.return_value = [2, 2, 2]
-        image.crop.return_value = image
-        result = cli._expectCompare(image, None, 0)
+        cli.screen = mock.Mock()
+        cli.screen.histogram.return_value = [2, 2, 2]
+        cli.screen.crop.return_value = cli.screen
+        result = cli._expectCompare(cli, None, 0)
         assert result == cli
 
     def test_expectCompareFails(self):
@@ -126,11 +126,11 @@ class TestVNCDoToolClient(TestCase):
         cli.deferred = mock.Mock()
         cli.expected = [2, 2, 2]
         cli.framebufferUpdateRequest = mock.Mock()
-        image = mock.Mock()
-        image.histogram.return_value = [1, 1, 1]
-        image.crop.return_value = image
+        cli.screen = mock.Mock()
+        cli.screen.histogram.return_value = [1, 1, 1]
+        cli.screen.crop.return_value = cli.screen
 
-        result = cli._expectCompare(image, None, 0)
+        result = cli._expectCompare(cli, None, 0)
 
         assert result != cli
         assert result == cli.deferred
@@ -144,11 +144,11 @@ class TestVNCDoToolClient(TestCase):
         cli.deferred = mock.Mock()
         cli.expected = [2, 2]
         cli.framebufferUpdateRequest = mock.Mock()
-        image = mock.Mock()
-        image.histogram.return_value = [1, 1, 1]
-        image.crop.return_value = image
+        cli.screen = mock.Mock()
+        cli.screen.histogram.return_value = [1, 1, 1]
+        cli.screen.crop.return_value = cli.screen
 
-        result = cli._expectCompare(image, None, 0)
+        result = cli._expectCompare(cli, None, 0)
 
         assert result != cli
         assert result == cli.deferred
@@ -188,7 +188,7 @@ class TestVNCDoToolClient(TestCase):
         self.client.deferred = self.deferred
         self.client.commitUpdate(rects)
 
-        self.deferred.callback.assert_called_once_with(self.client.screen)
+        self.deferred.callback.assert_called_once_with(self.client)
 
     def test_vncRequestPassword_attribute(self):
         cli = self.client

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -69,7 +69,8 @@ class TestVNCDoToolClient(TestCase):
         fname = 'foo.png'
 
         d = cli.captureScreen(fname)
-        d.addCallback.assert_called_once_with(cli._captureSave, fname)
+        d.addCallback.assert_a_call_exists_with(cli._captureSave, fname)
+        d.addCallback.assert_a_call_exists
         assert cli.framebufferUpdateRequest.called
 
     def test_captureSave(self):

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -237,11 +237,16 @@ class VNCDoToolClient(rfb.RFBClient):
         log.debug('captureRegion %s', filename)
         return self._capture(filename, x, y, x+w, y+h)
 
+    def refreshScreen(self, incremental=0):
+        d = self.deferred = Deferred()
+        self.framebufferUpdateRequest(incremental=incremental)
+        d.addCallback(lambda *args: self)
+        return d
+
     def _capture(self, filename, *args):
-        self.framebufferUpdateRequest()
-        self.deferred = Deferred()
-        self.deferred.addCallback(self._captureSave, filename, *args)
-        return self.deferred
+        d = self.refreshScreen()
+        d.addCallback(self._captureSave, filename, *args)
+        return d
 
     def _captureSave(self, data, filename, *args):
         log.debug('captureSave %s', filename)

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -240,7 +240,6 @@ class VNCDoToolClient(rfb.RFBClient):
     def refreshScreen(self, incremental=0):
         d = self.deferred = Deferred()
         self.framebufferUpdateRequest(incremental=incremental)
-        d.addCallback(lambda *args: self)
         return d
 
     def _capture(self, filename, *args):
@@ -287,10 +286,10 @@ class VNCDoToolClient(rfb.RFBClient):
 
         return self.deferred
 
-    def _expectCompare(self, image, box, maxrms):
-        image = image.crop(box)
+    def _expectCompare(self, data, box, maxrms):
+        image = self.screen.crop(box)
 
-        hist = image.histogram()
+        hist = self.screen.histogram()
         if len(hist) == len(self.expected):
             sum_ = 0
             for h, e in zip(hist, self.expected):
@@ -398,7 +397,7 @@ class VNCDoToolClient(rfb.RFBClient):
         if self.deferred:
             d = self.deferred
             self.deferred = None
-            d.callback(self.screen)
+            d.callback(self)
 
     def updateCursor(self, x, y, width, height, image, mask):
         if self.factory.nocursor:


### PR DESCRIPTION
This change was suggested by @sibson in https://github.com/sibson/vncdotool/pull/118#issuecomment-357261582

I want to be able to use the in-memory PIL image without writing it out
to disk, through the API shim. This commit separates out the two pieces
of functionality.

What makes this a little more complicated is that you can't return a
deferred without a callback from a method on the client, or, just as if
you hadn't returned a deferred at all, the client instance gets replaced
by another object. I haven't spent the time to learn why this is the
case. To get around that, I add a no-op callback to the deferred in
`refreshScreen`.

When actually taking a screenshot, the callback to save the image is
simply added to the same deferred.