### PR TITLE
Support subclassing of VNCDoTool types in API shim

### DIFF
--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -37,49 +37,6 @@ if sys.version_info.major == 2:
         pass
 
 
-def connect(server, password=None, factory_class=None, proxy=None, timeout=None):
-    """ Connect to a VNCServer and return a Client instance that is usable
-    in the main thread of non-Twisted Python Applications, EXPERIMENTAL.
-
-    >>> from vncdotool import api
-    >>> with api.connect('host') as client
-    >>>     client.keyPress('c')
-
-    You may then call any regular VNCDoToolClient method on client from your
-    application code.
-
-    If you are using a GUI toolkit or other major async library please read
-    http://twistedmatrix.com/documents/13.0.0/core/howto/choosing-reactor.html
-    for a better method of intergrating vncdotool.
-    """
-    if not reactor.running:
-        global _THREAD
-        _THREAD = threading.Thread(target=reactor.run, name='Twisted',
-                         kwargs={'installSignalHandlers': False})
-        _THREAD.daemon = True
-        _THREAD.start()
-
-        observer = PythonLoggingObserver()
-        observer.start()
-
-    if factory_class is None:
-        factory_class = VNCDoToolFactory
-
-    factory = factory_class()
-
-    if password is not None:
-        factory.password = password
-
-    if proxy is None:
-        proxy = ThreadedVNCClientProxy
-
-    family, host, port = command.parse_server(server)
-    client = proxy(factory, timeout)
-    client.connect(host, port=port, family=family)
-
-    return client
-
-
 def shutdown():
     if not reactor.running:
         return
@@ -90,11 +47,9 @@ def shutdown():
 
 class ThreadedVNCClientProxy(object):
 
-    def __init__(self, factory, timeout=None):
+    def __init__(self, factory, timeout=60 * 60):
         self.factory = factory
         self.queue = queue.Queue()
-        if timeout is None:
-            timeout = 60 * 60
         self._timeout = timeout
 
     def __enter__(self):
@@ -153,6 +108,44 @@ class ThreadedVNCClientProxy(object):
 
     def __dir__(self):
         return dir(self.__class__) + dir(self.factory.protocol)
+
+
+def connect(server, password=None,
+        factory_class=VNCDoToolFactory, proxy=ThreadedVNCClientProxy, timeout=None):
+    """ Connect to a VNCServer and return a Client instance that is usable
+    in the main thread of non-Twisted Python Applications, EXPERIMENTAL.
+
+    >>> from vncdotool import api
+    >>> with api.connect('host') as client
+    >>>     client.keyPress('c')
+
+    You may then call any regular VNCDoToolClient method on client from your
+    application code.
+
+    If you are using a GUI toolkit or other major async library please read
+    http://twistedmatrix.com/documents/13.0.0/core/howto/choosing-reactor.html
+    for a better method of intergrating vncdotool.
+    """
+    if not reactor.running:
+        global _THREAD
+        _THREAD = threading.Thread(target=reactor.run, name='Twisted',
+                         kwargs={'installSignalHandlers': False})
+        _THREAD.daemon = True
+        _THREAD.start()
+
+        observer = PythonLoggingObserver()
+        observer.start()
+
+    factory = factory_class()
+
+    if password is not None:
+        factory.password = password
+
+    family, host, port = command.parse_server(server)
+    client = proxy(factory, timeout)
+    client.connect(host, port=port, family=family)
+
+    return client
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I want to be able to modify the behavior of the underlying client
without monkey patching. Specifically, I need to work around VMWare VNC
server bugs.

I also want to be able to add additional behavior to the proxy object,
in my case to add additional sync methods which wrap multiple pointer
or key events.

This also includes a small change to allow setting the proxy's timeout
when calling `connect`.

With these changes, my VNC client module looks like this:

```
from vncdotool.api import ThreadedVNCClientProxy, connect as api_connect
from vncdotool.client import VNCDoToolFactory, VNCDoToolClient

from events import Events # pointer and key event wrappers
from screen import Screen # screenshot wrappers

class VNCClient(VNCDoToolClient):
     pass # VMWare VNC server bug workarounds here

class VNCFactory(VNCDoToolFactory):
    protocol = VNCClient

class VNCProxy(Events, Screen, ThreadedVNCClientProxy):
    pass

def connect(host, password = None, timeout = 2):
    return api_connect(host, password, factory_class=VNCFactory, proxy=VNCProxy, timeout=timeout)
```