### PR TITLE
Make the client work with badly behaved servers

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -37,6 +37,8 @@ class TestVNCDoToolClient(TestCase):
 
     def test_vncConnectionMade(self):
         cli = self.client
+        cli._packet = [b"RFB003.003\n"]
+        cli._handleInitial()
         cli._handleServerInit(b" " * 24)
         cli.vncConnectionMade()
         factory = cli.factory
@@ -66,6 +68,8 @@ class TestVNCDoToolClient(TestCase):
 
     def test_captureScreen(self):
         cli = self.client
+        cli._packet = [b"RFB003.003\n"]
+        cli._handleInitial()
         cli._handleServerInit(b" " * 24)
         cli.vncConnectionMade()
         fname = 'foo.png'
@@ -86,6 +90,8 @@ class TestVNCDoToolClient(TestCase):
         self._tryPIL()
 
         cli = self.client
+        cli._packet = [b"RFB003.003\n"]
+        cli._handleInitial()
         cli._handleServerInit(b" " * 24)
         cli.vncConnectionMade()
         cli.screen = mock.Mock()

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -119,6 +119,7 @@ class RFBClient(Protocol):
         self._handler = self._handleInitial
         self._already_expecting = 0
         self._version = None
+        self._version_server = None
 
     #------------------------------------------------------
     # states used on connection startup
@@ -147,6 +148,7 @@ class RFBClient(Protocol):
             self._packet_len = len(buffer)
             self._handler = self._handleExpected
             self._version = version
+            self._version_server = version_server
             if version < 3.7:
                 self.expect(self._handleAuth, 4)
             else:


### PR DESCRIPTION
When responding to framebuffer update requests, the VMWare VNC server
will send a single-pixel update on alternate responses, even when a
full buffer update has been requested. To cancel this out, you can
resend any framebuffer update request that receives such a response.
Since this means essentially rejecting what are valid responses, I do
this in a subclass so as to avoid doing it when it's not needed.

The MacOS built-in VNC server is unusual in several ways.

- It advertises itself as supporting protocol version 3.889
- If no password is used it attemts a nonstandard authentication
  sequence
- 8-, 24-, and 32-bit pixel formats cause the server to disconnect as
  soon as the first post-handshake client request as made

The first two are already handled without changes to the client (it
falls back to operating in protocol version 3.8, which works fine, and
you just have to set a password), but the third requires special
handling. Since this is a nonstandard protocol version, and this only
has to happen once per session, it seems safe to build this directly
into `setImageMode`.

I currently just have my own subclass that supports these two
behaviors, but they're common enough servers (and both referenced in
open issues on this repo) that I think including the fixes here is
valuable. If you disagree, at least storing the server-sent version
number is helpful for detecting the MacOS server in a subclass.