### PR TITLE
Use cropped image for compare

### DIFF
--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -290,7 +290,7 @@ class VNCDoToolClient(rfb.RFBClient):
     def _expectCompare(self, data, box, maxrms):
         image = self.screen.crop(box)
 
-        hist = self.screen.histogram()
+        hist = image.histogram()
         if len(hist) == len(self.expected):
             sum_ = 0
             for h, e in zip(hist, self.expected):


### PR DESCRIPTION
The histogram should be computed from the cropped image not from the full screen. Otherwise, expectRegion does not work.