### PR TITLE
added port argument to api.connect

### DIFF
--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -118,7 +118,7 @@ class ThreadedVNCClientProxy(object):
         return dir(self.__class__) + dir(self.factory.protocol)
 
 
-def connect(server, password=None,
+def connect(server, password=None, port=None,
         factory_class=VNCDoToolFactory, proxy=ThreadedVNCClientProxy, timeout=None):
     """ Connect to a VNCServer and return a Client instance that is usable
     in the main thread of non-Twisted Python Applications, EXPERIMENTAL.
@@ -149,9 +149,9 @@ def connect(server, password=None,
     if password is not None:
         factory.password = password
 
-    family, host, port = command.parse_server(server)
+    s_family, s_host, s_port = command.parse_server(server)
     client = proxy(factory, timeout)
-    client.connect(host, port=port, family=family)
+    client.connect(s_host, port=(port if port else s_port), family=s_family)
 
     return client
 


### PR DESCRIPTION
hi there,

i noticed server argument to `api.connect` function parses it and gives port number automatically. In order to use standard tcp/ip port double colon (`::`) needed as seperator

i mostly use this library through ssh-forward, thus port numbers generally in 10k space.
specifying port number as an argument simpler than `host + "::" + port` imho, also looks better

only downside is that when specified, port argument overrides port if server was given with display number or port