### PR TITLE
Force reactor to poll socket when dragging

### DIFF
--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -330,12 +330,14 @@ class VNCDoToolClient(rfb.RFBClient):
             ysteps = range(self.y, y, step)
 
         for ypos in ysteps:
-            time.sleep(.2)
             self.mouseMove(self.x, ypos)
+            reactor.doPoll(timeout=5)
+            time.sleep(.2)
 
         for xpos in xsteps:
-            time.sleep(.2)
             self.mouseMove(xpos, self.y)
+            reactor.doPoll(timeout=5)
+            time.sleep(.2)
 
         self.mouseMove(x, y)
 


### PR DESCRIPTION
The `mouseDrag()` method is called during the reactor loop and all
of its calls to `mouseMove()` will be buffered as the reactor
won't check the underlying socket while that method is running.
That means that all the move operations will be sent at once to the
VNC server *after* `mouseDrag()` has executed, causing the cursor
to jump straight to the final location. The `sleep()` calls in the
drag method should prevent this, but since they are not yielded to
the reactor they have no effect.

A simple solution is to call `reactor.doPoll()` after each
`mouseMove()` to make sure that the socket is polled by the reactor
and that the previous move command is sent to the VNC Server.

This fixes issue #54.