### PR TITLE
Fix HEXTILE encoding under Python3

### DIFF
--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -24,6 +24,9 @@ from twisted.application import internet, service
 
 #~ from twisted.internet import reactor
 
+# Python3 compatibility replacement for ord(str) as ord(byte)
+if not isinstance(b' ', str):
+    def ord(x): return x
 
 #encoding-type
 #for SetEncodings()


### PR DESCRIPTION
In Python 3, data is represented as `bytes`, not as `str`. So, things like `ord(block[pos])` won't work in Python3. This is used extensively in decoding Hextile.

I have added a replacement for `ord()` which is activated only on Python3 (i.e. when `b' ' ` is not a `str`) which returns the argument unchanged.