### PR TITLE
Fix missing self argument in updateDesktopSize

### DIFF
--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -643,7 +643,7 @@ class RFBClient(Protocol):
         """ New cursor, focuses at (x, y)
         """
 
-    def updateDesktopSize(width, height):
+    def updateDesktopSize(self, width, height):
         """ New desktop size of width*height. """
 
     def bell(self):


### PR DESCRIPTION
Minor fix: `updateDesktopSize()` is missing the `self` argument