### PR TITLE
ZRLE implementation

### DIFF
--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -124,7 +124,7 @@ class AuthenticationError(Exception):
 
 
 class VNCDoToolClient(rfb.RFBClient):
-    encoding = rfb.ZRLE_ENCODING
+    encoding = rfb.RAW_ENCODING
     x = 0
     y = 0
     buttons = 0

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -124,7 +124,7 @@ class AuthenticationError(Exception):
 
 
 class VNCDoToolClient(rfb.RFBClient):
-    encoding = rfb.RAW_ENCODING
+    encoding = rfb.ZRLE_ENCODING
     x = 0
     y = 0
     buttons = 0

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -24,6 +24,9 @@ from twisted.application import internet, service
 
 #~ from twisted.internet import reactor
 
+# Python3 compatibility replacement for ord(str) as ord(byte)
+if not isinstance(b' ', str):
+    def ord(x): return x
 
 #encoding-type
 #for SetEncodings()

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -117,7 +117,7 @@ KEY_SpaceBar=   0x0020
 
 
 # ZRLE helpers
-def _next_bit(it, pixels_in_tile):
+def _zrle_next_bit(it, pixels_in_tile):
     num_pixels = 0
     while True:
         b = ord(next(it))
@@ -131,7 +131,7 @@ def _next_bit(it, pixels_in_tile):
                 return
 
 
-def _next_dibit(it, pixels_in_tile):
+def _zrle_next_dibit(it, pixels_in_tile):
     num_pixels = 0
     while True:
         b = ord(next(it))
@@ -145,7 +145,7 @@ def _next_dibit(it, pixels_in_tile):
                 return
 
 
-def _next_nibble(it, pixels_in_tile):
+def _zrle_next_nibble(it, pixels_in_tile):
     num_pixels = 0
     while True:
         b = ord(next(it))
@@ -629,11 +629,11 @@ class RFBClient(Protocol):
 
                     palette = [bytearray(cpixel(it)) for _ in range(palette_size)]
                     if palette_size == 2:
-                        next_index = _next_bit(it, pixels_in_tile)
+                        next_index = _zrle_next_bit(it, pixels_in_tile)
                     elif palette_size == 3 or palette_size == 4:
-                        next_index = _next_dibit(it, pixels_in_tile)
+                        next_index = _zrle_next_dibit(it, pixels_in_tile)
                     else:
-                        next_index = _next_nibble(it, pixels_in_tile)
+                        next_index = _zrle_next_nibble(it, pixels_in_tile)
 
                     for palette_index in next_index:
                         pixel_data.extend(palette[palette_index])


### PR DESCRIPTION
I have implemented ZRLE encoding. Since this is the most efficient and bandwith saving encoding of all available encodings so far, I would suggest making this the default.

This was originally written under Python 3. I have packported to Python2 using the `ord()` compatibility hack previously used to make hextile encoding work under Python3.