### PR TITLE
Fix a wrong fix to `ord`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ vncdotool.egg-info
 .noseids
 .tox
 docs/_build
+
+*~
+#*

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -27,7 +27,20 @@ from twisted.application import internet, service
 
 # Python3 compatibility replacement for ord(str) as ord(byte)
 if sys.version_info[0] >= 3:
-    def ord(x): return x
+    original_ord = ord
+    def ord(x):
+        # in python 2, there are two possible cases ord is used.
+        # * string of length > 1, --(index access)--> string of length 1 --(ord)--> int
+        # * string of length 1 --(ord)--> int
+        # however in python3, this usage morphs into
+        # * byte of length > 1, --(index access)--> int --(ord)--> Error
+        # * byte of length 1 --(ord)--> int
+        if isinstance(x, int):
+            return x
+        elif isinstance(x, bytes) or isinstance(x, str):
+            return original_ord(x)
+        else:
+            raise TypeError(f"ord takes an int, a byte, or a str. Got {type(x)} : {x}")
 
 #encoding-type
 #for SetEncodings()
@@ -487,6 +500,8 @@ class RFBClient(Protocol):
             pos += self.bypp
         if subencoding & 8:     #AnySubrects
             #~ (subrects, ) = unpack("!B", block)
+            # In python2, block : string, block[pos] : string, ord(block[pos]) : int
+            # In python3, block : byte,   block[pos] : int,    ord(block[pos]) : error
             subrects = ord(block[pos])
         #~ print subrects
         if subrects:

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -40,7 +40,7 @@ if sys.version_info[0] >= 3:
         elif isinstance(x, bytes) or isinstance(x, str):
             return original_ord(x)
         else:
-            raise TypeError(f"ord takes an int, a byte, or a str. Got {type(x)} : {x}")
+            raise TypeError(f"our customized ord takes an int, a byte, or a str. Got {type(x)} : {x}")
 
 #encoding-type
 #for SetEncodings()

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -26,7 +26,7 @@ from twisted.application import internet, service
 #~ from twisted.internet import reactor
 
 # Python3 compatibility replacement for ord(str) as ord(byte)
-if not isinstance(b' ', str):
+if sys.version_info[0] >= 3:
     def ord(x): return x
 
 #encoding-type


### PR DESCRIPTION
Due to python3's incompatible change, data buffer is represented as a `byte` rather than `str` .
The RFB code depends on the assumption that they are str, which no longer works.
The code uses `ord` to convert a single-char string into an `int`.
There are two typical usages of `ord` in the code:

* buffer string of length > 1 --(index access)--> string of length 1 --(ord)--> int
* string of length 1 --(ord)--> int

However in python3, this usage morphs into

* byte of length > 1, --(index access)--> int --(ord)--> Error
* byte of length 1 --(ord)--> int

The previous wrong fix #164 only considers the first case, and replace `ord` with an identity that returns an int.
However this fix causes an error (#170 #172).
I reimplemented ord simply as a cast : When the input is an int, returns it, otherwise apply the normal `ord`.