### PR TITLE
Exemplify the many ways of specifying the server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ It's under active development and seems to be working, but please report any pro
 
 Quick Start
 --------------------------------
-To use vncdotool you will need a VNC server.  
+To use vncdotool you will need a VNC server.
 Most virtualization products include one, or use RealVNC, TightVNC or clone your Desktop using x11vnc.
 
 Once, you have a server running you can install vncdotool from pypi::
@@ -19,11 +19,22 @@ Once, you have a server running you can install vncdotool from pypi::
 
 and then send a message to the vncserver with::
 
-    vncdo -s vncserveraddress type "hello world"
+    vncdo -s vncserver type "hello world"
+
+The `vncserver` argument needs to be in the format `address[:display|::port]`. For example::
+
+    # connect to 192.168.1.1 on default port 5900
+    vncdo -s 192.168.1.1 type "hello world"
+
+    # connect to localhost on display :3 (port 5903)
+    vncdo -s localhost:3 type "hello world"
+
+    # connect to myvncserver.com on port 5902 (two colons needed)
+    vncdo -s myvncserver.com::5902 type "hello world"
 
 You can also take a screen capture with::
 
-    vncdo -s vncservername capture screen.png
+    vncdo -s vncserver capture screen.png
 
 
 More documentation can be found on `Read the Docs`_.

--- a/docs/library.rst
+++ b/docs/library.rst
@@ -2,12 +2,23 @@ Embedding in Python Applications
 ===================================
 vncdotool is built with the Twisted_ framework, as such it best intergrates with other Twisted Applications
 Rewriting your application to use Twisted may not be an option, so vncdotool provides a compatability layer.
-It uses a seperate thread to run the Twisted reactor and communitcates with the main program using a threadsafe Queue.
+It uses a seperate thread to run the Twisted reactor and communicates with the main program using a threadsafe Queue.
 
 To use the syncronous API you can do the following::
 
     from vncdotool import api
-    client = api.connect('vnchost:display', password=None)
+    client = api.connect('vncserver', password=None)
+
+The first argument passed to the `connect` method is the VNC server to connect to, and it needs to be in the format `address[:display|::port]`. For example::
+
+    # connect to 192.168.1.1 on default port 5900
+    client = api.connect('192.168.1.1', password=None)
+
+    # connect to localhost on display :3 (port 5903)
+    client = api.connect('localhost:3', password=None)
+
+    # connect to myvncserver.com on port 5902 (two colons needed)
+    client = api.connect('myvncserver.com::5902', password=None)
 
 You can then call any of the methods available on
 :class:`vncdotool.client.VNCDoToolClient` and they will block until completion.


### PR DESCRIPTION
The format for the server address is not clearly specified in the
documentation, and this has led to users having problems such as
issue #150.