### PR TITLE
add errback for clientConnectionLost

### DIFF
--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -478,7 +478,7 @@ class VNCDoToolFactory(rfb.RFBFactory):
         self.deferred = Deferred()
 
     def clientConnectionLost(self, connector, reason):
-        pass
+        self.deferred.errback(reason)
 
     def clientConnectionFailed(self, connector, reason):
         self.deferred.errback(reason)


### PR DESCRIPTION
Fix client operation timeout when vnc password is wrong,  twisted will call clientConnectionLost and it don't put any result in queue will lead self.queue.get timeout, add errback for clientConnectionLost.