### PR TITLE
Add support for Apple Remote Desktop (ARD)

### DIFF
--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -464,6 +464,7 @@ class VMWareClient(VNCDoToolClient):
 
 
 class VNCDoToolFactory(rfb.RFBFactory):
+    username = None
     password = None
 
     protocol = VNCDoToolClient

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -252,6 +252,9 @@ def add_standard_options(parser):
     parser.add_option('-p', '--password', action='store', metavar='PASSWORD',
         help='use password to access server')
 
+    parser.add_option('-u', '--username', action='store', metavar='USERNAME',
+        help='use username to access server')
+
     parser.add_option('-s', '--server', action='store', metavar='SERVER',
         default='127.0.0.1',
         help='connect to VNC server at ADDRESS[:DISPLAY|::PORT] [%default]')
@@ -412,6 +415,7 @@ def vncdo():
     log.info('connecting to %s:%s', options.host, options.port)
 
     factory = build_tool(options, args)
+    factory.username = options.username
     factory.password = options.password
 
     if options.localcursor:


### PR DESCRIPTION
This adds support for Apple Remote Desktop (ARD) in order to support Apple's screen sharing / remote management feature. This is done by adding support for a username parameter, and RFB protocol version 3.889 and auth type 30.