### PR TITLE
add missing pycryptodome dependency to requirements.txt to pass build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Pillow==6.2.0
 Twisted==21.7.0
 zope.interface==5.4.0
+pycryptodome==3.12.0


### PR DESCRIPTION
Hello 👋 

I was looking at making use of this project and I noticed that the build is broken because the code references modules which are not marked as dependencies, which [fails the build](https://github.com/sibson/vncdotool/runs/3854662017?check_suite_focus=true).

This PR is to outline this dependency in requirements.txt and ensure that the unit tests in the pipeline can run again.  Please let me know if there is anything else I need to do, as this is my first time contributing to this project.