### PR TITLE
Use only logging for output to avoid unwanted such on stdout

### DIFF
--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -385,10 +385,10 @@ class VNCDoToolClient(rfb.RFBClient):
         self.factory.clientConnectionMade(self)
 
     def bell(self):
-        print('ding')
+        log.info('ding')
 
     def copy_text(self, text):
-        print('clipboard copy', repr(text))
+        log.info('clipboard copy', repr(text))
 
     def paste(self, message):
         self.clientCutText(message)


### PR DESCRIPTION
There are two functions in the client module that output explicitly
to stdout instead of using the provided loggers. Some remote sessions
could break down because of some of this output and there isn't any
easy way to prevent the output from being emitted. As the client module
already makes full use of the logging levels and filters let's make
the following code respect that too.