### PR TITLE
Fix error when buffer doesn't start with RFB

### DIFF
--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -197,6 +197,7 @@ class RFBClient(Protocol):
         buffer = b''.join(self._packet)
         if b'\n' in buffer:
             version = 3.3
+            version_server = None
             if buffer[:3] == b'RFB':
                 version_server = float(buffer[3:-1].replace(b'0', b''))
                 SUPPORTED_VERSIONS = (3.3, 3.7, 3.8)
@@ -209,6 +210,8 @@ class RFBClient(Protocol):
                             % version_server)
                     version = max(filter(
                         lambda x: x <= version_server, SUPPORTED_VERSIONS))
+            else:
+                log.msg("Server did not return expected version format: %s", buffer[:30])
             buffer = buffer[12:]
             log.msg("Using protocol version %.3f" % version)
             parts = str(version).split('.')


### PR DESCRIPTION
Fixes this error:

```
[CRITICAL]	2022-03-20T06:41:29.696Z	ba5101fc-68db-4723-9ab2-c68cd21c6f72	Unhandled Error
Traceback (most recent call last):
  File "/var/task/twisted/python/log.py", line 103, in callWithLogger
    return callWithContext({"system": lp}, func, *args, **kw)
  File "/var/task/twisted/python/log.py", line 86, in callWithContext
    return context.call({ILogContext: newCtx}, func, *args, **kw)
  File "/var/task/twisted/python/context.py", line 122, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "/var/task/twisted/python/context.py", line 85, in callWithContext
    return func(*args,**kw)
--- <exception caught here> ---
  File "/var/task/twisted/internet/posixbase.py", line 614, in _doReadOrWrite
    why = selectable.doRead()
  File "/var/task/twisted/internet/tcp.py", line 243, in doRead
    return self._dataReceived(data)
  File "/var/task/twisted/internet/tcp.py", line 249, in _dataReceived
    rval = self.protocol.dataReceived(data)
  File "/var/task/vncdotool/rfb.py", line 527, in dataReceived
    self._handler()
  File "/var/task/vncdotool/rfb.py", line 151, in _handleInitial
    self._version_server = version_server
builtins.UnboundLocalError: local variable 'version_server' referenced before assignment
```

Our version is a bit outdated but the issue still exists in main. 