### PR TITLE
Support an unchanged framebuffer in expectCompare

### DIFF
--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -285,7 +285,9 @@ class VNCDoToolClient(rfb.RFBClient):
         return self._expectCompare(None, (x, y, x + w, y + h), maxrms)
 
     def _expectCompare(self, data, box, maxrms):
+        incremental = 0
         if self.screen:
+            incremental = 1
             image = self.screen.crop(box)
 
             hist = image.histogram()
@@ -301,7 +303,7 @@ class VNCDoToolClient(rfb.RFBClient):
 
         self.deferred = Deferred()
         self.deferred.addCallback(self._expectCompare, box, maxrms)
-        self.framebufferUpdateRequest(incremental=1)  # use box ~(x, y, w - x, h - y)?
+        self.framebufferUpdateRequest(incremental=incremental)  # use box ~(x, y, w - x, h - y)?
 
         return self.deferred
 

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -278,28 +278,26 @@ class VNCDoToolClient(rfb.RFBClient):
         return self._expectFramebuffer(filename, x, y, maxrms)
 
     def _expectFramebuffer(self, filename, x, y, maxrms):
-        self.framebufferUpdateRequest(incremental=1)
         image = Image.open(filename)
         w, h = image.size
         self.expected = image.histogram()
-        self.deferred = Deferred()
-        self.deferred.addCallback(self._expectCompare, (x, y, x + w, y + h), maxrms)
 
-        return self.deferred
+        return self._expectCompare(None, (x, y, x + w, y + h), maxrms)
 
     def _expectCompare(self, data, box, maxrms):
-        image = self.screen.crop(box)
+        if self.screen:
+            image = self.screen.crop(box)
 
-        hist = image.histogram()
-        if len(hist) == len(self.expected):
-            sum_ = 0
-            for h, e in zip(hist, self.expected):
-                sum_ += (h - e) ** 2
-            rms = math.sqrt(sum_ / len(hist))
+            hist = image.histogram()
+            if len(hist) == len(self.expected):
+                sum_ = 0
+                for h, e in zip(hist, self.expected):
+                    sum_ += (h - e) ** 2
+                rms = math.sqrt(sum_ / len(hist))
 
-            log.debug('rms:%s maxrms: %s', int(rms), int(maxrms))
-            if rms <= maxrms:
-                return self
+                log.debug('rms:%s maxrms: %s', int(rms), int(maxrms))
+                if rms <= maxrms:
+                    return self
 
         self.deferred = Deferred()
         self.deferred.addCallback(self._expectCompare, box, maxrms)


### PR DESCRIPTION
Did bump into an issue when calling `captureScreen` and `expectScreen` one after the other. 

The observation was that `expectScreen` did hang.

Code snippet:

```
    client.captureScreen(os.path.join(base_path, 'screenshot.png'))
    client.expectScreen(os.path.join(base_path, 'screenshot.png'))
```

I think the issue is caused because the screen content did not change and is already present, so there is no need for the server to send any update.

If I understand the whole thing correctly, then this will lead to a situation where `self.deferred` is never triggered. As far as I am tell it would be triggered from `_doConnection` in `rfb.py`, which calls into `commitUpdate`.

My understanding of twisted's deferred mechanism and also of the vnc protocol are somewhat "rusty", so I would probably need a few hints to bring the attached idea for a fix into proper shape. 

The basic idea to avoid the issue is this:

Since we have the `screen` already, we can call `_expectCompare` initially synchronously. It will do the check, and only if it does not match (or if we did not yet have `screen` in the first place) it would go into the loop based on deferreds and hope for getting an update from the server after requesting this via `framebufferUpdateRequest`.

