### PR TITLE
test: Fix regression #221

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -96,8 +96,6 @@ class TestVNCDoToolClient(TestCase):
         cli._handleInitial()
         cli._handleServerInit(b" " * 24)
         cli.vncConnectionMade()
-        cli.screen = mock.Mock()
-        cli.screen.size = (1024, 768)
         fname = 'something.png'
 
         region = (0 ,0, 11, 22)


### PR DESCRIPTION
`test_expectScreen()` calls `expectScreen()` calls `_expectFramebuffer()`, which changed behavior by #221:

- previously it called `_expectCompare()` via a `Deferred`. As the unit-test runs without any Twisted reactor running, the real code for comparison was never executed.
- now `_expectCompare()` is called synchronously (is a previous `screen` already exists) and fails, because the mocked Image cannot be used with `len()`:
> if len(hist) == len(self.expected):
> E TypeError: object of type 'Mock' has no len()

For the unit test restore the old behavior and let `self.screen = None` remain to *not* trigger calling `_expectCompare()`.