### PR TITLE
Fix functest and vnclog

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -5,8 +5,8 @@ Running Tests
 
 Unit tests can be quickly run with the following commands::
 
-    make venv
-    source .venv/bin/activate
+    virtualenv venv
+    . venv/bin/activate
 
     make test
 

--- a/libvncserver.mk
+++ b/libvncserver.mk
@@ -20,9 +20,11 @@ LIBVNCSERVER_EXAMPLES_SRCS=$(addsuffix .c, $(LIBVNCSERVER_EXAMPLES))
 
 libvnc-examples: $(LIBVNCSERVER_EXAMPLES)
 
+.PHONY: veryclean
 veryclean:
 	rm -rf $(BUILD_DIR)
 
+.PHONY: clean
 clean:
 	rm -f $(LIBVNCSERVER_EXAMPLES)
 
@@ -43,6 +45,7 @@ $(LIBVNCSERVER_EXAMPLES_SRCS): $(LIBVNCSERVER_DIR) $(LIBVNCSERVER_MAKEFILE)
 $(LIBVNCSERVER_EXAMPLES): $(LIBVNCSERVER_EXAMPLES_SRCS)
 	$(MAKE) -C $(LIBVNCSERVER_DIR)
 
+.PHONY: test-libvnc
 test-libvnc: export PATH:=$(PATH):$(LIBVNCSERVER_DIR)/examples
 test-libvnc:
 	$(PYTHON) -m unittest discover tests/functional

--- a/libvncserver.mk
+++ b/libvncserver.mk
@@ -1,5 +1,6 @@
 LIBVNCSERVER_VERSION?=0.9.14
 BUILD_DIR?=/tmp/vncdo
+PYTHON?=python3
 
 
 
@@ -44,4 +45,4 @@ $(LIBVNCSERVER_EXAMPLES): $(LIBVNCSERVER_EXAMPLES_SRCS)
 
 test-libvnc: export PATH:=$(PATH):$(LIBVNCSERVER_DIR)/examples
 test-libvnc:
-	python -m unittest discover tests/functional
+	$(PYTHON) -m unittest discover tests/functional

--- a/makefile
+++ b/makefile
@@ -3,6 +3,7 @@
 .DEFAULT: help
 
 VERSION_FILE?=vncdotool/__init__.py
+PYTHON?=python3
 
 
 help:
@@ -15,9 +16,9 @@ help:
 	@echo "release:	upload a release to pypi"
 
 version:
-	python setup.py --version
+	$(PYTHON) setup.py --version
 
-version-%: OLDVERSION:=$(shell python setup.py --version)
+version-%: OLDVERSION:=$(shell $(PYTHON) setup.py --version)
 version-%: NEWVERSION=$(subst -,.,$*)
 version-%:
 	sed -i '' -e s/$(OLDVERSION)/$(NEWVERSION)/ $(VERSION_FILE)
@@ -27,14 +28,14 @@ release: release-test release-tag upload
 
 release-test: test-unit test-func
 
-release-tag: VERSION:=$(shell python setup.py --version)
+release-tag: VERSION:=$(shell $(PYTHON) setup.py --version)
 release-tag:
 	git tag -a v$(VERSION) -m"release version $(VERSION)"
 	git push --tags
 
 upload:
-	python setup.py sdist
-	twine upload dist/$(shell python setup.py --fullname).*
+	$(PYTHON) setup.py sdist
+	twine upload dist/$(shell $(PYTHON) setup.py --fullname).*
 
 docs:
 	$(MAKE) -C docs/ html
@@ -43,7 +44,7 @@ test: test-unit
 testall: test-unit test-func
 
 test-unit:
-	python -m unittest discover tests/unit
+	$(PYTHON) -m unittest discover tests/unit
 
 include libvncserver.mk
 

--- a/makefile
+++ b/makefile
@@ -1,11 +1,11 @@
 #!/usr/bin/make -f
-.PHONY: upload release release-test release-tag upload docs test
 .DEFAULT: help
 
 VERSION_FILE?=vncdotool/__init__.py
 PYTHON?=python3
 
 
+.PHONY: help
 help:
 	@echo "test:		run unit tests"
 	@echo "test-func:	run functional tests"
@@ -15,6 +15,7 @@ help:
 	@echo "version-M.m.p:	update version to M.m.p"
 	@echo "release:	upload a release to pypi"
 
+.PHONY: version
 version:
 	$(PYTHON) setup.py --version
 
@@ -24,28 +25,37 @@ version-%:
 	sed -i '' -e s/$(OLDVERSION)/$(NEWVERSION)/ $(VERSION_FILE)
 	git ci $(VERSION_FILE) -m"bump version to $*"
 
+.PHONY: release
 release: release-test release-tag upload
 
+.PHONY: release-test
 release-test: test-unit test-func
 
+.PHONY: release-tag
 release-tag: VERSION:=$(shell $(PYTHON) setup.py --version)
 release-tag:
 	git tag -a v$(VERSION) -m"release version $(VERSION)"
 	git push --tags
 
+.PHONY: upload
 upload:
 	$(PYTHON) setup.py sdist
 	twine upload dist/$(shell $(PYTHON) setup.py --fullname).*
 
+.PHONY: docs
 docs:
 	$(MAKE) -C docs/ html
 
+.PHONY: test
 test: test-unit
+.PHONY: testall
 testall: test-unit test-func
 
+.PHONY: test-unit
 test-unit:
 	$(PYTHON) -m unittest discover tests/unit
 
 include libvncserver.mk
 
+.PHONY: test-func
 test-func: libvnc-examples test-libvnc

--- a/tests/functional/test_proxy.py
+++ b/tests/functional/test_proxy.py
@@ -12,11 +12,11 @@ class TestLogEvents(TestCase):
     def setUp(self):
         cmd = 'vncev -rfbport 5999 -rfbwait 1000'
         self.server = pexpect.spawn(cmd, timeout=2)
-        self.server.logfile_read = sys.stdout
+        self.server.logfile_read = sys.stdout.buffer
 
         cmd = 'vnclog --listen 1842 -s :99 -'
         self.recorder = pexpect.spawn(cmd, timeout=2)
-        self.recorder.logfile_read = sys.stdout
+        self.recorder.logfile_read = sys.stdout.buffer
 
     def tearDown(self):
         self.server.terminate(force=True)
@@ -26,7 +26,7 @@ class TestLogEvents(TestCase):
     def run_vncdo(self, commands):
         cmd = 'vncdo -s localhost::1842 ' + commands
         vnc = pexpect.spawn(cmd, timeout=2)
-        vnc.logfile_read = sys.stdout
+        vnc.logfile_read = sys.stdout.buffer
         retval = vnc.wait()
         assert retval == 0, (retval, str(vnc))
 

--- a/tests/functional/test_screen.py
+++ b/tests/functional/test_screen.py
@@ -51,8 +51,10 @@ class TestVNCCapture(TestCase):
         assert vnc.exitstatus == exitcode, vnc.exitstatus
 
     def assertFilesEqual(self, filename, othername):
-        content = open(filename, 'rb').read()
-        othercontent = open(othername, 'rb').read()
+        with open(filename, 'rb') as fd:
+            content = fd.read()
+        with open(othername, 'rb') as fd:
+            othercontent = fd.read()
 
         assert content == othercontent
 

--- a/tests/functional/test_screen.py
+++ b/tests/functional/test_screen.py
@@ -38,12 +38,12 @@ class TestVNCCapture(TestCase):
     def run_server(self, server):
         cmd = '%s -rfbport 5910 -rfbwait 1000' % server
         self.server = pexpect.spawn(cmd, timeout=2)
-        self.server.logfile_read = sys.stdout
+        self.server.logfile_read = sys.stdout.buffer
 
     def run_vncdo(self, commands, exitcode=0):
         cmd = 'vncdo -s :10 ' + commands
         vnc = pexpect.spawn(cmd, logfile=sys.stdout, timeout=5)
-        vnc.logfile_read = sys.stdout
+        vnc.logfile_read = sys.stdout.buffer
         vnc.expect(pexpect.EOF)
         if vnc.isalive():
             vnc.wait()

--- a/tests/functional/test_send_events.py
+++ b/tests/functional/test_send_events.py
@@ -15,7 +15,7 @@ class TestSendEvents(TestCase):
 
     def setUp(self):
         cmd = 'vncev -rfbport 5933 -rfbwait 1000'
-        self.server = pexpect.spawn(cmd, logfile=sys.stdout, timeout=2)
+        self.server = pexpect.spawn(cmd, logfile=sys.stdout.buffer, timeout=2)
 
     def tearDown(self):
         self.server.terminate(force=True)
@@ -38,7 +38,7 @@ class TestSendEvents(TestCase):
 
     def run_vncdo(self, commands):
         cmd = 'vncdo -v -s :33 ' + commands
-        vnc = pexpect.spawn(cmd, logfile=sys.stdout, timeout=5)
+        vnc = pexpect.spawn(cmd, logfile=sys.stdout.buffer, timeout=5)
         retval = vnc.wait()
         assert retval == 0, retval
 

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -145,7 +145,7 @@ class VNCDoToolClient(rfb.RFBClient):
     SPECIAL_KEYS_US = "~!@#$%^&*()_+{}|:\"<>?"
 
     def connectionMade(self) -> None:
-        rfb.RFBClient.connectionMade(self)
+        super().connectionMade()
 
         if self.transport.addressFamily == socket.AF_INET:
             self.transport.setTcpNoDelay(True)

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -61,6 +61,7 @@ class RFBServer(Protocol):  # type: ignore[misc]
     def _handle_security(self) -> None:
         # sectype = self.buffer[0]
         del self.buffer[:1]
+        self._handler = self._handle_clientInit, 1
 
     def _handle_VNCAuthResponse(self) -> None:
         del self.buffer[:16]

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -30,7 +30,7 @@ class RFBServer(Protocol):  # type: ignore[misc]
     _handler: Tuple[Callable[..., None], int] = (lambda data: None, 0)
 
     def connectionMade(self) -> None:
-        Protocol.connectionMade(self)
+        super().connectionMade()
         self.transport.setTcpNoDelay(True)
 
         self.buffer = bytearray()
@@ -167,7 +167,7 @@ class VNCLoggingClientProxy(portforward.ProxyClient):  # type: ignore[misc]
         self.vnclog.expect(self.vnclog._handleServerInit, 24)
 
     def dataReceived(self, data: bytes) -> None:
-        portforward.ProxyClient.dataReceived(self, data)
+        super().dataReceived(data)
         if self.vnclog:
             self.vnclog.dataReceived(data)
 
@@ -190,19 +190,19 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
 
     def connectionMade(self) -> None:
         log.info('new connection from %s', self.transport.getPeer().host)
-        portforward.ProxyServer.connectionMade(self)
+        super().connectionMade()
         RFBServer.connectionMade(self)
         self.mouse: Tuple[Optional[int], Optional[int]] = (None, None)
         self.last_event = time.time()
         self.recorder = self.factory.getRecorder()
 
     def connectionLost(self, reason: Failure) -> None:
-        portforward.ProxyServer.connectionLost(self, reason)
+        super().connectionLost(reason)
         self.factory.clientConnectionLost(self)
 
     def dataReceived(self, data: bytes) -> None:
         RFBServer.dataReceived(self, data)
-        portforward.ProxyServer.dataReceived(self, data)
+        super().dataReceived(data)
 
     def _handle_clientInit(self) -> None:
         RFBServer._handle_clientInit(self)

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -246,8 +246,12 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
 class VNCLoggingServerFactory(portforward.ProxyFactory):  # type: ignore[misc]
     protocol = VNCLoggingServerProxy
     shared = True
+
     pseudocursor = False
     nocursor = False
+    pseudodesktop = True
+    force_caps = False
+
     password_required = False
 
     output: Union[IO[str], str] = sys.stdout

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -3,6 +3,7 @@ import sys
 import time
 import os.path
 import logging
+import socket
 from typing import IO, Callable, List, Optional, Sequence, Tuple, Union
 
 from twisted.protocols import portforward
@@ -124,6 +125,7 @@ class RFBServer(Protocol):  # type: ignore[misc]
 
 
 class NullTransport:
+    addressFamily = socket.AF_UNSPEC
 
     def write(self, data: bytes) -> None:
         return

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -150,7 +150,7 @@ class VNCLoggingClient(VNCDoToolClient):
 class VNCLoggingClientProxy(portforward.ProxyClient):  # type: ignore[misc]
     """ Accept data from a server and forward to logger and downstream client
 
-    vnc server -> VNCLoggingClientProxy -> vnc client
+    VNC server -> VNCLoggingClientProxy -> VNC client
                                         -> VNCLoggingClient
     """
     vnclog: Optional[VNCLoggingClient] = None
@@ -177,9 +177,9 @@ class VNCLoggingClientFactory(portforward.ProxyClientFactory):  # type: ignore[m
 
 
 class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore[misc]
-    """ Proxy in the Middle, decodes and logs RFB messages before sending them upstream
+    """ Proxy in the middle, decodes and logs RFB messages before sending them upstream
 
-    vnc client -> VNCLoggingServerProxy -> vnc server
+    VNC client -> VNCLoggingServerProxy -> VNC server
                                         -> RFBServer
     """
     clientProtocolFactory = VNCLoggingClientFactory

--- a/vncdotool/pyDes.py
+++ b/vncdotool/pyDes.py
@@ -69,8 +69,8 @@ from pyDes import *
 data = b"Please encrypt my data"
 k = des(b"DESCRYPT", CBC, b"\0\0\0\0\0\0\0\0", pad=None, padmode=PAD_PKCS5)
 d = k.encrypt(data)
-print "Encrypted: %r" % d
-print "Decrypted: %r" % k.decrypt(d)
+print(f"Encrypted: {d!r}")
+print(f"Decrypted: {k.decrypt(d)!r}")
 assert k.decrypt(d, padmode=PAD_PKCS5) == data
 
 
@@ -542,7 +542,7 @@ class des(_baseDes):
 			if not pad:
 				raise ValueError(f"Invalid data length, data must be a multiple of {self.BLOCK_SIZE} bytes\n. Try setting the optional padding character")
 			data += pad * (-len(data) % self.BLOCK_SIZE)
-			# print "Len of data: %f" % (len(data) / self.BLOCK_SIZE)
+			# print(f"Len of data: {len(data) / self.BLOCK_SIZE}")
 
 		if self.getMode() == CBC:
 			iv_ = self.getIV()
@@ -561,7 +561,7 @@ class des(_baseDes):
 			# Test code for caching encryption results
 			#lines += 1
 			#if dict.has_key(data[i:i+8]):
-				#print "Cached result for: %s" % data[i:i+8]
+			#	print(f"Cached result for: {data[i:i+8]!r}")
 			#	cached += 1
 			#	result.append(dict[data[i:i+8]])
 			#	i += 8
@@ -596,7 +596,7 @@ class des(_baseDes):
 			#dict[data[i:i+8]] = d
 			i += 8
 
-		# print "Lines: %d, cached: %d" % (lines, cached)
+		# print(f"Lines: {lines}, cached: {cached}")
 
 		# Return the full crypted string
 		return b''.join(result)

--- a/vncdotool/pyDes.py
+++ b/vncdotool/pyDes.py
@@ -396,7 +396,7 @@ class des(_baseDes):
 		# Sanity checking of arguments.
 		if len(key) != 8:
 			raise ValueError("Invalid DES key size. Key must be exactly 8 bytes long.")
-		_baseDes.__init__(self, mode, IV, pad, padmode)
+		super().__init__(mode, IV, pad, padmode)
 		self.key_size = 8
 
 		self.L: List[int] = []
@@ -408,7 +408,7 @@ class des(_baseDes):
 
 	def setKey(self, key: bytes) -> None:
 		"""Will set the crypting key for this object. Must be 8 bytes."""
-		_baseDes.setKey(self, key)
+		super().setKey(key)
 		self.__create_sub_keys()
 
 	def __String_to_BitList(self, data: bytes) -> List[int]:
@@ -668,7 +668,7 @@ class triple_des(_baseDes):
 		with this instance.
 	"""
 	def __init__(self, key: bytes, mode: Mode = ECB, IV: Optional[bytes] = None, pad: Optional[bytes] = None, padmode: Padding = PAD_NORMAL) -> None:
-		_baseDes.__init__(self, mode, IV, pad, padmode)
+		super().__init__(mode, IV, pad, padmode)
 		self.setKey(key)
 
 	def setKey(self, key: bytes) -> None:
@@ -689,31 +689,31 @@ class triple_des(_baseDes):
 			self.__key3 = self.__key1
 		else:
 			self.__key3 = des(key[16:], self._mode, self._iv, self._padding, self._padmode)
-		_baseDes.setKey(self, key)
+		super().setKey(key)
 
 	# Override setter methods to work on all 3 keys.
 
 	def setMode(self, mode: Mode) -> None:
 		"""Sets the type of crypting mode, pyDes.ECB or pyDes.CBC"""
-		_baseDes.setMode(self, mode)
+		super().setMode(mode)
 		for key in (self.__key1, self.__key2, self.__key3):
 			key.setMode(mode)
 
 	def setPadding(self, pad: bytes) -> None:
 		"""setPadding() -> bytes of length 1. Padding character."""
-		_baseDes.setPadding(self, pad)
+		super().setPadding(pad)
 		for key in (self.__key1, self.__key2, self.__key3):
 			key.setPadding(pad)
 
 	def setPadMode(self, mode: Padding) -> None:
 		"""Sets the type of padding mode, pyDes.PAD_NORMAL or pyDes.PAD_PKCS5"""
-		_baseDes.setPadMode(self, mode)
+		super().setPadMode(mode)
 		for key in (self.__key1, self.__key2, self.__key3):
 			key.setPadMode(mode)
 
 	def setIV(self, IV: bytes) -> None:
 		"""Will set the Initial Value, used in conjunction with CBC mode"""
-		_baseDes.setIV(self, IV)
+		super().setIV(IV)
 		for key in (self.__key1, self.__key2, self.__key3):
 			key.setIV(IV)
 

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -249,7 +249,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
 
     def _handleAuth(self, block: bytes) -> None:
         (auth,) = unpack("!I", block)
-        #~ print "auth:", auth
+        #~ print(f"{auth=}")
         if auth == 0:
             self.expect(self._handleConnFailed, 4)
         elif auth == 1:
@@ -325,7 +325,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
 
     def _handleVNCAuthResult(self, block: bytes) -> None:
         (result,) = unpack("!I", block)
-        #~ print "auth:", auth
+        #~ print(f"{auth=}")
         if result == 0:     #OK
             self._doClientInitialization()
             return
@@ -455,7 +455,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
             self._doConnection()
 
     def _handleRRESubRectangles(self, block: bytes, topx: int, topy: int) -> None:
-        #~ print "_handleRRESubRectangle"
+        #~ print("_handleRRESubRectangle")
         pos = 0
         end = len(block)
         sz  = self.bypp + 8
@@ -478,7 +478,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
             self._doConnection()
 
     def _handleDecodeCORRERectangles(self, block: bytes, topx: int, topy: int) -> None:
-        #~ print "_handleDecodeCORRERectangle"
+        #~ print("_handleDecodeCORRERectangle")
         pos = 0
         end = len(block)
         sz  = self.bypp + 4
@@ -587,7 +587,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
             # In python2, block : string, block[pos] : string, ord(block[pos]) : int
             # In python3, block : byte,   block[pos] : int,    ord(block[pos]) : error
             subrects = block[pos]
-        #~ print subrects
+        #~ print(subrects)
         if subrects:
             if subencoding & 16:    #SubrectsColoured
                 self.expect(self._handleDecodeHextileSubrectsColoured, (self.bypp + 2)*subrects, bg, color, subrects, x, y, width, height, tx, ty, tw, th)
@@ -828,7 +828,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
     #------------------------------------------------------
     def dataReceived(self, data: bytes) -> None:
         #~ sys.stdout.write(repr(data) + '\n')
-        #~ print len(data), ", ", len(self._packet)
+        #~ print(f"{len(data), {len(self._packet)}")
         self._packet.extend(data)
         self._handler()
 
@@ -875,7 +875,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
         self.redmax, self.greenmax, self.bluemax = redmax, greenmax, bluemax
         self.redshift, self.greenshift, self.blueshift = redshift, greenshift, blueshift
         self.bypp = self.bpp // 8        #calc bytes per pixel
-        #~ print self.bypp
+        #~ print(self.bypp)
 
     def setEncodings(self, list_of_encodings: List[int]) -> None:
         self.transport.write(pack("!BxH", 2, len(list_of_encodings)))


### PR DESCRIPTION
After the migration to Python 3 `make functest` fails as mentioned at  https://github.com/sibson/vncdotool/pull/229#issuecomment-1370367735

This PR fixes the `bytes` vs. `unicode` changes: `pyexpect` logs `bytes` and as such needs access to the underlying `byte`-stream of `stdout`.

It also fixes some other minor nits I discovered why trying to get `make functest` work:
- `make` not doing anything for `PHONY` targets
- `make venv` not working
- `python` not being found
- warning about open files
- fix `vnclog` #140 and probably #106