### PR TITLE
Add IPv6 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,10 @@ The `vncserver` argument needs to be in the format `address[:display|::port]`. F
     # connect to myvncserver.com on port 5902 (two colons needed)
     vncdo -s myvncserver.com::5902 type "hello world"
 
+    # connect via IPv6 to localhost on display :3 (port 5903)
+    vncdo -s '[::1]:3' type "hello IPv6"
+    #         ^   ^ mind those square brackets around the IPv6 address
+
 You can also take a screen capture with::
 
     vncdo -s vncserver capture screen.png

--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -177,11 +177,45 @@ class TestParseServer(unittest.TestCase):
         assert host == '127.0.0.1'
         assert port == 5910
 
+    def test_missing_display(self):
+        with self.assertRaises(ValueError):
+            command.parse_server(":")
+
+    def test_missing_port(self):
+        with self.assertRaises(ValueError):
+            command.parse_server("::")
+
+    def test_invalid(self):
+        with self.assertRaises(ValueError):
+            command.parse_server(":::")
+
     def test_just_port(self):
         family, host, port = command.parse_server('::1111')
         assert family == socket.AF_INET
         assert host == '127.0.0.1'
         assert port == 1111
+
+    def test_ipv6_host_display(self):
+        family, host, port = command.parse_server('[::1]:10')
+        assert family == socket.AF_INET6
+        assert host == '::1'
+        assert port == 5910
+
+    def test_ipv6_host_port(self):
+        family, host, port = command.parse_server('[::1]::4444')
+        assert family == socket.AF_INET6
+        assert host == '::1'
+        assert port == 4444
+
+    def test_ipv6_just_host(self):
+        family, host, port = command.parse_server('[::1]')
+        assert family == socket.AF_INET6
+        assert host == '::1'
+        assert port == 5900
+
+    def test_ipv6_broken(self):
+        with self.assertRaises(ValueError):
+            command.parse_server("[::1")
 
     @skipUnless(hasattr(socket, "AF_UNIX"), reason="AF_UNIX not supported by old Windows")
     @mock.patch("os.path.exists")
@@ -190,6 +224,12 @@ class TestParseServer(unittest.TestCase):
         family, host, port = command.parse_server('/some/path/unix.skt')
         assert family == socket.AF_UNIX
         assert host == '/some/path/unix.skt'
+        assert port == 5900
+
+    def test_dns_name(self):
+        family, host, port = command.parse_server('localhost')
+        assert family == socket.AF_UNSPEC
+        assert host == 'localhost'
         assert port == 5900
 
 


### PR DESCRIPTION
~~This fixed the two issues you found in my previous #232 and also~~ adds IPv6 support, which is #95

While `reactor.connectTCP()` already supports IPv6, it only works when given an IPv6 address but not, when a DNS name is given which resolved to one. This is a bug in `twisted/internet/tcp.py` where `self.addressFamily = socket.AF_INET6` does not get set in that case.

My next try was to call [socket.getaddrinfo()](https://docs.python.org/3/library/socket.html#socket.getaddrinfo) myself, which returns multiple addresses. Any client must iterate over them in turn and try to connect it until one works. That way most clients will try IPv6 first and fall back to IPv4.
But doing the iteration manually does not work well with the Twisted reactor design as you have to hook the iteration to `clientConnectionFailed()`, which I did not get to work.

So I decided to switch to the newer [endpoints API](https://docs.twistedmatrix.com/en/stable/core/howto/endpoints.html), which already has code to work with `getaddrinfo()`. But it works with `Factory` instead of `Clientfactory`, so all those `clientConnection*` callbacks are no longer invoked. Because of that I added code to still call them.

I have testes this successfully on my local system with IPv4 (`127.0.0.1:0`), IPv6 (`[::1]:0`), DNS (`localhost`), UNIX (`/tmp/qemu`), but please have a closer look yourself.