### PR TITLE
Improve Pixelformat handling

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -5,6 +5,14 @@ from vncdotool import client, rfb
 
 class TestVNCDoToolClient(TestCase):
 
+    MSG_HANDSHAKE = b"RFB 003.003\n"
+    MSG_INIT = (
+        b"\x00\x00"  # width
+        b"\x00\x00"  # height
+        b"\x20\x18\x00\x01\x00\xff\x00\xff\x00\xff\x00\x08\x10\x00\x00\x00"  # pixel-format
+        b"\x00\x00\x00\x00"  # server-name-len
+    )
+
     def setUp(self) -> None:
         self.client = client.VNCDoToolClient()
         self.client.transport = mock.Mock()
@@ -18,10 +26,9 @@ class TestVNCDoToolClient(TestCase):
 
     def test_vncConnectionMade(self):
         cli = self.client
-        cli._packet = bytearray(b"RFB 003.003\n")
+        cli._packet = bytearray(self.MSG_HANDSHAKE)
         cli._handleInitial()
-        cli._handleServerInit(b" " * 24)
-        cli.vncConnectionMade()
+        cli._handleServerInit(self.MSG_INIT)
         factory = cli.factory
         factory.clientConnectionMade.assert_called_once_with(cli)
         self.client.setEncodings.assert_called_once_with([
@@ -53,9 +60,9 @@ class TestVNCDoToolClient(TestCase):
     @mock.patch('vncdotool.client.Deferred')
     def test_captureScreen(self, Deferred):
         cli = self.client
-        cli._packet = bytearray(b"RFB 003.003\n")
+        cli._packet = bytearray(self.MSG_HANDSHAKE)
         cli._handleInitial()
-        cli._handleServerInit(b" " * 24)
+        cli._handleServerInit(self.MSG_INIT)
         cli.vncConnectionMade()
         fname = 'foo.png'
 
@@ -75,9 +82,9 @@ class TestVNCDoToolClient(TestCase):
     @mock.patch('vncdotool.client.Deferred')
     def test_expectScreen(self, Deferred, image_open):
         cli = self.client
-        cli._packet = bytearray(b"RFB 003.003\n")
+        cli._packet = bytearray(self.MSG_HANDSHAKE)
         cli._handleInitial()
-        cli._handleServerInit(b" " * 24)
+        cli._handleServerInit(self.MSG_INIT)
         cli.vncConnectionMade()
         fname = 'something.png'
 

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -453,7 +453,7 @@ class VNCDoToolClient(rfb.RFBClient):
         if not width or not height:
             self.cursor = None
 
-        self.cursor = Image.frombytes('RGBX', (width, height), image)
+        self.cursor = Image.frombytes('RGB', (width, height), image, "raw", self.image_mode)
         self.cmask = Image.frombytes('1', (width, height), mask)
         self.cfocus = x, y
         self.drawCursor()

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -205,6 +205,9 @@ class NullTransport:
     def setTcpNoDelay(self, enabled: bool) -> None:
         return
 
+    def loseConnection(self) -> None:
+        return
+
 
 class VNCLoggingClient(VNCDoToolClient):
     """ Specialization of a VNCDoToolClient that will save screen captures

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -11,7 +11,7 @@ from twisted.protocols import portforward
 from twisted.python.failure import Failure
 
 from .client import KEYMAP, VNCDoToolClient
-from .rfb import AuthTypes, IntEnumLookup, PixelFormat, Rect
+from .rfb import AuthTypes, Encoding, IntEnumLookup, PixelFormat, Rect
 
 log = logging.getLogger(__name__)
 
@@ -119,7 +119,7 @@ class RFBServer(Protocol):  # type: ignore[misc]
 
     def _handle_clientInit(self) -> None:
         shared = self.buffer[0]
-        log.debug("Shared server: %s", shared)
+        log.debug("Client shares: %s", shared)
         del self.buffer[:1]
         # XXX react to shared
         # XXX send serverInit
@@ -143,6 +143,8 @@ class RFBServer(Protocol):  # type: ignore[misc]
             nbytes = 4 * nencodings
             encodings = unpack_from('!' + 'I' * nencodings, self.buffer)
             del self.buffer[:nbytes]
+            for encoding in encodings:
+                log.debug(f"Client announces {Encoding.lookup(encoding)!r}")
             self.handle_setEncodings(encodings)
         elif ptype == MsgC2S.FRAMEBUFFER_UPDATE_REQUEST:
             inc, x, y, w, h = unpack('!BHHHH', block)

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -13,7 +13,6 @@ MIT License
 """
 
 import getpass
-import math
 import os
 import re
 import sys
@@ -639,7 +638,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
                 self.expect(self._handleDecodeZRLE, 4, x, y, width, height)
             elif encoding == Encoding.PSEUDO_CURSOR:
                 length = width * height * self.bypp
-                length += int(math.floor((width + 7.0) / 8)) * height
+                length += ((width + 7) // 8) * height
                 self.expect(self._handleDecodePsuedoCursor, length, x, y, width, height)
             elif encoding == Encoding.PSEUDO_DESKTOP_SIZE:
                 self._handleDecodeDesktopSize(width, height)

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -49,11 +49,16 @@ class IntEnumLookup(IntEnum):
 class Encoding(IntEnumLookup):
     """encoding-type for SetEncodings()"""
 
+    @staticmethod
+    def s32(value: int) -> int:
+        return value - 0x1_0000_0000 if value >= 0x8000_0000 else value
+
     def __new__(cls, value: int) -> "Encoding":
-        # Convert to signed32
-        if value >= 0x8000_0000:
-            value = value - 0x1_0000_0000
-        return int.__new__(cls, value)
+        return int.__new__(cls, cls.s32(value))
+
+    @classmethod
+    def lookup(cls, value: int) -> object:
+        return super().lookup(cls.s32(value))
 
     RAW = 0
     COPY_RECTANGLE = 1


### PR DESCRIPTION
This is my result from looking at #205, which tried to force ARD to use `BRG;16` instead of `RGB32`. This PR introduces a new class `PixelFormat` based on `dataclasses` to pass around those many values of [PIXEL_FORMAT](https://www.rfc-editor.org/rfc/rfc6143#section-7.4).

As usual I found some more issues on my way:
- The `Encoding.lookup()` was not working for Encodings defined via negative numbers, but where looked up using a unsigned-int.
- Pseudo-Cursors using `RGB24` was not handles correctly
- Simplified one location doing integer math
- Improved and added some more debug logging
- Add `NullTransport.loseConnection` required for `logproxy`

The last one is problematic and incomplete, but I currently have no idea myself how to _fix_ it for real: The bigger picture is that currently stream handling is wrong in several cases: As neither TCP nor the RFB/VNC protocol defines any framing, all messages passed from client-to-server and server-to-client must be understood and handled.
While testing with `gvncviewer` as my client connecting `LibVNCServer-0.9.14/examples/pnmshow24` as my server via `vnclog` I noticed, that they negotiated many more _pseudo encoding_ than `vnclog` understands and can handle:
- <Encoding.TIGHT: 7>
- <Encoding.PSEUDO_QEMU_EXTENDED_KEY_EVENT: -258>
- <Encoding.PSEUDO_QEMU_LED_STATE: -261>
- <Encoding.PSEUDO_DESKTOP_SIZE: -223>
- <Encoding.PSEUDO_VMWARE_DISPLAY_MODE_CHANGE: 1464686185>
- <Encoding.PSEUDO_QEMU_AUDIO: -259>
- <Encoding.PSEUDO_CURSOR: -239>
- <Encoding.PSEUDO_X_CURSOR: -240>
- <Encoding.PSEUDO_QEMU_POINTER_MODTION_CHANGE: -257>
- <Encoding.ZRLE: 16>
- <Encoding.HEXTILE: 5>
- <Encoding.RRE: 2>
- <Encoding.COPY_RECTANGLE: 1>
- <Encoding.RAW: 0>

The `pnmshow24` server supports many of them, but not all:
```
rfbProcessClientNormalMessage: ignoring unsupported encoding type Enc(0xFFFFFEFE)
rfbProcessClientNormalMessage: ignoring unsupported encoding type Enc(0xFFFFFEFB)
Enabling NewFBSize protocol extension for client 127.0.0.1
rfbProcessClientNormalMessage: ignoring unsupported encoding type Enc(0x574D5669)
rfbProcessClientNormalMessage: ignoring unsupported encoding type Enc(0xFFFFFEFD)
Enabling full-color cursor updates for client 127.0.0.1
Enabling X-style cursor updates for client 127.0.0.1
rfbProcessClientNormalMessage: ignoring unsupported encoding type Enc(0xFFFFFEFF)
Using tight encoding for client 127.0.0.1
```
The last one is problematic as this results in a [FramebufferUpdate-Message](https://www.rfc-editor.org/rfc/rfc6143#section-7.6.1) with the `Encoding.TIGHT` pseudo-encoding, which `vncdotool` cannot handle:
```
INFO:twisted:x=3 y=3 width=8 height=7 <Encoding.PSEUDO_CURSOR: -239>
INFO:twisted:x=0 y=0 width=256 height=256 <Encoding.TIGHT: 7>
INFO:twisted:unknown encoding received <Encoding.TIGHT: 7>
INFO:twisted:x=181 y=48643 width=30721 height=60669 '<Encoding.UNKNOWN: 5785c57>'
```
Afterwards `vnclog` is out-of-synchronisation and starts logging many errors as most following bytes are seen as an unknown [Server-to-Client message ID](https://www.rfc-editor.org/rfc/rfc6143#section-7.6).

To handle this correctly `vnclog` needs to **sit in-between** of the client and the server and **must rewrite some of those messages to filter out** any `AuthType`, `Encoding`, … `vncdotool` does not understand.

That's too much for me to do as of now, but someone might work on that. At least the PR improves the situation, but there is more work to do. Feel free to merge now and create new issues for the newly identified issues — or delay this PR until we have some idea on how to fix them.