### PR TITLE
Regressions in 1.1.0pre

### DIFF
--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -321,7 +321,7 @@ class VNCDoToolClient(rfb.RFBClient):
                 sum_ = sum((h - e) ** 2 for h, e in zip(hist, self.expected))
                 rms = math.sqrt(sum_ / len(hist))
 
-                log.debug('rms:%d maxrms:%d', rms, maxrms)
+                log.debug('rms:%f maxrms:%f', rms, maxrms)
                 if rms <= maxrms:
                     return self
 

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -141,8 +141,8 @@ PF2IM = {
     RGB24: "RGB",
     RGB32: "RGBX",
     BGR16: "BGR;16",
-    rfb.PixelFormat(24, 24, False, True, 255, 255, 255, 16, 8, 0): "BGR;24",
-    rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 16, 8, 0): "BGR;32",
+    rfb.PixelFormat(24, 24, False, True, 255, 255, 255, 16, 8, 0): "BGR",
+    rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 16, 8, 0): "BGRX",
 }
 
 

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -183,7 +183,7 @@ def build_command_list(
             factory.deferred.addCallback(client.captureScreen, filename, int(incremental_refreshes))
         elif cmd == 'expect':
             filename = args.pop(0)
-            rms = int(args.pop(0))
+            rms = float(args.pop(0))
             factory.deferred.addCallback(client.expectScreen, filename, rms)
         elif cmd == 'rcapture':
             filename = args.pop(0)
@@ -199,7 +199,7 @@ def build_command_list(
             filename = args.pop(0)
             x = int(args.pop(0))
             y = int(args.pop(0))
-            rms = int(args.pop(0))
+            rms = float(args.pop(0))
             factory.deferred.addCallback(client.expectRegion, filename, x, y, rms)
         elif cmd in ('pause', 'sleep'):
             duration = float(args.pop(0)) / warp

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -659,7 +659,8 @@ class RFBClient(Protocol):  # type: ignore[misc]
         if self.rectangles:
             self.expect(self._handleRectangle, 12)
         else:
-            self.commitUpdate(self.rectanglePos)
+            if self.rectanglePos:
+                self.commitUpdate(self.rectanglePos)
             self.expect(self._handleConnection, 1)
 
     def _handleRectangle(self, block: bytes) -> None:
@@ -691,6 +692,8 @@ class RFBClient(Protocol):  # type: ignore[misc]
                 self._handleDecodeDesktopSize(width, height)
             elif encoding == Encoding.PSEUDO_QEMU_EXTENDED_KEY_EVENT:
                 self.negotiated_encodings.add(Encoding.PSEUDO_QEMU_EXTENDED_KEY_EVENT)
+                del self.rectanglePos[-1]  # undo append as this is no real update
+                self._doConnection()
             else:
                 log.msg(f"unknown encoding received {Encoding.lookup(encoding)!r}")
                 self.transport.loseConnection()


### PR DESCRIPTION
1. #244 introduced a regression, where the wrong [PILLOW raw format](https://github.com/python-pillow/Pillow/blob/main/src/libImaging/Unpack.c) was used and connecting to `qemu` failed.
2. #235 contained a fix for #232, which added QEMU client message support #153. The fix was incomplete and handled the case wrong, where a single `updateRectangle` message contains only the _key event message_ and no further real _update rectangles_. This fired the `Deferred` too early and `vncdo … capture …` got stuck as it found no image when called; that only happened with the 2nd _update rectangle_, but `vncdo` was no longer waiting for that.
3. Handle _root mean square_ as `float`.