### PR TITLE
Improve RFB protocol handling

### DIFF
--- a/tests/unit/test_rfb.py
+++ b/tests/unit/test_rfb.py
@@ -1,0 +1,77 @@
+from unittest import TestCase, mock
+
+from vncdotool import rfb
+
+
+class TestRFB(TestCase):
+
+    def setUp(self) -> None:
+        self.client = rfb.RFBClient()
+        self.client.transport = mock.Mock()
+        self.client.factory = mock.Mock()
+
+    def test_auth_invalid(self):
+        self.client._packet += b"X"
+        self.client._handler()
+        self.client.transport.loseConnection.assert_called_once()
+
+    def test_auth_incmplete(self):
+        self.client._packet += b"RFB 000.000"
+        self.client._handler()
+        self.client.transport.loseConnection.assert_not_called()
+
+    def test_auth_invalid33(self):
+        self.client._packet += (
+            b"RFB 003.003\n"  # header
+            b"\x00\x00\x00\x00"  # AuthTypes.INVALID
+            b"\x00\x00\x00\x1a"  # length
+            b"Too many security failures"
+        )
+        self.client._handler()
+        assert self.client._version_server == (3, 3)
+        assert self.client._version == (3, 3)
+        self.client.transport.loseConnection.assert_called_once()
+
+    def test_auth_none33(self):
+        self.client._packet += (
+            b"RFB 003.003\n"  # header
+            b"\x00\x00\x00\x01"  # AuthTypes.NONE
+        )
+        self.client.factory.shared = 0
+        self.client._handler()
+        assert self.client._version_server == (3, 3)
+        self.client.transport.write.assert_has_calls([
+            mock.call(b"RFB 003.003\n"),
+            mock.call(b"\x00"),  # shared
+        ])
+
+    def test_auth_none37(self):
+        self.client._packet += (
+            b"RFB 003.007\n"  # header
+            b"\x01"  # num-auth-types
+            b"\x01"  # AuthTypes.NONE
+        )
+        self.client.factory.shared = 0
+        self.client._handler()
+        assert self.client._version_server == (3, 7)
+        self.client.transport.write.assert_has_calls([
+            mock.call(b"RFB 003.007\n"),
+            mock.call(b"\x01"),  # AuthTypes.NONE
+            mock.call(b"\x00"),  # shared
+        ])
+
+    def test_auth_none38(self):
+        self.client._packet += (
+            b"RFB 003.008\n"  # header
+            b"\x01"  # num-auth-types
+            b"\x01"  # AuthTypes.NONE
+            b"\x00\x00\x00\x00"  # OK
+        )
+        self.client.factory.shared = 0
+        self.client._handler()
+        assert self.client._version_server == (3, 8)
+        self.client.transport.write.assert_has_calls([
+            mock.call(b"RFB 003.008\n"),
+            mock.call(b"\x01"),  # AuthTypes.NONE
+            mock.call(b"\x00"),  # shared
+        ])

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -20,7 +20,7 @@ import zlib
 from dataclasses import astuple, dataclass
 from enum import IntEnum, IntFlag
 from struct import Struct, pack, unpack
-from typing import Any, Callable, ClassVar, Collection, Iterator, List, Optional, Tuple, cast
+from typing import Any, Callable, ClassVar, Collection, Dict, Iterator, List, Optional, Tuple, cast
 
 from Crypto.Cipher import AES
 from Crypto.Hash import MD5
@@ -452,6 +452,9 @@ class RFBClient(Protocol):  # type: ignore[misc]
     def __init__(self) -> None:
         self._packet = bytearray()
         self._handler = self._handleInitial
+        self._expected_len = 12
+        self._expected_args: Tuple[Any, ...] = ()
+        self._expected_kwargs: Dict[str, Any] = {}
         self._already_expecting = False
         self._version: Ver = (0, 0)
         self._version_server: Ver = (0, 0)


### PR DESCRIPTION
1. Improve handling of initial handshake #110
2. Force transport to loose connection on protocol errors due to the lack of framing
3. Basic handling of [SetColourMapEntries](https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#setcolourmapentries) (only handle the message, but adding support for _palette formats_ should be done in the future)
4. Initialize all values in `__init__()`.