### PR TITLE
rework handling of error, ref #256, #189

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-1.1.0 (unreleased)
+1.1.0 (2023-04-01)
 ----------------------
 Huge thanks to @pmhahn for single handedly driving conversion to modern Python3, as well
 as cleaning up a ton of outstanding issues.

--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -142,9 +142,6 @@ def connect(
     http://twistedmatrix.com/documents/13.0.0/core/howto/choosing-reactor.html
     for a better method of intergrating vncdotool.
     """
-
-
-
     if not reactor.running:
 
         # For api.shutdown to kill reactor threads before trying to exit due to an Exception

--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -94,12 +94,13 @@ class ThreadedVNCClientProxy:
             return reason
 
         def callable_threaded_proxy(*args: Any, **kwargs: Any) -> Any:
-            reactor.callFromThread(
-                    self.factory.deferred.addCallbacks, # ensure we're connected
-                                   threaded_call,
-                                   errback_not_connected,
-                                   args,
-                                   kwargs)
+        reactor.callFromThread(
+            self.factory.deferred.addCallbacks,  # ensure we're connected
+            threaded_call,
+            errback_not_connected,
+            args,
+            kwargs,
+        )
             try:
                 result = self.queue.get(timeout=self._timeout)
             except queue.Empty:

--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -161,8 +161,6 @@ def connect(
         )
         _THREAD.daemon = True
         _THREAD.name = 'Twisted Reactor'
-
-
         _THREAD.start()
 
         observer = PythonLoggingObserver()

--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -9,6 +9,7 @@ import queue
 import socket
 import sys
 import threading
+from types import TracebackType
 from typing import Any, List, Optional, Type, TypeVar
 
 from twisted.internet import reactor
@@ -146,7 +147,7 @@ def connect(
         # ensure we kill reactor threads before trying to exit due to an Exception
         sys_excepthook = sys.excepthook
 
-        def ensure_reactor_stopped(etype, value, traceback):
+        def ensure_reactor_stopped(etype: Type[BaseException], value: BaseException, traceback: TracebackType) -> None:
             shutdown()
             sys_excepthook(etype, value, traceback)
 

--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -89,7 +89,7 @@ class ThreadedVNCClientProxy:
             d.addBoth(result_callback)
             return d
 
-        def errback_not_connected(reason: Failure, *args: Any, **kwargs: Any) -> None:
+        def errback_not_connected(reason: Failure, *args: Any, **kwargs: Any) -> Failure:
             self.queue.put(reason)
             return reason
 

--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -94,13 +94,13 @@ class ThreadedVNCClientProxy:
             return reason
 
         def callable_threaded_proxy(*args: Any, **kwargs: Any) -> Any:
-        reactor.callFromThread(
-            self.factory.deferred.addCallbacks,  # ensure we're connected
-            threaded_call,
-            errback_not_connected,
-            args,
-            kwargs,
-        )
+            reactor.callFromThread(
+                self.factory.deferred.addCallbacks,  # ensure we're connected
+                threaded_call,
+                errback_not_connected,
+                args,
+                kwargs,
+            )
             try:
                 result = self.queue.get(timeout=self._timeout)
             except queue.Empty:
@@ -143,12 +143,13 @@ def connect(
     for a better method of intergrating vncdotool.
     """
     if not reactor.running:
-
-        # For api.shutdown to kill reactor threads before trying to exit due to an Exception
+        # ensure we kill reactor threads before trying to exit due to an Exception
         sys_excepthook = sys.excepthook
+
         def ensure_reactor_stopped(etype, value, traceback):
             shutdown()
             sys_excepthook(etype, value, traceback)
+
         sys.excepthook = ensure_reactor_stopped
 
         global _THREAD

--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -29,17 +29,16 @@ log = logging.getLogger(__name__)
 _THREAD: Optional[threading.Thread] = None
 
 
-class VNCDoException(Exception):
-    pass
-
 
 def shutdown() -> None:
     if not reactor.running:
         return
 
     reactor.callFromThread(reactor.stop)
+    global _THREAD
     if _THREAD is not None:
         _THREAD.join()
+        _THREAD = None
 
 
 class ThreadedVNCClientProxy:
@@ -82,10 +81,7 @@ class ThreadedVNCClientProxy:
     def __getattr__(self, attr: str) -> Any:
         method = getattr(self.factory.protocol, attr)
 
-        def errback(reason: Failure, *args: Any, **kwargs: Any) -> None:
-            self.queue.put(Failure(reason))
-
-        def callback(protocol: VNCDoToolClient, *args: Any, **kwargs: Any) -> Deferred:
+        def threaded_call(protocol: VNCDoToolClient, *args: Any, **kwargs: Any) -> Deferred:
             def result_callback(result: V) -> V:
                 self.queue.put(result)
                 return result
@@ -93,21 +89,29 @@ class ThreadedVNCClientProxy:
             d.addBoth(result_callback)
             return d
 
-        def proxy_call(*args: Any, **kwargs: Any) -> Any:
-            reactor.callFromThread(self.factory.deferred.addCallbacks,
-                                   callback, errback, args, kwargs)
+        def errback_not_connected(reason: Failure, *args: Any, **kwargs: Any) -> None:
+            self.queue.put(reason)
+            return reason
+
+        def callable_threaded_proxy(*args: Any, **kwargs: Any) -> Any:
+            reactor.callFromThread(
+                    self.factory.deferred.addCallbacks, # ensure we're connected
+                                   threaded_call,
+                                   errback_not_connected,
+                                   args,
+                                   kwargs)
             try:
                 result = self.queue.get(timeout=self._timeout)
             except queue.Empty:
                 raise TimeoutError("Timeout while waiting for client response")
 
             if isinstance(result, Failure):
-                raise VNCDoException(result)
+                result.raiseException()
 
             return result
 
         if callable(method):
-            return proxy_call
+            return callable_threaded_proxy
         else:
             return getattr(self.protocol, attr)
 
@@ -137,7 +141,18 @@ def connect(
     http://twistedmatrix.com/documents/13.0.0/core/howto/choosing-reactor.html
     for a better method of intergrating vncdotool.
     """
+
+
+
     if not reactor.running:
+
+        # For api.shutdown to kill reactor threads before trying to exit due to an Exception
+        sys_excepthook = sys.excepthook
+        def ensure_reactor_stopped(etype, value, traceback):
+            shutdown()
+            sys_excepthook(etype, value, traceback)
+        sys.excepthook = ensure_reactor_stopped
+
         global _THREAD
         _THREAD = threading.Thread(
             target=reactor.run,
@@ -145,6 +160,9 @@ def connect(
             kwargs={'installSignalHandlers': False},
         )
         _THREAD.daemon = True
+        _THREAD.name = 'Twisted Reactor'
+
+
         _THREAD.start()
 
         observer = PythonLoggingObserver()

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -132,7 +132,11 @@ except ImportError:
     PIL = _RuntimeImportError()
 
 
-class AuthenticationError(Exception):
+class VNCDoException(Exception):
+    pass
+
+
+class AuthenticationError(VNCDoException):
     """ VNC Server requires Authentication """
 
 
@@ -521,7 +525,7 @@ class VNCDoToolFactory(rfb.RFBFactory):
         self.deferred = Deferred()
 
     def clientConnectionLost(self, connector: IConnector, reason: Failure) -> None:
-        self.deferred.errback(reason)
+        pass
 
     def clientConnectionFailed(self, connector: IConnector, reason: Failure) -> None:
         self.deferred.errback(reason)


### PR DESCRIPTION
revert #189, connectionLost is called after the deferred was called for a successful or failed connection. Leading to AlreadyCalledError being raised

Further investigation uncovered a few bugs
 - api.ahutdown() if called multiple times would try to join a dead thread
 - renamed functions to be more readable to aid debugging
 - ensure we shutdown the reactor and associated threads when exiting program due to an exception.  This prevents hangs because the reactor creates a ThreadPool with non-daemon threads
 - BREAKING, may now raise Twisted Exceptions rather than VNCDoException wrapping the underlying exceptions