### PR TITLE
Simplify RPM support to Python 3 only

### DIFF
--- a/rpm/python-vncdotool.spec
+++ b/rpm/python-vncdotool.spec
@@ -1,7 +1,7 @@
-# A basic RPM packaging for VNCDoTool with both Python 2 and 3.
+# A basic RPM packaging for VNCDoTool with Python 3.
 
-Name:           python-vncdotool
-Version:        0.12.0
+Name:           python3-vncdotool
+Version:        1.2.0
 Release:        0%{?dist}
 Summary:        A command line VNC client and python library
 Group:          Development/Languages
@@ -11,58 +11,34 @@ Source0:        https://files.pythonhosted.org/packages/2f/99/c5dfe95a64b203c113
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-BuildArch:      noarch 
+BuildArch:      noarch
 
 BuildRequires:  gcc
 BuildRequires:  redhat-rpm-config
-BuildRequires:  python-devel
-BuildRequires:  python-setuptools
-Requires:       python-twisted
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+Requires:       python3-twisted
 
 
 %description
 A command line VNC client and python library
 
-%package -n python3-vncdotool
-Summary:        A command line VNC client and python library
-Group:          Development/Languages
-BuildRequires:  python3-devel
-BuildRequires:  python3-setuptools
-Requires:       python3-twisted
-%description -n python3-vncdotool
-A command line VNC client and python library
 
 %prep
 %setup -q -n vncdotool-%{version}
-rm -rf %{py3dir}
-cp -a . %{py3dir}
 
 %build
-%{__python} setup.py build
-
-pushd %{py3dir}
 %{__python3} setup.py build
-popd
 
 %install
-%{__python} setup.py install -O1 --skip-build --root $RPM_BUILD_ROOT
-
-pushd %{py3dir}
 %{__python3} setup.py install -O1 --skip-build --root $RPM_BUILD_ROOT
-popd
 
 %files
 %defattr(-,root,root,-)
 #%doc README.txt
-%{python_sitelib}/vncdotool/*.py*
-%{python_sitelib}/vncdotool-*.egg-info
+%{python3_sitelib}/vncdotool/*.py*
+%{python3_sitelib}/vncdotool/__pycache__/*.cpython-3*.py*
+%{python3_sitelib}/vncdotool-*.egg-info
 /usr/bin/vncdo
 /usr/bin/vncdotool
 /usr/bin/vnclog
-
-%files -n python3-vncdotool
-%defattr(-,root,root,-)
-%{python3_sitelib}/vncdotool/*.py*
-%{python3_sitelib}/vncdotool/__pycache__/*.cpython-3?.py*
-%{python3_sitelib}/vncdotool/__pycache__/*.cpython-3?.opt-1.py*
-%{python3_sitelib}/vncdotool-*.egg-info


### PR DESCRIPTION
Now that the VNCDoTool no longer officially supports Python 2 we can simplify the RPM spec file and restore compatibility with most recent RPM packager distros.