### PR TITLE
Improve special key handling

### DIFF
--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -74,6 +74,8 @@ class ThreadedVNCClientProxy:
 
     def __getattr__(self, attr: str) -> Any:
         method = getattr(self.factory.protocol, attr)
+        if not callable(method):
+            return getattr(self.protocol, attr)
 
         def threaded_call(
             protocol: VNCDoToolClient, *args: Any, **kwargs: Any
@@ -110,10 +112,7 @@ class ThreadedVNCClientProxy:
 
             return result
 
-        if callable(method):
-            return callable_threaded_proxy
-        else:
-            return getattr(self.protocol, attr)
+        return callable_threaded_proxy
 
     def __dir__(self) -> List[str]:
         return dir(self.__class__) + dir(self.factory.protocol)

--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -47,7 +47,7 @@ class ThreadedVNCClientProxy:
     ) -> None:
         self.factory = factory
         self.queue: queue.Queue[Any] = queue.Queue()
-        self._timeout = timeout
+        self.timeout = timeout
         self.protocol: Optional[VNCDoToolClient] = None
 
     def __enter__(self: TProxy) -> TProxy:
@@ -55,16 +55,6 @@ class ThreadedVNCClientProxy:
 
     def __exit__(self, *_: Any) -> None:
         self.disconnect()
-
-    @property
-    def timeout(self) -> Optional[float]:
-        """Timeout in seconds for API requests."""
-        return self._timeout
-
-    @timeout.setter
-    def timeout(self, timeout: float) -> None:
-        """Timeout in seconds for API requests."""
-        self._timeout = timeout
 
     def connect(
         self, host: str, port: int = 5900, family: socket.AddressFamily = socket.AF_INET
@@ -111,7 +101,7 @@ class ThreadedVNCClientProxy:
                 kwargs,
             )
             try:
-                result = self.queue.get(timeout=self._timeout)
+                result = self.queue.get(timeout=self.timeout)
             except queue.Empty:
                 raise TimeoutError("Timeout while waiting for client response")
 

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -195,23 +195,26 @@ class VNCDoToolClient(rfb.RFBClient):
 
         key: string: either [a-z] or a from KEYMAP
         """
-        log.debug("keyPress %s", key)
-        self.keyDown(key)
-        self.keyUp(key)
+        keys = self._decodeKey(key)
+        log.debug("keyPress %s", keys)
+        for k in keys:
+            self.keyEvent(k, down=True)
+        for k in reversed(keys):
+            self.keyEvent(k, down=False)
 
         return self
 
     def keyDown(self: TClient, key: str) -> TClient:
-        log.debug("keyDown %s", key)
         keys = self._decodeKey(key)
+        log.debug("keyDown %s", keys)
         for k in keys:
             self.keyEvent(k, down=True)
 
         return self
 
     def keyUp(self: TClient, key: str) -> TClient:
-        log.debug("keyUp %s", key)
         keys = self._decodeKey(key)
+        log.debug("keyUp %s", keys)
         for k in keys:
             self.keyEvent(k, down=False)
 


### PR DESCRIPTION
At least (old) version of Qemu (2.6 from ~2016) have a problem when key-sequences are releases in the same order they are pressed. Reverse the order the the key pressed last is released first.

Also two minore code cleanups.