### PR TITLE
Remove transitive dependency zope.interface from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 Pillow>=9.3.0
 Twisted>=22.10.0
-zope.interface>=5.4.0
 pycryptodomex>=3.12.0


### PR DESCRIPTION
As part of our ongoing research on Python dependency management we noticed a potential improvement in your project’s dependency management.

Specifically, the transitive dependency `zope.interface` of package `Twisted` is specified as a requirement in the `requirements.txt` file, when in reality it is not needed.

This PR removes it from requirements.txt to let pip manage it automatically, which helps keeping the dependency list clean.

Hope this is helpful!

Best regards