### PR TITLE
Update supported Python versions

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ author_email = sibson+vncdotool@gmail.com
 description = Command line VNC client
 long_description = file: README.rst, CHANGELOG.rst
 keywords = VNC, RFB
-python_requires = >=3.8
+python_requires = >=3.9
 license = MIT License
 license_files = LICENSE.txt
 classifiers =
@@ -21,11 +21,11 @@ classifiers =
 	Operating System :: Microsoft :: Windows
 	Operating System :: POSIX
 	Programming Language :: Python
-	Programming Language :: Python :: 3.8
-	Programming Language :: Python :: 3.9
-	Programming Language :: Python :: 3.10
-	Programming Language :: Python :: 3.11
-	Programming Language :: Python :: 3.12
+        Programming Language :: Python :: 3.9
+        Programming Language :: Python :: 3.10
+        Programming Language :: Python :: 3.11
+        Programming Language :: Python :: 3.12
+        Programming Language :: Python :: 3.13
 	Topic :: Multimedia :: Graphics :: Viewers
 	Topic :: Software Development :: Testing
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 min_version = 4.0
 envlist =
-    py37
-    py38
     py39
     py310
     py311
+    py312
+    py313
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
## Summary
- drop Python 3.8 and require Python 3.9+
- expand supported versions to include Python 3.13 in metadata and tox
- update the CI matrix to exercise the newer Python releases

## Testing
- python -m unittest discover tests/unit

------
https://chatgpt.com/codex/tasks/task_e_6907629311748327ad7724078bc8b3b5