### PR TITLE
Fix ThreadedVNCClientProxy.disconnect() to block until disconnected

### DIFF
--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -71,10 +71,17 @@ class ThreadedVNCClientProxy:
         reactor.callWhenRunning(factory_connect, self.factory, host, port, family)
 
     def disconnect(self) -> None:
+        event = threading.Event()
+
+        def on_disconnected(reason: Any) -> None:
+            event.set()
+
         def disconnector(protocol: VNCDoToolClient) -> None:
+            self.factory._disconnect_callbacks.append(on_disconnected)
             protocol.transport.loseConnection()
 
         reactor.callFromThread(self.factory.deferred.addCallback, disconnector)
+        event.wait(timeout=self.timeout)
 
     def __getattr__(self, attr: str) -> Any:
         method = getattr(self.factory.protocol, attr)

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -12,7 +12,7 @@ import math
 import socket
 from pathlib import Path
 from struct import pack
-from typing import IO, Any, Iterator, TypeVar, Union
+from typing import IO, Any, Callable, Iterator, TypeVar, Union
 
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred, inlineCallbacks, returnValue
@@ -546,9 +546,12 @@ class VNCDoToolFactory(rfb.RFBFactory):
 
     def __init__(self) -> None:
         self.deferred = Deferred()
+        self._disconnect_callbacks: list[Callable[[Failure], None]] = []
 
     def clientConnectionLost(self, connector: IConnector, reason: Failure) -> None:
-        pass
+        for cb in self._disconnect_callbacks:
+            cb(reason)
+        self._disconnect_callbacks.clear()
 
     def clientConnectionFailed(self, connector: IConnector, reason: Failure) -> None:
         self.deferred.errback(reason)


### PR DESCRIPTION
disconnect() previously scheduled loseConnection() and returned immediately, before the TCP connection was actually closed. This caused race conditions where code running after disconnect() could still be affected by the old connection being torn down (e.g. a VNC server closing both old and new connections in certain conditions).

Fix by registering a disconnect callback on VNCDoToolFactory and waiting on a threading.Event in disconnect() until clientConnectionLost fires, making the synchronous API truly synchronous on disconnect as well.

Fixes #314

https://claude.ai/code/session_01AA4gPSov9NB2ewZLgtAp16