### PR TITLE
Fix functional test runner invocation (unittest discover)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 1.3.1 (UNRELEASED)
 ----------------------
+  - Fix ``make test-func`` and documented functional test command failing with relative import error (#303)
 
 1.3.0 (2026-04-03)
 ----------------------

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -19,7 +19,7 @@ running.  You can either manually configure and update your path or use the prov
 
     make libvnc-examples
     export PATH="$PATH:.vncdo/libvncserver-LibVNCServer-0.9.14/examples"
-    python -m unittest discover tests/functional
+    python -m unittest discover -t . -s tests/functional
 
 
 The RFB/VNC Protocol

--- a/libvncserver.mk
+++ b/libvncserver.mk
@@ -47,7 +47,9 @@ $(LIBVNCSERVER_EXAMPLES_SRCS): $(LIBVNCSERVER_DIR) $(LIBVNCSERVER_MAKEFILE)
 $(LIBVNCSERVER_EXAMPLES): $(LIBVNCSERVER_EXAMPLES_SRCS)
 	$(MAKE) -C $(LIBVNCSERVER_DIR)
 
+UNITTEST_ARGS?=-t .
+
 .PHONY: test-libvnc
 test-libvnc: export PATH:=$(PATH):$(LIBVNCSERVER_DIR)/examples
 test-libvnc:
-	$(PYTHON) -m unittest discover $(UNITTEST_ARGS) tests/functional
+	$(PYTHON) -m unittest discover $(UNITTEST_ARGS) -s tests/functional


### PR DESCRIPTION
## Summary

Fixes the functional test runner reported broken in [#303](https://github.com/sibson/vncdotool/pull/303#issuecomment-4679782983).

`python -m unittest discover tests/functional` sets the top-level dir to `tests/functional`, so the test modules are imported as top-level names (`test_proxy`) and `from .cli import spawn_command` fails with *"attempted relative import with no known parent package."* The Makefile's `test-libvnc` target had the same bug because `$(UNITTEST_ARGS)` was never defined.

This PR keeps the project on the standard library `unittest` runner (no new pytest dependency — CI and tox already use `unittest discover`):

- `libvncserver.mk`: default `UNITTEST_ARGS?=-t .` and run `discover $(UNITTEST_ARGS) -s tests/functional`, preserving the `tests.functional` package context for `make test-func`.
- `DEVELOP.rst`: documented command updated to `python -m unittest discover -t . -s tests/functional`.

## Testing
- `python -m unittest discover -t . -s tests/functional` now imports modules as `tests.functional.*` (relative imports resolve).

https://claude.ai/code/session_01Tvg8Ce2dzGiY9a9Pg71pp6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tvg8Ce2dzGiY9a9Pg71pp6)_