### PR TITLE
Fix functional test runner and add pytest to dev deps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,7 @@
 1.3.1 (UNRELEASED)
 ----------------------
+  - Fix ``make test-func`` and documented functional test command failing with relative import error (#303)
+  - Add pytest to requirements-dev.txt
 
 1.3.0 (2026-04-03)
 ----------------------

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -19,7 +19,7 @@ running.  You can either manually configure and update your path or use the prov
 
     make libvnc-examples
     export PATH="$PATH:.vncdo/libvncserver-LibVNCServer-0.9.14/examples"
-    python -m unittest discover tests/functional
+    python -m unittest discover -t . -s tests/functional
 
 
 The RFB/VNC Protocol

--- a/libvncserver.mk
+++ b/libvncserver.mk
@@ -47,7 +47,9 @@ $(LIBVNCSERVER_EXAMPLES_SRCS): $(LIBVNCSERVER_DIR) $(LIBVNCSERVER_MAKEFILE)
 $(LIBVNCSERVER_EXAMPLES): $(LIBVNCSERVER_EXAMPLES_SRCS)
 	$(MAKE) -C $(LIBVNCSERVER_DIR)
 
+UNITTEST_ARGS?=-t .
+
 .PHONY: test-libvnc
 test-libvnc: export PATH:=$(PATH):$(LIBVNCSERVER_DIR)/examples
 test-libvnc:
-	$(PYTHON) -m unittest discover $(UNITTEST_ARGS) tests/functional
+	$(PYTHON) -m unittest discover $(UNITTEST_ARGS) -s tests/functional

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 pexpect>=4.9.0
+pytest>=7.0
 pyvirtualdisplay>=3.0
 sphinx
 twine


### PR DESCRIPTION
## Summary

Addresses both points raised in [#303](https://github.com/sibson/vncdotool/pull/303#issuecomment-4679782983).

1. `python -m unittest discover tests/functional` sets the top-level dir to `tests/functional`, so the test modules import as top-level names and `from .cli import spawn_command` fails with *"attempted relative import with no known parent package."* The Makefile's `test-libvnc` target had the same bug (`$(UNITTEST_ARGS)` was never defined). Fixed by running discovery with `-t .` and `-s tests/functional`, both in `libvncserver.mk` and the `DEVELOP.rst` instructions.
2. Adds `pytest` to `requirements-dev.txt` so `pytest tests/functional` (as shown in #303's Testing section) works out of the box. `pyvirtualdisplay` was already listed.

> **Note:** This is the alternative to #326. #326 fixes the same runner bug but stays on stdlib `unittest` only (no pytest dependency). Pick whichever direction you prefer for pytest.

## Testing
- `python -m unittest discover -t . -s tests/functional` now imports modules as `tests.functional.*` (relative imports resolve).

https://claude.ai/code/session_01Tvg8Ce2dzGiY9a9Pg71pp6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tvg8Ce2dzGiY9a9Pg71pp6)_