### PR TITLE
Fix vnclog startup message output to stderr

### DIFF
--- a/libvncserver.mk
+++ b/libvncserver.mk
@@ -50,4 +50,4 @@ $(LIBVNCSERVER_EXAMPLES): $(LIBVNCSERVER_EXAMPLES_SRCS)
 .PHONY: test-libvnc
 test-libvnc: export PATH:=$(PATH):$(LIBVNCSERVER_DIR)/examples
 test-libvnc:
-	$(PYTHON) -m unittest discover $(UNITTEST_ARGS) tests/functional
+	$(PYTHON) -m unittest discover $(UNITTEST_ARGS) -s tests/functional -t .

--- a/tests/functional/test_proxy.py
+++ b/tests/functional/test_proxy.py
@@ -23,6 +23,7 @@ class TestLogEvents(TestCase):
             "vnclog", "--listen", "1842", "-s", ":99", "-", timeout=5
         )
         self.recorder.logfile_read = sys.stdout.buffer
+        self.recorder.expect(r'accepting connections on ::\d+')
 
     def tearDown(self) -> None:
         self.server.terminate(force=True)

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -401,6 +401,12 @@ def vnclog() -> None:
     output = args[0]
 
     factory = build_proxy(options)
+    # stderr, because stdout may carry the recorded session (OUTPUT of `-`)
+    print(
+        f"accepting connections on ::{factory.listen_port}",
+        file=sys.stderr,
+        flush=True,
+    )
 
     if options.forever and os.path.isdir(output):
         factory.output = output
@@ -410,9 +416,6 @@ def vnclog() -> None:
         factory.output = sys.stdout
     else:
         factory.output = open(output, "w")
-
-    if options.listen == 0:
-        log.info("accepting connections on ::%d", factory.listen_port)
 
     factory.password = options.password
 

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -82,7 +82,8 @@ class ExitingProcess(protocol.ProcessProtocol):  # type: ignore[misc]
         reactor.callLater(0.1, reactor.stop)
 
     def errReceived(self, data: bytes) -> None:
-        print(data)
+        sys.stderr.buffer.write(data)
+        sys.stderr.buffer.flush()
 
 
 class VNCDoToolOptionParser(optparse.OptionParser):


### PR DESCRIPTION
## Summary
This change fixes the vnclog command to output its startup message to stderr instead of using the logging system, ensuring that stdout remains clean for recording output when using the `-` output option.

## Key Changes
- **vncdotool/command.py**: Replaced the conditional logging statement with an unconditional print to stderr that always displays the listening port information. This ensures the startup message doesn't interfere with stdout when recording to stdout (via `-`).
- **tests/functional/test_proxy.py**: Updated the test to expect the startup message by adding a regex pattern match for the new stderr output format.
- **libvncserver.mk**: Fixed the unittest discovery command to use the `-s` and `-t` flags for proper test discovery, making the test runner more robust.

## Implementation Details
- The startup message is now printed directly to `sys.stderr` with `flush=True` to ensure immediate visibility
- The message format remains the same: `accepting connections on ::<port>`
- This change is particularly important for the `-` output mode where stdout carries the actual recorded VNC session data

https://claude.ai/code/session_01AQqcRj379NCNfUVhSncTs4