### PR TITLE
Spike: live UltraVNC (Windows) and Apple Screen Sharing (macOS) on hosted runners

### DIFF
--- a/.github/workflows/spike-os-servers.yml
+++ b/.github/workflows/spike-os-servers.yml
@@ -1,0 +1,294 @@
+name: Spike - OS-hosted VNC servers
+
+# Viability spike: can GitHub-hosted windows-latest / macos-latest runners host a
+# live, OS-bound VNC server (UltraVNC on Windows, Apple Screen Sharing / Remote
+# Management on macOS) that vncdotool can connect to, drive, and screenshot?
+#
+# The two jobs are fully independent - one OS failing must never take down the
+# other, so there is no `needs:`, no matrix, and each job carries its own
+# artifact uploads and diagnostics.
+
+on:
+  push:
+    branches: [claude/spike-os-servers]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  windows-ultravnc:
+    name: Windows - UltraVNC
+    runs-on: windows-latest
+    timeout-minutes: 20
+    continue-on-error: true
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Search available UltraVNC choco packages (diagnostic)
+        run: choco search ultravnc --all-versions
+        continue-on-error: true
+
+      - name: Install UltraVNC via chocolatey
+        run: choco install ultravnc -y --no-progress
+
+      - name: Locate winvnc.exe
+        id: locate
+        run: |
+          $candidates = Get-ChildItem -Path 'C:\Program Files','C:\Program Files (x86)' -Recurse -Filter winvnc.exe -ErrorAction SilentlyContinue
+          if (-not $candidates) {
+            Write-Error "winvnc.exe not found after choco install"
+            exit 1
+          }
+          $winvnc = $candidates[0].FullName
+          Write-Host "Found winvnc.exe at $winvnc"
+          $dir = Split-Path $winvnc -Parent
+          "winvnc_path=$winvnc" >> $env:GITHUB_OUTPUT
+          "winvnc_dir=$dir" >> $env:GITHUB_OUTPUT
+
+      - name: Write ultravnc.ini (no-auth, loopback-only variant)
+        run: |
+          $dir = "${{ steps.locate.outputs.winvnc_dir }}"
+          $ini = @"
+          [admin]
+          UseRegistry=0
+
+          [ultravnc]
+          PortNumber=5900
+          HTTPPortNumber=0
+          AuthRequired=0
+          AuthHosts=+127.0.0.1
+          AllowLoopback=1
+          LoopbackOnly=1
+          QuerySetting=0
+          QueryTimeout=0
+          NewMSLogon=0
+          RemoveWallpaper=1
+          NeverShutdown=1
+          DebugMode=1
+          DebugLevel=9
+          Debugmode=1
+          FileTransferEnabled=1
+          "@
+          Set-Content -Path (Join-Path $dir 'ultravnc.ini') -Value $ini -Encoding ASCII
+          # Some UltraVNC builds also read the ini from ProgramData; write both to be safe.
+          $pdDir = 'C:\ProgramData\uvnc bvba\UltraVNC'
+          New-Item -ItemType Directory -Force -Path $pdDir | Out-Null
+          Copy-Item (Join-Path $dir 'ultravnc.ini') (Join-Path $pdDir 'ultravnc.ini') -Force
+          Get-Content (Join-Path $dir 'ultravnc.ini')
+
+      - name: Start winvnc.exe
+        run: |
+          $winvnc = "${{ steps.locate.outputs.winvnc_path }}"
+          Start-Process -FilePath $winvnc -ArgumentList '-run' -PassThru | Out-Null
+          Start-Sleep -Seconds 5
+          Get-Process -Name winvnc -ErrorAction SilentlyContinue | Format-List *
+
+      - name: Wait for port 5900
+        id: waitport
+        run: |
+          $ok = $false
+          for ($i = 0; $i -lt 30; $i++) {
+            $test = Test-NetConnection -ComputerName 127.0.0.1 -Port 5900 -WarningAction SilentlyContinue
+            if ($test.TcpTestSucceeded) { $ok = $true; break }
+            Start-Sleep -Seconds 2
+          }
+          "port_open=$ok" >> $env:GITHUB_OUTPUT
+          if (-not $ok) {
+            Write-Host "::warning::port 5900 never opened"
+          }
+
+      - name: Diagnostics if port never opened
+        if: steps.waitport.outputs.port_open != 'true'
+        run: |
+          Get-Process -Name winvnc -ErrorAction SilentlyContinue | Format-List *
+          $dir = "${{ steps.locate.outputs.winvnc_dir }}"
+          Get-ChildItem $dir -Filter *.log -ErrorAction SilentlyContinue | ForEach-Object {
+            Write-Host "---- $($_.FullName) ----"
+            Get-Content $_.FullName -ErrorAction SilentlyContinue
+          }
+          Get-ChildItem $dir | Format-Table Name,Length
+
+      - name: Install vncdotool
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install pillow
+
+      - name: Connect, type, and capture (no-auth)
+        id: connect
+        run: |
+          vncdo -s 127.0.0.1::5900 type hello capture shot.png
+          python -c @"
+          from PIL import Image
+          img = Image.open('shot.png')
+          img.load()
+          extrema = img.convert('L').getextrema()
+          print('extrema:', extrema)
+          assert extrema != (0, 0), 'screenshot is fully black'
+          print('OK: screenshot captured and is not fully black')
+          "@
+
+      - name: Upload screenshot artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-ultravnc-screenshot
+          path: shot.png
+          if-no-files-found: ignore
+
+      - name: Collect winvnc log / ini for diagnosis
+        if: always()
+        run: |
+          $dir = "${{ steps.locate.outputs.winvnc_dir }}"
+          New-Item -ItemType Directory -Force -Path diagnostics | Out-Null
+          Copy-Item (Join-Path $dir 'ultravnc.ini') diagnostics\ -ErrorAction SilentlyContinue
+          Get-ChildItem $dir -Filter *.log -ErrorAction SilentlyContinue | Copy-Item -Destination diagnostics\ -ErrorAction SilentlyContinue
+          Get-Process -Name winvnc -ErrorAction SilentlyContinue | Out-File diagnostics\winvnc-process.txt
+
+      - name: Upload diagnostics artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-ultravnc-diagnostics
+          path: diagnostics
+          if-no-files-found: ignore
+
+  macos-ard:
+    name: macOS - Screen Sharing / Remote Management
+    runs-on: macos-latest
+    timeout-minutes: 20
+    continue-on-error: true
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Create dedicated local user for VNC auth
+        id: adduser
+        run: |
+          set -x
+          sudo sysadminctl -addUser vncspike -fullName "VNC Spike" -password vncspike1 2>&1 | tee adduser.log
+          echo "exit=$?" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      - name: Activate Remote Management (ARD) and grant access
+        id: kickstart
+        run: |
+          set -x
+          sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart \
+            -activate -configure -access -on \
+            -users runner,vncspike -privs -all \
+            -restart -agent 2>&1 | tee kickstart.log
+          echo "exit=$?" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      - name: Variant A - attempt legacy VNC password (diagnostic only)
+        id: legacy
+        run: |
+          set -x
+          sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart \
+            -configure -clientopts -setvnclegacy -vnclegacy yes -setvncpw vncspike1 2>&1 | tee legacy-vnc.log
+          echo "exit=$?" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      - name: Wait for port 5900
+        id: waitport
+        run: |
+          ok=false
+          for i in $(seq 1 30); do
+            if nc -z -w2 127.0.0.1 5900 2>/dev/null; then
+              ok=true
+              break
+            fi
+            sleep 2
+          done
+          echo "port_open=$ok" >> "$GITHUB_OUTPUT"
+          if [ "$ok" != "true" ]; then
+            echo "::warning::port 5900 never opened"
+          fi
+          sudo lsof -iTCP:5900 -sTCP:LISTEN -P || true
+
+      - name: Install vncdotool
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install pillow
+
+      - name: Connect, type, and capture (ARD / Diffie-Hellman auth, dedicated user)
+        id: connect_ard
+        run: |
+          vncdo -s 127.0.0.1::5900 --username vncspike --password vncspike1 type hello capture shot-ard.png
+          python3 - <<'EOF'
+          from PIL import Image
+          img = Image.open('shot-ard.png')
+          img.load()
+          extrema = img.convert('L').getextrema()
+          print('extrema:', extrema)
+          assert extrema != (0, 0), 'screenshot is fully black'
+          print('OK: screenshot captured and is not fully black')
+          EOF
+        continue-on-error: true
+
+      - name: Connect, type, and capture (legacy VNC password, variant A)
+        id: connect_legacy
+        if: steps.connect_ard.outcome != 'success'
+        run: |
+          vncdo -s 127.0.0.1::5900 --password vncspike1 type hello capture shot-legacy.png
+          python3 - <<'EOF'
+          from PIL import Image
+          img = Image.open('shot-legacy.png')
+          img.load()
+          extrema = img.convert('L').getextrema()
+          print('extrema:', extrema)
+          assert extrema != (0, 0), 'screenshot is fully black'
+          print('OK: screenshot captured and is not fully black')
+          EOF
+        continue-on-error: true
+
+      - name: Fail job if neither auth variant produced a usable screenshot
+        if: steps.connect_ard.outcome != 'success' && steps.connect_legacy.outcome != 'success'
+        run: |
+          echo "::error::Neither ARD/DH auth nor legacy VNC password auth succeeded"
+          exit 1
+
+      - name: Upload screenshot artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-ard-screenshots
+          path: |
+            shot-ard.png
+            shot-legacy.png
+          if-no-files-found: ignore
+
+      - name: Collect Remote Management / Screen Sharing logs
+        if: always()
+        run: |
+          set -x
+          mkdir -p diagnostics
+          cp adduser.log kickstart.log legacy-vnc.log diagnostics/ 2>/dev/null || true
+          sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -status 2>&1 | tee diagnostics/kickstart-status.log || true
+          log show --last 5m --predicate 'process CONTAINS "ARDAgent" OR process CONTAINS "screensharingd" OR process CONTAINS "AppleVNCServer"' > diagnostics/system.log 2>&1 || true
+          sudo lsof -iTCP:5900 -sTCP:LISTEN -P > diagnostics/port5900.log 2>&1 || true
+
+      - name: Upload diagnostics artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-ard-diagnostics
+          path: diagnostics
+          if-no-files-found: ignore

--- a/.github/workflows/spike-os-servers.yml
+++ b/.github/workflows/spike-os-servers.yml
@@ -91,27 +91,42 @@ jobs:
         run: |
           # Round 2 finding: UltraVNC hard-refuses every connection with
           # "This server does not have a valid password enabled" regardless
-          # of AuthRequired - a password is mandatory. UltraVNC's ultravnc.ini
-          # stores it as DES-encrypted hex, using the same RFB DES-variant key
-          # transform vncdotool itself implements in rfb.py's _vnc_des(): the
-          # password's bits are reversed per byte to form a DES key, which is
-          # then used to encrypt 8 zero bytes; the ciphertext is hex-encoded
-          # with a trailing 00 update-flag byte appended.
+          # of AuthRequired - a password is mandatory.
+          #
+          # Round 3 attempt: encrypt 8 zero bytes with a DES key derived from
+          # the password itself (the same bit-reversal transform vncdotool's
+          # rfb.py uses in _vnc_des() for the RFB auth *challenge response*).
+          # That got further - UltraVNC accepted the ini and offered
+          # VNC_AUTHENTICATION - but the server rejected the challenge
+          # response, meaning the password it decoded from our hex was not
+          # "vncspike1". The challenge-response key transform was the wrong
+          # thing to reuse for password *storage*.
+          #
+          # Round 4: use the actual classic VNC password-file obfuscation
+          # algorithm instead (the one behind ~/.vnc/passwd across the whole
+          # VNC family - TightVNC/TigerVNC/x11vnc/UltraVNC all derive from
+          # the original AT&T vncauth.c): encrypt the password bytes
+          # (null-padded to 8) as plaintext, using a DES key derived from a
+          # fixed constant key {23,82,107,6,35,78,88,7} via the same
+          # bit-reversal transform. This is the opposite pairing from round 3
+          # (fixed key encrypts the password, rather than the password
+          # deriving a key that encrypts zeros).
           $script = @'
           from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
-          def vnc_des_key(password):
-              pw = (password + "\0" * 8)[:8]
-              key = pw.encode("ascii")
+          def bit_reverse_key(raw_key):
               return bytes(
                   sum((128 >> i) if (k & (1 << i)) else 0 for i in range(8))
-                  for k in key
+                  for k in raw_key
               )
 
+          FIXED_KEY = bytes([23, 82, 107, 6, 35, 78, 88, 7])
+
           password = "vncspike1"
-          key = vnc_des_key(password)
+          key = bit_reverse_key(FIXED_KEY)
+          pw = (password + "\0" * 8)[:8].encode("ascii")
           des = Cipher(algorithms.TripleDES(key * 3), modes.ECB()).encryptor()
-          cipher = des.update(b"\x00" * 8) + des.finalize()
+          cipher = des.update(pw) + des.finalize()
           print((cipher + b"\x00").hex())
           '@
           Set-Content -Path compute_passwd.py -Value $script -Encoding ASCII

--- a/.github/workflows/spike-os-servers.yml
+++ b/.github/workflows/spike-os-servers.yml
@@ -7,6 +7,25 @@ name: Spike - OS-hosted VNC servers
 # The two jobs are fully independent - one OS failing must never take down the
 # other, so there is no `needs:`, no matrix, and each job carries its own
 # artifact uploads and diagnostics.
+#
+# Round-1 findings baked into this version:
+#  - Recursively scanning C:\Program Files for winvnc.exe took 5+ minutes on the
+#    loaded windows-latest toolcache image. Choco always installs UltraVNC to a
+#    fixed path, so that path is used directly instead.
+#  - `winvnc.exe -run` on a fresh install opened an interactive "Settings"
+#    dialog (visible in the process's MainWindowTitle) rather than truly
+#    headless-serving; the RFB connection then failed silently under
+#    vncdotool's default (non-verbose) logging. Round 2 installs UltraVNC as a
+#    Windows service instead, and runs vncdo at -v -v with explicit exit-code
+#    checks so any failure is visible in the log.
+#  - macOS: ARD/Diffie-Hellman auth via a dedicated local user worked end to
+#    end (TCP connect, RFB handshake, auth, type, capture) but the captured
+#    framebuffer was fully black. The legacy VNC password path
+#    (kickstart -setvnclegacy -setvncpw) is confirmed non-functional on this
+#    OS image - kickstart accepts the command but the server still demands
+#    ARD/DH auth with a username. Round 2 drops the legacy attempt from the
+#    pass/fail gate (kept as an informational-only step) and adds diagnostics
+#    aimed at explaining the black framebuffer.
 
 on:
   push:
@@ -34,22 +53,28 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Search available UltraVNC choco packages (diagnostic)
-        run: choco search ultravnc --all-versions
-        continue-on-error: true
-
       - name: Install UltraVNC via chocolatey
         run: choco install ultravnc -y --no-progress
 
       - name: Locate winvnc.exe
         id: locate
         run: |
-          $candidates = Get-ChildItem -Path 'C:\Program Files','C:\Program Files (x86)' -Recurse -Filter winvnc.exe -ErrorAction SilentlyContinue
-          if (-not $candidates) {
-            Write-Error "winvnc.exe not found after choco install"
-            exit 1
+          # Round 1: a full recursive scan of C:\Program Files took 5+ minutes
+          # on the loaded windows-latest toolcache. Choco always installs to
+          # this fixed path, so check it directly first and only fall back to
+          # a narrow (non-recursive-over-everything) search if that's wrong.
+          $known = 'C:\Program Files\uvnc bvba\UltraVNC\winvnc.exe'
+          if (Test-Path $known) {
+            $winvnc = $known
+          } else {
+            Write-Host "::warning::winvnc.exe not at expected path, falling back to a scoped search"
+            $candidates = Get-ChildItem -Path 'C:\Program Files\uvnc bvba' -Recurse -Filter winvnc.exe -ErrorAction SilentlyContinue
+            if (-not $candidates) {
+              Write-Error "winvnc.exe not found after choco install"
+              exit 1
+            }
+            $winvnc = $candidates[0].FullName
           }
-          $winvnc = $candidates[0].FullName
           Write-Host "Found winvnc.exe at $winvnc"
           $dir = Split-Path $winvnc -Parent
           "winvnc_path=$winvnc" >> $env:GITHUB_OUTPUT
@@ -86,12 +111,28 @@ jobs:
           Copy-Item (Join-Path $dir 'ultravnc.ini') (Join-Path $pdDir 'ultravnc.ini') -Force
           Get-Content (Join-Path $dir 'ultravnc.ini')
 
-      - name: Start winvnc.exe
+      - name: Install and start UltraVNC as a Windows service
+        id: service
         run: |
+          # Round 1: launching winvnc.exe directly (-run) opened an
+          # interactive "Settings" window instead of headlessly serving.
+          # Service mode is UltraVNC's normal unattended-deployment path and
+          # avoids any desktop-session GUI popup.
           $winvnc = "${{ steps.locate.outputs.winvnc_path }}"
-          Start-Process -FilePath $winvnc -ArgumentList '-run' -PassThru | Out-Null
-          Start-Sleep -Seconds 5
-          Get-Process -Name winvnc -ErrorAction SilentlyContinue | Format-List *
+          & $winvnc -install
+          Start-Sleep -Seconds 3
+          $svc = Get-Service | Where-Object { $_.Name -match 'uvnc|winvnc' -or $_.DisplayName -match 'UltraVNC' }
+          if (-not $svc) {
+            Write-Error "No UltraVNC service found after -install"
+            Get-Service | Format-Table Name, DisplayName, Status
+            exit 1
+          }
+          $svcName = $svc[0].Name
+          Write-Host "Found service: $svcName ($($svc[0].DisplayName))"
+          Start-Service -Name $svcName
+          Start-Sleep -Seconds 3
+          Get-Service -Name $svcName | Format-List *
+          "service_name=$svcName" >> $env:GITHUB_OUTPUT
 
       - name: Wait for port 5900
         id: waitport
@@ -110,13 +151,15 @@ jobs:
       - name: Diagnostics if port never opened
         if: steps.waitport.outputs.port_open != 'true'
         run: |
-          Get-Process -Name winvnc -ErrorAction SilentlyContinue | Format-List *
+          $svcName = "${{ steps.service.outputs.service_name }}"
+          if ($svcName) { Get-Service -Name $svcName | Format-List * }
           $dir = "${{ steps.locate.outputs.winvnc_dir }}"
           Get-ChildItem $dir -Filter *.log -ErrorAction SilentlyContinue | ForEach-Object {
             Write-Host "---- $($_.FullName) ----"
             Get-Content $_.FullName -ErrorAction SilentlyContinue
           }
           Get-ChildItem $dir | Format-Table Name,Length
+          Get-EventLog -LogName Application -Source '*vnc*' -Newest 20 -ErrorAction SilentlyContinue | Format-List *
 
       - name: Install vncdotool
         run: |
@@ -124,10 +167,34 @@ jobs:
           pip install .
           pip install pillow
 
-      - name: Connect, type, and capture (no-auth)
+      - name: Connect and type (no-auth, verbose)
         id: connect
         run: |
-          vncdo -s 127.0.0.1::5900 type hello capture shot.png
+          vncdo -v -v -s 127.0.0.1::5900 type hello
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "vncdo type failed with exit code $LASTEXITCODE"
+            exit $LASTEXITCODE
+          }
+          Write-Host "vncdo type: OK"
+
+      - name: Capture screenshot (verbose)
+        id: capture
+        if: always()
+        run: |
+          vncdo -v -v -s 127.0.0.1::5900 capture shot.png
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "vncdo capture failed with exit code $LASTEXITCODE"
+            exit $LASTEXITCODE
+          }
+          if (-not (Test-Path shot.png)) {
+            Write-Error "shot.png was not created"
+            exit 1
+          }
+          Write-Host "vncdo capture: OK, file size $((Get-Item shot.png).Length) bytes"
+
+      - name: Assert screenshot is not fully black
+        if: always() && steps.capture.outcome == 'success'
+        run: |
           python -c @"
           from PIL import Image
           img = Image.open('shot.png')
@@ -146,14 +213,17 @@ jobs:
           path: shot.png
           if-no-files-found: ignore
 
-      - name: Collect winvnc log / ini for diagnosis
+      - name: Collect winvnc log / ini / service state for diagnosis
         if: always()
         run: |
           $dir = "${{ steps.locate.outputs.winvnc_dir }}"
+          $svcName = "${{ steps.service.outputs.service_name }}"
           New-Item -ItemType Directory -Force -Path diagnostics | Out-Null
           Copy-Item (Join-Path $dir 'ultravnc.ini') diagnostics\ -ErrorAction SilentlyContinue
           Get-ChildItem $dir -Filter *.log -ErrorAction SilentlyContinue | Copy-Item -Destination diagnostics\ -ErrorAction SilentlyContinue
+          if ($svcName) { Get-Service -Name $svcName -ErrorAction SilentlyContinue | Out-File diagnostics\service.txt }
           Get-Process -Name winvnc -ErrorAction SilentlyContinue | Out-File diagnostics\winvnc-process.txt
+          Get-EventLog -LogName Application -Source '*vnc*' -Newest 20 -ErrorAction SilentlyContinue | Out-File diagnostics\eventlog.txt
 
       - name: Upload diagnostics artifact
         if: always()
@@ -182,7 +252,6 @@ jobs:
         run: |
           set -x
           sudo sysadminctl -addUser vncspike -fullName "VNC Spike" -password vncspike1 2>&1 | tee adduser.log
-          echo "exit=$?" >> "$GITHUB_OUTPUT"
         continue-on-error: true
 
       - name: Activate Remote Management (ARD) and grant access
@@ -193,16 +262,32 @@ jobs:
             -activate -configure -access -on \
             -users runner,vncspike -privs -all \
             -restart -agent 2>&1 | tee kickstart.log
-          echo "exit=$?" >> "$GITHUB_OUTPUT"
         continue-on-error: true
 
-      - name: Variant A - attempt legacy VNC password (diagnostic only)
+      - name: Variant A - attempt legacy VNC password (informational only, known non-functional)
         id: legacy
         run: |
           set -x
           sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart \
             -configure -clientopts -setvnclegacy -vnclegacy yes -setvncpw vncspike1 2>&1 | tee legacy-vnc.log
-          echo "exit=$?" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      - name: Keep display awake for the duration of the job
+        run: |
+          # Round 1 produced a fully black framebuffer over a working ARD/DH
+          # connection. Rule out display/App Nap sleep as a contributing cause.
+          caffeinate -d -i -u -t 1100 &
+          disown
+        continue-on-error: true
+
+      - name: Display / console session diagnostics (pre-connect)
+        run: |
+          set -x
+          who
+          stat -f "console owner: %Su" /dev/console || true
+          pmset -g || true
+          system_profiler SPDisplaysDataType 2>&1 | head -50 || true
+          ioreg -lw0 | grep -i "IOPowerManagement\|CGSSession\|display" | head -20 || true
         continue-on-error: true
 
       - name: Wait for port 5900
@@ -230,40 +315,38 @@ jobs:
 
       - name: Connect, type, and capture (ARD / Diffie-Hellman auth, dedicated user)
         id: connect_ard
+        continue-on-error: true
         run: |
-          vncdo -s 127.0.0.1::5900 --username vncspike --password vncspike1 type hello capture shot-ard.png
+          vncdo -v -v -s 127.0.0.1::5900 --username vncspike --password vncspike1 type hello capture shot-ard.png
+          echo "vncdo exit code: $?"
+          ls -l shot-ard.png
+
+      - name: Report screenshot pixel content (does not fail the job)
+        if: always()
+        run: |
           python3 - <<'EOF'
           from PIL import Image
-          img = Image.open('shot-ard.png')
+          import os
+          path = 'shot-ard.png'
+          if not os.path.exists(path):
+              print(f'{path} was not created')
+              raise SystemExit(0)
+          img = Image.open(path)
           img.load()
+          print('size:', img.size, 'mode:', img.mode)
           extrema = img.convert('L').getextrema()
           print('extrema:', extrema)
-          assert extrema != (0, 0), 'screenshot is fully black'
-          print('OK: screenshot captured and is not fully black')
+          if extrema == (0, 0):
+              print('RESULT: framebuffer is fully black (protocol succeeded, no visible desktop content)')
+          else:
+              print('RESULT: framebuffer has visible content')
           EOF
         continue-on-error: true
 
-      - name: Connect, type, and capture (legacy VNC password, variant A)
-        id: connect_legacy
-        if: steps.connect_ard.outcome != 'success'
+      - name: Fail job only if the ARD connection itself did not succeed
+        if: always()
         run: |
-          vncdo -s 127.0.0.1::5900 --password vncspike1 type hello capture shot-legacy.png
-          python3 - <<'EOF'
-          from PIL import Image
-          img = Image.open('shot-legacy.png')
-          img.load()
-          extrema = img.convert('L').getextrema()
-          print('extrema:', extrema)
-          assert extrema != (0, 0), 'screenshot is fully black'
-          print('OK: screenshot captured and is not fully black')
-          EOF
-        continue-on-error: true
-
-      - name: Fail job if neither auth variant produced a usable screenshot
-        if: steps.connect_ard.outcome != 'success' && steps.connect_legacy.outcome != 'success'
-        run: |
-          echo "::error::Neither ARD/DH auth nor legacy VNC password auth succeeded"
-          exit 1
+          test -s shot-ard.png
 
       - name: Upload screenshot artifacts
         if: always()
@@ -281,9 +364,11 @@ jobs:
           set -x
           mkdir -p diagnostics
           cp adduser.log kickstart.log legacy-vnc.log diagnostics/ 2>/dev/null || true
-          sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -status 2>&1 | tee diagnostics/kickstart-status.log || true
-          log show --last 5m --predicate 'process CONTAINS "ARDAgent" OR process CONTAINS "screensharingd" OR process CONTAINS "AppleVNCServer"' > diagnostics/system.log 2>&1 || true
+          log show --last 10m --predicate 'process CONTAINS "ARDAgent" OR process CONTAINS "screensharingd" OR process CONTAINS "AppleVNCServer" OR process CONTAINS "loginwindow" OR process CONTAINS "WindowServer"' > diagnostics/system.log 2>&1 || true
           sudo lsof -iTCP:5900 -sTCP:LISTEN -P > diagnostics/port5900.log 2>&1 || true
+          who > diagnostics/who.log 2>&1 || true
+          pmset -g > diagnostics/pmset.log 2>&1 || true
+          system_profiler SPDisplaysDataType > diagnostics/displays.log 2>&1 || true
 
       - name: Upload diagnostics artifact
         if: always()

--- a/.github/workflows/spike-os-servers.yml
+++ b/.github/workflows/spike-os-servers.yml
@@ -80,9 +80,49 @@ jobs:
           "winvnc_path=$winvnc" >> $env:GITHUB_OUTPUT
           "winvnc_dir=$dir" >> $env:GITHUB_OUTPUT
 
-      - name: Write ultravnc.ini (no-auth, loopback-only variant)
+      - name: Install vncdotool
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install pillow
+
+      - name: Compute UltraVNC ini password hash
+        id: pwhash
+        run: |
+          # Round 2 finding: UltraVNC hard-refuses every connection with
+          # "This server does not have a valid password enabled" regardless
+          # of AuthRequired - a password is mandatory. UltraVNC's ultravnc.ini
+          # stores it as DES-encrypted hex, using the same RFB DES-variant key
+          # transform vncdotool itself implements in rfb.py's _vnc_des(): the
+          # password's bits are reversed per byte to form a DES key, which is
+          # then used to encrypt 8 zero bytes; the ciphertext is hex-encoded
+          # with a trailing 00 update-flag byte appended.
+          $script = @'
+          from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+          def vnc_des_key(password):
+              pw = (password + "\0" * 8)[:8]
+              key = pw.encode("ascii")
+              return bytes(
+                  sum((128 >> i) if (k & (1 << i)) else 0 for i in range(8))
+                  for k in key
+              )
+
+          password = "vncspike1"
+          key = vnc_des_key(password)
+          des = Cipher(algorithms.TripleDES(key * 3), modes.ECB()).encryptor()
+          cipher = des.update(b"\x00" * 8) + des.finalize()
+          print((cipher + b"\x00").hex())
+          '@
+          Set-Content -Path compute_passwd.py -Value $script -Encoding ASCII
+          $hash = python compute_passwd.py
+          Write-Host "Computed ultravnc.ini passwd hex: $hash"
+          "passwd_hex=$hash" >> $env:GITHUB_OUTPUT
+
+      - name: Write ultravnc.ini (DES-encrypted password)
         run: |
           $dir = "${{ steps.locate.outputs.winvnc_dir }}"
+          $passwdHex = "${{ steps.pwhash.outputs.passwd_hex }}"
           $ini = @"
           [admin]
           UseRegistry=0
@@ -90,12 +130,9 @@ jobs:
           [ultravnc]
           PortNumber=5900
           HTTPPortNumber=0
-          AuthRequired=0
-          AuthHosts=+127.0.0.1
+          passwd=$passwdHex
           AllowLoopback=1
-          LoopbackOnly=1
-          QuerySetting=0
-          QueryTimeout=0
+          AuthHosts=+127.0.0.1
           NewMSLogon=0
           RemoveWallpaper=1
           NeverShutdown=1
@@ -161,16 +198,10 @@ jobs:
           Get-ChildItem $dir | Format-Table Name,Length
           Get-EventLog -LogName Application -Source '*vnc*' -Newest 20 -ErrorAction SilentlyContinue | Format-List *
 
-      - name: Install vncdotool
-        run: |
-          python -m pip install --upgrade pip
-          pip install .
-          pip install pillow
-
-      - name: Connect and type (no-auth, verbose)
+      - name: Connect and type (VNC password auth, verbose)
         id: connect
         run: |
-          vncdo -v -v -s 127.0.0.1::5900 type hello
+          vncdo -v -v -s 127.0.0.1::5900 --password vncspike1 type hello
           if ($LASTEXITCODE -ne 0) {
             Write-Error "vncdo type failed with exit code $LASTEXITCODE"
             exit $LASTEXITCODE
@@ -181,7 +212,7 @@ jobs:
         id: capture
         if: always()
         run: |
-          vncdo -v -v -s 127.0.0.1::5900 capture shot.png
+          vncdo -v -v -s 127.0.0.1::5900 --password vncspike1 capture shot.png
           if ($LASTEXITCODE -ne 0) {
             Write-Error "vncdo capture failed with exit code $LASTEXITCODE"
             exit $LASTEXITCODE


### PR DESCRIPTION
## What this is

Viability spike for **Tier 2** of the server compatibility plan: can GitHub-hosted `windows-latest` / `macos-latest` runners host live OS-bound VNC servers for vncdotool to test against? Verdict: **viable on both**, with one macOS caveat. Final [spike-os-servers run](https://github.com/sibson/vncdotool/actions/runs/31730610001) is green on both jobs after four evidence-driven rounds. Single file added: `.github/workflows/spike-os-servers.yml`.

## Windows / UltraVNC — works end-to-end

- `choco install ultravnc`; `winvnc.exe` is at the fixed path `C:\Program Files\uvnc bvba\UltraVNC\winvnc.exe` (do not search `Program Files` recursively — minutes-slow on runner images)
- UltraVNC refuses **all** connections until a password is set, regardless of `AuthRequired` — no no-auth shortcut exists (server literally replies "Until a password is set, incoming connections cannot be accepted")
- The `ultravnc.ini` `passwd=` hex uses the classic VNC password-*file* obfuscation (DES with the fixed `vncauth.c` key, bit-reversed) — computed in a few lines of Python on the runner; note this is *not* the challenge-response transform
- Must run as a Windows service (`winvnc.exe -install` + `Start-Service`); `winvnc.exe -run` opens an interactive settings dialog instead of serving
- `vncdo type` + `capture` succeed with genuine, non-black desktop content → Windows supports real visual assertions

## macOS / Screen Sharing — works at the protocol level

- Create a dedicated user (`sysadminctl -addUser`), enable Remote Management via `kickstart`; Screen Sharing is socket-activated on :5900 out of the box
- Auth is **ARD/Diffie-Hellman (type 30)** with username+password — vncdotool's existing ARD support handles the full round trip (connect, auth, type, capture)
- Legacy VNC password is confirmed dead on modern macOS: kickstart accepts `-setvnclegacy`/`-setvncpw` silently but the server still demands ARD auth
- **Caveat**: the captured framebuffer is fully black — the runner has no rendered desktop. macOS jobs therefore validate protocol/auth/input, not pixels, pending a follow-up into whether a display can be attached
- Bonus robustness finding: with no username supplied, `rfb.py` falls into an interactive `input("username:")` prompt and dies with `EOFError` on a TTY-less runner — filed under the plan's Phase 1 fail-loudly items

## Spike status

Spike-quality proof, triggered only on pushes to this branch + manual dispatch. Graduation (per `docs/server-compatibility-plan.md`): both jobs move under the change-triggered/path-filtered policy — Windows as a full type+capture check, macOS with pixel assertions explicitly excluded — with passwords moved to repository secrets and the dedicated-user/service-mode setup retained.

---
_Generated by [Claude Code](https://claude.ai/code/session_01STWkReabCK9sJW2qQ45brM)_