### PR TITLE
Spike: UltraVNC (Windows) and Apple Screen Sharing (macOS) on hosted runners

### DIFF
--- a/.github/workflows/spike-os-servers.yml
+++ b/.github/workflows/spike-os-servers.yml
@@ -1,0 +1,133 @@
+name: Spike - OS-hosted VNC servers
+
+# Viability spike: can GitHub-hosted windows-latest / macos-latest runners host
+# a live, OS-bound VNC server (UltraVNC on Windows, Apple Screen Sharing on
+# macOS) that vncdotool can connect to, drive and screenshot?
+#
+# What each server needs, and what it does and doesn't prove, is documented
+# next to the setup scripts in tests/servers/ultravnc/README.md and
+# tests/servers/screen-sharing/README.md. This file only wires those scripts
+# and tests/functional/test_os_servers.py together.
+#
+# The two jobs are deliberately independent - one OS failing must never take
+# down the other, so there is no `needs:` and no matrix.
+
+on:
+  push:
+    branches:
+      - claude/spike-os-servers
+      - claude/ultravnc-apple-screen-sharing-b04ev5
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: '1'
+  PIP_NO_PYTHON_VERSION_WARNING: '1'
+  VNCDOTOOL_SCREENSHOT_DIR: screenshots
+
+jobs:
+  windows-ultravnc:
+    name: Windows - UltraVNC
+    runs-on: windows-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install vncdotool
+        run: |
+          python -m pip install --upgrade pip
+          pip install . pillow
+
+      - name: Set up the UltraVNC server
+        run: ./tests/servers/ultravnc/setup.ps1
+
+      - name: Run OS server functional tests
+        run: python -m unittest discover -v -s tests/functional -t . -p 'test_os_servers.py'
+
+      - name: Capture screenshots and build the gallery
+        if: always()
+        timeout-minutes: 3
+        run: python tests/functional/capture_screenshots.py os
+
+      - name: Collect UltraVNC diagnostics
+        if: always()
+        run: ./tests/servers/ultravnc/collect-diagnostics.ps1
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ultravnc-screenshots
+          path: screenshots/
+          if-no-files-found: ignore
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ultravnc-diagnostics
+          path: diagnostics/
+          if-no-files-found: ignore
+
+  macos-screen-sharing:
+    name: macOS - Screen Sharing
+    runs-on: macos-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install vncdotool
+        run: |
+          python -m pip install --upgrade pip
+          pip install . pillow
+
+      - name: Set up the Screen Sharing server
+        run: bash tests/servers/screen-sharing/setup.sh
+
+      - name: Run OS server functional tests
+        run: python -m unittest discover -v -s tests/functional -t . -p 'test_os_servers.py'
+
+      - name: Capture screenshots and build the gallery
+        if: always()
+        timeout-minutes: 3
+        run: python tests/functional/capture_screenshots.py os
+
+      - name: Collect Screen Sharing diagnostics
+        if: always()
+        run: bash tests/servers/screen-sharing/collect-diagnostics.sh
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: screen-sharing-screenshots
+          path: screenshots/
+          if-no-files-found: ignore
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: screen-sharing-diagnostics
+          path: diagnostics/
+          if-no-files-found: ignore

--- a/.github/workflows/spike-os-servers.yml
+++ b/.github/workflows/spike-os-servers.yml
@@ -69,6 +69,12 @@ jobs:
       - name: Set up the VNC server
         run: ${{ matrix.setup }}
 
+      # An open port is not readiness: the first connection to macOS Screen
+      # Sharing is what starts it, and that connection can stall for good
+      # while the next one succeeds immediately.
+      - name: Wait for the server to serve a screen
+        run: python tests/functional/wait_for_servers.py os
+
       - name: Run OS server functional tests
         run: python -m unittest discover -v -s tests/functional -t . -p 'test_os_servers.py'
 

--- a/.github/workflows/spike-os-servers.yml
+++ b/.github/workflows/spike-os-servers.yml
@@ -7,10 +7,9 @@ name: Spike - OS-hosted VNC servers
 # What each server needs, and what it does and doesn't prove, is documented
 # next to the setup scripts in tests/servers/ultravnc/README.md and
 # tests/servers/screen-sharing/README.md. This file only wires those scripts
-# and tests/functional/test_os_servers.py together.
-#
-# The two jobs are deliberately independent - one OS failing must never take
-# down the other, so there is no `needs:` and no matrix.
+# and tests/functional/test_os_servers.py together: the two OSes differ by
+# which script sets the server up and which shell runs it, so they are one
+# matrix job rather than two near-identical ones.
 
 on:
   push:
@@ -28,13 +27,31 @@ env:
   VNCDOTOOL_SCREENSHOT_DIR: screenshots
 
 jobs:
-  windows-ultravnc:
-    name: Windows - UltraVNC
-    runs-on: windows-latest
+  os-server:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
+    strategy:
+      # One OS failing must never take down the other: each is a separate
+      # data point about that OS, not a step in a shared pipeline.
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows - UltraVNC
+            runner: windows-latest
+            shell: pwsh
+            server: ultravnc
+            setup: ./tests/servers/ultravnc/setup.ps1
+            diagnostics: ./tests/servers/ultravnc/collect-diagnostics.ps1
+          - name: macOS - Screen Sharing
+            runner: macos-latest
+            shell: bash
+            server: screen-sharing
+            setup: bash tests/servers/screen-sharing/setup.sh
+            diagnostics: bash tests/servers/screen-sharing/collect-diagnostics.sh
     defaults:
       run:
-        shell: pwsh
+        shell: ${{ matrix.shell }}
     steps:
       - name: Check out source
         uses: actions/checkout@v4
@@ -49,26 +66,30 @@ jobs:
           python -m pip install --upgrade pip
           pip install . pillow
 
-      - name: Set up the UltraVNC server
-        run: ./tests/servers/ultravnc/setup.ps1
+      - name: Set up the VNC server
+        run: ${{ matrix.setup }}
 
       - name: Run OS server functional tests
         run: python -m unittest discover -v -s tests/functional -t . -p 'test_os_servers.py'
 
+      # Everything below is diagnostics and artifact collection, so it runs
+      # with if: always() -- a failing test is exactly when the screenshot
+      # and the server's own logs are worth having. The steps above are the
+      # test itself and deliberately stop the job when they fail.
       - name: Capture screenshots and build the gallery
         if: always()
         timeout-minutes: 3
         run: python tests/functional/capture_screenshots.py os
 
-      - name: Collect UltraVNC diagnostics
+      - name: Collect server diagnostics
         if: always()
-        run: ./tests/servers/ultravnc/collect-diagnostics.ps1
+        run: ${{ matrix.diagnostics }}
 
       - name: Upload screenshots
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ultravnc-screenshots
+          name: ${{ matrix.server }}-screenshots
           path: screenshots/
           if-no-files-found: ignore
 
@@ -76,58 +97,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ultravnc-diagnostics
-          path: diagnostics/
-          if-no-files-found: ignore
-
-  macos-screen-sharing:
-    name: macOS - Screen Sharing
-    runs-on: macos-latest
-    timeout-minutes: 20
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - name: Check out source
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Install vncdotool
-        run: |
-          python -m pip install --upgrade pip
-          pip install . pillow
-
-      - name: Set up the Screen Sharing server
-        run: bash tests/servers/screen-sharing/setup.sh
-
-      - name: Run OS server functional tests
-        run: python -m unittest discover -v -s tests/functional -t . -p 'test_os_servers.py'
-
-      - name: Capture screenshots and build the gallery
-        if: always()
-        timeout-minutes: 3
-        run: python tests/functional/capture_screenshots.py os
-
-      - name: Collect Screen Sharing diagnostics
-        if: always()
-        run: bash tests/servers/screen-sharing/collect-diagnostics.sh
-
-      - name: Upload screenshots
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: screen-sharing-screenshots
-          path: screenshots/
-          if-no-files-found: ignore
-
-      - name: Upload diagnostics
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: screen-sharing-diagnostics
+          name: ${{ matrix.server }}-diagnostics
           path: diagnostics/
           if-no-files-found: ignore

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ help:
 	@echo "servers-up:	start the docker VNC test servers"
 	@echo "servers-down:	stop the docker VNC test servers"
 	@echo "test-servers:	run functional tests against the VNC test servers"
+	@echo "test-os-server:	run functional tests against this OS's VNC server"
 	@echo "screenshots:	screenshot each running VNC test server into a gallery"
 	@echo "docs:		build documentation"
 	@echo "release:	tag and push current version to trigger PyPI release"

--- a/docs/server-compatibility-plan.md
+++ b/docs/server-compatibility-plan.md
@@ -373,7 +373,13 @@ Tier 1 follow-ups:
 `claude/spike-os-servers` (commit `2de3252`, workflow
 `spike-os-servers.yml`); final run
 [31730610001](https://github.com/sibson/vncdotool/actions/runs/31730610001)
-has both jobs green after four evidence-driven rounds.
+has both jobs green after four evidence-driven rounds. The recipe below
+now lives as checked-in setup/diagnostic scripts under
+`tests/servers/ultravnc/` and `tests/servers/screen-sharing/` (each with
+a README recording why it does what it does), driven by
+`tests/functional/test_os_servers.py`, which reuses the same server
+description, round trip and screenshot gallery as Tier 1 via
+`tests/functional/vncservers.py`.
 
 *Windows / UltraVNC — works, full recipe:*
 - `choco install ultravnc`; `winvnc.exe` lands at the fixed path

--- a/tests/functional/capture_screenshots.py
+++ b/tests/functional/capture_screenshots.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Capture a screenshot of every running Docker Compose VNC test server.
+"""Capture a screenshot of every running VNC test server.
+
+Which servers those are is chosen by the group named on the command line:
+``docker`` (the default, the Docker Compose servers) or ``os`` (the
+OS-hosted server on this machine, i.e. UltraVNC or Apple Screen Sharing).
+See vncservers.py.
 
 Screenshots land in the screenshots directory (``tests/servers/screenshots``
 by default, override with ``VNCDOTOOL_SCREENSHOT_DIR``) alongside a
@@ -22,21 +27,23 @@ from pathlib import Path
 from typing import List, NamedTuple, Optional
 
 _HERE = Path(__file__).resolve().parent
-# This module's own directory, for test_servers, plus the repo root, so the
+# This module's own directory, for vncservers, plus the repo root, so the
 # script works from a checkout without vncdotool having been pip installed.
 sys.path[:0] = [str(_HERE), str(_HERE.parents[1])]
 
-from test_servers import (  # noqa: E402
+from vncservers import (  # noqa: E402
+    CONNECT_TIMEOUT,
     HOST,
-    VNC_SERVERS,
     VNCServer,
+    capture_screenshot,
     port_open,
     screenshot_dir,
+    select_servers,
 )
 
 from vncdotool import api  # noqa: E402
 
-CAPTURE_TIMEOUT = 5.0
+DEFAULT_GROUP = "docker"
 
 
 class Capture(NamedTuple):
@@ -51,9 +58,7 @@ def capture(server: VNCServer, directory: Path) -> Capture:
 
     path = directory / f"{server.name}.png"
     try:
-        with api.connect(f"{HOST}::{server.port}", password=server.password) as client:
-            client.timeout = CAPTURE_TIMEOUT
-            client.captureScreen(str(path))
+        capture_screenshot(server, path, timeout=CONNECT_TIMEOUT)
     except Exception as exc:  # noqa: BLE001 - diagnostics must not fail the build
         return Capture(server, None, f"failed, {exc}")
 
@@ -137,9 +142,10 @@ def write_job_summary(captures: List[Capture]) -> None:
         handle.write("\n".join(rows))
 
 
-def main() -> int:
+def main(argv: List[str]) -> int:
+    group = argv[1] if len(argv) > 1 else DEFAULT_GROUP
     directory = screenshot_dir()
-    captures = [capture(server, directory) for server in VNC_SERVERS]
+    captures = [capture(server, directory) for server in select_servers(group)]
 
     # api.connect() starts a background Twisted reactor thread that outlives
     # any individual client connection -- without stopping it here this
@@ -157,4 +163,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main(sys.argv))

--- a/tests/functional/capture_screenshots.py
+++ b/tests/functional/capture_screenshots.py
@@ -32,7 +32,6 @@ _HERE = Path(__file__).resolve().parent
 sys.path[:0] = [str(_HERE), str(_HERE.parents[1])]
 
 from vncservers import (  # noqa: E402
-    CONNECT_TIMEOUT,
     HOST,
     VNCServer,
     capture_screenshot,
@@ -58,7 +57,7 @@ def capture(server: VNCServer, directory: Path) -> Capture:
 
     path = directory / f"{server.name}.png"
     try:
-        capture_screenshot(server, path, timeout=CONNECT_TIMEOUT)
+        capture_screenshot(server, path)
     except Exception as exc:  # noqa: BLE001 - diagnostics must not fail the build
         return Capture(server, None, f"failed, {exc}")
 

--- a/tests/functional/test_os_servers.py
+++ b/tests/functional/test_os_servers.py
@@ -1,0 +1,26 @@
+"""Functional tests against the VNC server hosted by the OS we run on.
+
+Unlike the Docker servers in test_servers.py, these servers are part of the
+operating system rather than something we build: UltraVNC installed as a
+Windows service, or Apple Screen Sharing / Remote Management on macOS. The
+setup scripts live next to each server's notes in tests/servers/ultravnc
+and tests/servers/screen-sharing, and are what CI runs before this module.
+
+On a platform with no OS-hosted server described (Linux, say) there is
+simply nothing to register, and on a platform that has one but hasn't set
+it up the test skips with the command that would set it up.
+"""
+
+from vncdotool import api
+
+from .vncservers import os_servers, register_server_tests
+
+register_server_tests(os_servers(), globals())
+
+
+def tearDownModule() -> None:
+    # api.connect() starts a background Twisted reactor thread that
+    # outlives any individual client connection. Without stopping it here,
+    # the interpreter (and `unittest discover`) hangs on exit after all
+    # tests in this module have finished.
+    api.shutdown()

--- a/tests/functional/test_servers.py
+++ b/tests/functional/test_servers.py
@@ -6,142 +6,21 @@ before this module executes; a server whose port isn't open is skipped with
 a clear message rather than failing the whole run, so this module is also
 safe to run outside of that make target.
 
+The servers themselves, and the round trip run against each of them, are
+described in vncservers.py and shared with the OS-hosted servers tested by
+test_os_servers.py.
+
 Screenshots captured here are kept rather than thrown away: each one is
 written to the screenshots directory (``tests/servers/screenshots`` by
 default, override with ``VNCDOTOOL_SCREENSHOT_DIR``) so that a failing or
 suspicious capture can be looked at directly after the run.
 """
 
-import os
-import socket
-from pathlib import Path
-from typing import NamedTuple, Optional, Tuple
-from unittest import TestCase
-
-from PIL import Image
-
 from vncdotool import api
 
-HOST = "127.0.0.1"
-CONNECT_TIMEOUT = 5.0
-PORT_PROBE_TIMEOUT = 1.0
+from .vncservers import DOCKER_SERVERS, register_server_tests
 
-DEFAULT_SCREENSHOT_DIR = Path(__file__).resolve().parents[1] / "servers" / "screenshots"
-
-
-class VNCServer(NamedTuple):
-    name: str
-    port: int
-    password: Optional[str]
-    # Screen size the server's entrypoint configures, so a capture can be
-    # checked against what the server said it was serving.
-    size: Tuple[int, int] = (1024, 768)
-
-
-# (name, port, password) for each service in tests/servers/docker-compose.yml
-VNC_SERVERS = [
-    VNCServer("tigervnc", 5931, None),
-    VNCServer("tigervnc-auth", 5932, "vncdotool"),
-    VNCServer("x11vnc", 5933, None),
-]
-
-PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
-# getcolors() returns None above this many distinct colours, which is itself
-# proof the capture isn't a flat colour, so the cap only needs to be cheap.
-MAX_COLOURS = 256
-
-
-def screenshot_dir() -> Path:
-    """Directory screenshots are written to, created if needed."""
-    path = Path(os.environ.get("VNCDOTOOL_SCREENSHOT_DIR", DEFAULT_SCREENSHOT_DIR))
-    path.mkdir(parents=True, exist_ok=True)
-    return path
-
-
-def port_open(host: str, port: int, timeout: float = PORT_PROBE_TIMEOUT) -> bool:
-    try:
-        with socket.create_connection((host, port), timeout=timeout):
-            return True
-    except OSError:
-        return False
-
-
-class _VNCServerTestMixin:
-    """Shared test body, parameterized per-server by _make_server_test_case below.
-
-    Deliberately does NOT subclass TestCase: only the dynamically generated
-    per-server classes below should (otherwise `unittest discover` also
-    collects this shared base as its own, serverless test case).
-    """
-
-    server: VNCServer
-
-    def setUp(self) -> None:
-        if not port_open(HOST, self.server.port):
-            self.skipTest(
-                f"{self.server.name} not reachable on {HOST}:{self.server.port} -- "
-                "start the servers first with `make servers-up`"
-            )
-
-    def test_connect_key_and_capture(self) -> None:
-        """End-to-end round trip against one real server.
-
-        Passing means, in order:
-
-        * the RFB handshake completed against this server's protocol version
-          and security type (None, or VNC password auth for tigervnc-auth);
-        * a key event was accepted without the server dropping the session;
-        * a framebuffer update was received and encoded to a PNG file;
-        * that PNG is the size the server's entrypoint configured, and is not
-          a single flat colour -- i.e. we decoded real screen content
-          (the entrypoints run xlogo for exactly this reason) rather than
-          the all-black framebuffer you get when updates never arrive.
-        """
-        address = f"{HOST}::{self.server.port}"
-        png = screenshot_dir() / f"{self.server.name}.png"
-
-        with api.connect(address, password=self.server.password) as client:
-            client.timeout = CONNECT_TIMEOUT
-            client.keyPress("x")
-            client.captureScreen(str(png))
-
-        data = png.read_bytes()
-        print(f"{self.server.name}: screenshot written to {png}")
-
-        self.assertTrue(data, f"{self.server.name}: captured screenshot is empty")
-        self.assertEqual(
-            data[:8],
-            PNG_MAGIC,
-            f"{self.server.name}: captured file is not a valid PNG",
-        )
-
-        with Image.open(png) as image:
-            self.assertEqual(
-                image.size,
-                self.server.size,
-                f"{self.server.name}: capture is not the size the server serves",
-            )
-            colours = image.convert("RGB").getcolors(maxcolors=MAX_COLOURS)
-
-        self.assertNotEqual(
-            colours if colours is None else len(colours),
-            1,
-            f"{self.server.name}: capture is a single flat colour, "
-            "no screen content was decoded",
-        )
-
-
-def _make_server_test_case(server: VNCServer) -> type:
-    class_name = "TestServer_" + server.name.replace("-", "_")
-    return type(class_name, (_VNCServerTestMixin, TestCase), {"server": server})
-
-
-# Register one TestCase subclass per test server so `unittest discover`
-# reports pass/fail/skip separately for each server.
-for _server in VNC_SERVERS:
-    _test_case = _make_server_test_case(_server)
-    globals()[_test_case.__name__] = _test_case
-del _server, _test_case
+register_server_tests(DOCKER_SERVERS, globals())
 
 
 def tearDownModule() -> None:

--- a/tests/functional/vncservers.py
+++ b/tests/functional/vncservers.py
@@ -53,6 +53,10 @@ class VNCServer(NamedTuple):
     # flat, usually all-black, framebuffer is expected rather than a
     # failure -- see the macOS note in tests/servers/screen-sharing.
     renders_desktop: bool = True
+    # How long to wait for the server to answer a single request. The
+    # default suits a container on loopback; an OS-hosted server sharing a
+    # busy machine's real desktop can be far slower.
+    timeout: float = CONNECT_TIMEOUT
     # How to get this server running, quoted when a test skips itself.
     how_to_start: str = "start the servers first with `make servers-up`"
 
@@ -70,6 +74,10 @@ DOCKER_SERVERS = [
 OS_SERVER_USERNAME = os.environ.get("VNCDOTOOL_OS_SERVER_USERNAME", "vncspike")
 OS_SERVER_PASSWORD = os.environ.get("VNCDOTOOL_OS_SERVER_PASSWORD", "vncspike1")
 OS_SERVER_PORT = int(os.environ.get("VNCDOTOOL_OS_SERVER_PORT", "5900"))
+# An OS-hosted server shares a real, sometimes busy, desktop session, and
+# answers input events a lot less promptly than a container does: macOS
+# Screen Sharing took over five seconds to acknowledge a key event.
+OS_SERVER_TIMEOUT = float(os.environ.get("VNCDOTOOL_OS_SERVER_TIMEOUT", "60"))
 
 ULTRAVNC = VNCServer(
     name="ultravnc",
@@ -77,6 +85,7 @@ ULTRAVNC = VNCServer(
     password=OS_SERVER_PASSWORD,
     # The Windows runner's own desktop resolution, not one we configure.
     size=None,
+    timeout=OS_SERVER_TIMEOUT,
     how_to_start="set the server up first with tests/servers/ultravnc/setup.ps1",
 )
 
@@ -93,6 +102,7 @@ SCREEN_SHARING = VNCServer(
     # framebuffer, so captures come back black even though the protocol,
     # auth and input round trip all succeeded.
     renders_desktop=False,
+    timeout=OS_SERVER_TIMEOUT,
     how_to_start="set the server up first with tests/servers/screen-sharing/setup.sh",
 )
 
@@ -133,7 +143,7 @@ def port_open(host: str, port: int, timeout: float = PORT_PROBE_TIMEOUT) -> bool
         return False
 
 
-def connect(server: VNCServer, timeout: float = CONNECT_TIMEOUT) -> api.ThreadedVNCClientProxy:
+def connect(server: VNCServer, timeout: Optional[float] = None) -> api.ThreadedVNCClientProxy:
     """Connect to one server, with whatever credentials its security type needs.
 
     Remember that the returned client is a context manager, and that
@@ -144,11 +154,11 @@ def connect(server: VNCServer, timeout: float = CONNECT_TIMEOUT) -> api.Threaded
         password=server.password,
         username=server.username,
     )
-    client.timeout = timeout
+    client.timeout = server.timeout if timeout is None else timeout
     return client
 
 
-def capture_screenshot(server: VNCServer, path: Path, timeout: float = CONNECT_TIMEOUT) -> Path:
+def capture_screenshot(server: VNCServer, path: Path, timeout: Optional[float] = None) -> Path:
     """Capture ``server``'s framebuffer to ``path`` as a PNG."""
     with connect(server, timeout=timeout) as client:
         client.captureScreen(str(path))

--- a/tests/functional/vncservers.py
+++ b/tests/functional/vncservers.py
@@ -18,6 +18,7 @@ written twice.
 import os
 import socket
 import sys
+import time
 from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional, Tuple
 from unittest import TestCase
@@ -29,6 +30,11 @@ from vncdotool import api
 HOST = "127.0.0.1"
 CONNECT_TIMEOUT = 5.0
 PORT_PROBE_TIMEOUT = 1.0
+RETRY_DELAY = 2.0
+# Readiness budget for wait_until_ready(): how long one connection attempt
+# is given before it is abandoned, and how long to keep making them.
+READY_ATTEMPT_TIMEOUT = 20.0
+READY_DEADLINE = 180.0
 
 DEFAULT_SCREENSHOT_DIR = Path(__file__).resolve().parents[1] / "servers" / "screenshots"
 
@@ -163,6 +169,44 @@ def capture_screenshot(server: VNCServer, path: Path, timeout: Optional[float] =
     with connect(server, timeout=timeout) as client:
         client.captureScreen(str(path))
     return path
+
+
+def wait_until_ready(
+    server: VNCServer,
+    deadline_seconds: float = READY_DEADLINE,
+    attempt_timeout: float = READY_ATTEMPT_TIMEOUT,
+) -> bool:
+    """Block until ``server`` completes a whole RFB round trip, or give up.
+
+    An open port is not readiness. The Docker servers need a drawn-content
+    marker on top of it (tests/servers/draw-content.sh); an OS-hosted
+    server needs this instead, because the first connection can stall
+    indefinitely while the next one succeeds at once -- macOS Screen
+    Sharing is socket-activated, so that first connection is also what
+    starts the server.
+
+    Retrying a whole connection is therefore the only probe that means
+    anything: a per-request timeout can't rescue a connection that never
+    finished its handshake.
+    """
+    deadline = time.monotonic() + deadline_seconds
+    attempt = 0
+    while time.monotonic() < deadline:
+        attempt += 1
+        if not port_open(HOST, server.port):
+            time.sleep(RETRY_DELAY)
+            continue
+        try:
+            with connect(server, timeout=attempt_timeout) as client:
+                client.refreshScreen()
+        except Exception as exc:  # noqa: BLE001 - any failure means try again
+            print(f"{server.name}: not ready yet (attempt {attempt}: {exc})")
+            continue
+        print(f"{server.name}: ready after {attempt} attempt(s)")
+        return True
+
+    print(f"{server.name}: never completed an RFB round trip")
+    return False
 
 
 class _VNCServerTestMixin:

--- a/tests/functional/vncservers.py
+++ b/tests/functional/vncservers.py
@@ -1,0 +1,244 @@
+"""Shared description of the VNC servers vncdotool is tested against.
+
+Two families of server are described here and driven by the same code:
+
+* ``docker`` -- the Linux servers built and run by
+  ``tests/servers/docker-compose.yml`` (see ``make servers-up``);
+* ``os`` -- an OS-hosted server on the machine running the tests, i.e.
+  UltraVNC on Windows or Apple Screen Sharing on macOS, set up by the
+  scripts under ``tests/servers/ultravnc`` and
+  ``tests/servers/screen-sharing``.
+
+The two differ only in how the server is started and in what a capture is
+allowed to contain, so everything else -- connecting, capturing, the
+per-server test body, the screenshot gallery -- is shared rather than
+written twice.
+"""
+
+import os
+import socket
+import sys
+from pathlib import Path
+from typing import Dict, List, NamedTuple, Optional, Tuple
+from unittest import TestCase
+
+from PIL import Image
+
+from vncdotool import api
+
+HOST = "127.0.0.1"
+CONNECT_TIMEOUT = 5.0
+PORT_PROBE_TIMEOUT = 1.0
+
+DEFAULT_SCREENSHOT_DIR = Path(__file__).resolve().parents[1] / "servers" / "screenshots"
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+# getcolors() returns None above this many distinct colours, which is itself
+# proof the capture isn't a flat colour, so the cap only needs to be cheap.
+MAX_COLOURS = 256
+
+
+class VNCServer(NamedTuple):
+    name: str
+    port: int
+    password: Optional[str] = None
+    # Username, for servers whose security type authenticates one (Apple's
+    # ARD/Diffie-Hellman); None selects VNC password auth or no auth.
+    username: Optional[str] = None
+    # Screen size the server is known to serve, so a capture can be checked
+    # against it; None where the size is whatever the host display happens
+    # to be and therefore can't be asserted.
+    size: Optional[Tuple[int, int]] = (1024, 768)
+    # Whether the server has a rendered desktop behind it. False means a
+    # flat, usually all-black, framebuffer is expected rather than a
+    # failure -- see the macOS note in tests/servers/screen-sharing.
+    renders_desktop: bool = True
+    # How to get this server running, quoted when a test skips itself.
+    how_to_start: str = "start the servers first with `make servers-up`"
+
+
+# One entry per service in tests/servers/docker-compose.yml.
+DOCKER_SERVERS = [
+    VNCServer("tigervnc", 5931),
+    VNCServer("tigervnc-auth", 5932, password="vncdotool"),
+    VNCServer("x11vnc", 5933),
+]
+
+# Credentials the OS-hosted server setup scripts configure. They are spike
+# credentials for a throwaway runner, deliberately visible; a permanent job
+# passes real ones through these environment variables from CI secrets.
+OS_SERVER_USERNAME = os.environ.get("VNCDOTOOL_OS_SERVER_USERNAME", "vncspike")
+OS_SERVER_PASSWORD = os.environ.get("VNCDOTOOL_OS_SERVER_PASSWORD", "vncspike1")
+OS_SERVER_PORT = int(os.environ.get("VNCDOTOOL_OS_SERVER_PORT", "5900"))
+
+ULTRAVNC = VNCServer(
+    name="ultravnc",
+    port=OS_SERVER_PORT,
+    password=OS_SERVER_PASSWORD,
+    # The Windows runner's own desktop resolution, not one we configure.
+    size=None,
+    how_to_start="set the server up first with tests/servers/ultravnc/setup.ps1",
+)
+
+SCREEN_SHARING = VNCServer(
+    name="screen-sharing",
+    port=OS_SERVER_PORT,
+    password=OS_SERVER_PASSWORD,
+    # macOS Screen Sharing authenticates a local user over ARD/DH; the
+    # legacy VNC-password path is silently accepted but non-functional on
+    # current macOS.
+    username=OS_SERVER_USERNAME,
+    size=None,
+    # A hosted macOS runner has no rendered desktop session behind the
+    # framebuffer, so captures come back black even though the protocol,
+    # auth and input round trip all succeeded.
+    renders_desktop=False,
+    how_to_start="set the server up first with tests/servers/screen-sharing/setup.sh",
+)
+
+# The OS-hosted server for the platform the tests are running on, if any.
+OS_SERVERS_BY_PLATFORM: Dict[str, List[VNCServer]] = {
+    "win32": [ULTRAVNC],
+    "darwin": [SCREEN_SHARING],
+}
+
+
+def os_servers(platform: str = sys.platform) -> List[VNCServer]:
+    """OS-hosted servers testable on this platform, empty on other platforms."""
+    return OS_SERVERS_BY_PLATFORM.get(platform, [])
+
+
+def select_servers(group: str) -> List[VNCServer]:
+    """Servers in a named group: ``docker``, ``os``, or ``all``."""
+    groups = {"docker": DOCKER_SERVERS, "os": os_servers()}
+    if group == "all":
+        return [server for servers in groups.values() for server in servers]
+    if group not in groups:
+        raise ValueError(f"unknown server group {group!r}, expected one of {sorted(groups)} or 'all'")
+    return groups[group]
+
+
+def screenshot_dir() -> Path:
+    """Directory screenshots are written to, created if needed."""
+    path = Path(os.environ.get("VNCDOTOOL_SCREENSHOT_DIR", DEFAULT_SCREENSHOT_DIR))
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def port_open(host: str, port: int, timeout: float = PORT_PROBE_TIMEOUT) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def connect(server: VNCServer, timeout: float = CONNECT_TIMEOUT) -> api.ThreadedVNCClientProxy:
+    """Connect to one server, with whatever credentials its security type needs.
+
+    Remember that the returned client is a context manager, and that
+    ``api.shutdown()`` still has to be called once before the process exits.
+    """
+    client = api.connect(
+        f"{HOST}::{server.port}",
+        password=server.password,
+        username=server.username,
+    )
+    client.timeout = timeout
+    return client
+
+
+def capture_screenshot(server: VNCServer, path: Path, timeout: float = CONNECT_TIMEOUT) -> Path:
+    """Capture ``server``'s framebuffer to ``path`` as a PNG."""
+    with connect(server, timeout=timeout) as client:
+        client.captureScreen(str(path))
+    return path
+
+
+class _VNCServerTestMixin:
+    """Shared test body, parameterized per-server by register_server_tests().
+
+    Deliberately does NOT subclass TestCase: only the generated per-server
+    classes should (otherwise `unittest discover` also collects this shared
+    base as its own, serverless test case).
+    """
+
+    server: VNCServer
+
+    def setUp(self) -> None:
+        if not port_open(HOST, self.server.port):
+            self.skipTest(
+                f"{self.server.name} not reachable on {HOST}:{self.server.port} -- "
+                f"{self.server.how_to_start}"
+            )
+
+    def test_connect_key_and_capture(self) -> None:
+        """End-to-end round trip against one real server.
+
+        Passing means, in order:
+
+        * the RFB handshake completed against this server's protocol version
+          and security type (none, VNC password, or ARD/Diffie-Hellman);
+        * a key event was accepted without the server dropping the session;
+        * a framebuffer update was received and encoded to a PNG file;
+        * that PNG is the size the server said it serves, and -- for a server
+          with a desktop rendered behind it -- is not a single flat colour,
+          i.e. we decoded real screen content rather than the all-black
+          framebuffer you get when updates never arrive.
+        """
+        png = screenshot_dir() / f"{self.server.name}.png"
+
+        with connect(self.server) as client:
+            client.keyPress("x")
+            client.captureScreen(str(png))
+
+        data = png.read_bytes()
+        print(f"{self.server.name}: screenshot written to {png}")
+
+        self.assertTrue(data, f"{self.server.name}: captured screenshot is empty")
+        self.assertEqual(
+            data[:8],
+            PNG_MAGIC,
+            f"{self.server.name}: captured file is not a valid PNG",
+        )
+
+        with Image.open(png) as image:
+            if self.server.size is not None:
+                self.assertEqual(
+                    image.size,
+                    self.server.size,
+                    f"{self.server.name}: capture is not the size the server serves",
+                )
+            colours = image.convert("RGB").getcolors(maxcolors=MAX_COLOURS)
+
+        distinct = colours if colours is None else len(colours)
+        if not self.server.renders_desktop:
+            print(
+                f"{self.server.name}: {distinct} colours captured; content is not "
+                "asserted, this server has no rendered desktop behind it"
+            )
+            return
+
+        self.assertNotEqual(
+            distinct,
+            1,
+            f"{self.server.name}: capture is a single flat colour, "
+            "no screen content was decoded",
+        )
+
+
+def register_server_tests(servers: List[VNCServer], namespace: Dict[str, object]) -> None:
+    """Add one TestCase subclass per server to a test module's namespace.
+
+    Gives `unittest discover` a separate pass/fail/skip per server instead of
+    one test that stops at the first server that misbehaves.
+    """
+    for server in servers:
+        name = "TestServer_" + server.name.replace("-", "_")
+        namespace[name] = type(
+            name,
+            (_VNCServerTestMixin, TestCase),
+            # __module__ so test ids name the module that registered the
+            # case rather than this one.
+            {"server": server, "__module__": namespace.get("__name__", __name__)},
+        )

--- a/tests/functional/wait_for_servers.py
+++ b/tests/functional/wait_for_servers.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Wait until a group of VNC test servers can actually serve a screen.
+
+Used as a readiness gate before the functional tests run, so a server that
+is slow to become usable shows up here -- as a wait, with per-attempt
+reasons -- rather than as a mysterious timeout inside a test.
+
+Takes the same server group as capture_screenshots.py: ``docker``, ``os``,
+or ``all`` (see vncservers.py). Exits non-zero if any server in the group
+never became ready.
+"""
+
+import sys
+from pathlib import Path
+from typing import List
+
+_HERE = Path(__file__).resolve().parent
+# This module's own directory, for vncservers, plus the repo root, so the
+# script works from a checkout without vncdotool having been pip installed.
+sys.path[:0] = [str(_HERE), str(_HERE.parents[1])]
+
+from vncservers import select_servers, wait_until_ready  # noqa: E402
+
+from vncdotool import api  # noqa: E402
+
+DEFAULT_GROUP = "os"
+
+
+def main(argv: List[str]) -> int:
+    group = argv[1] if len(argv) > 1 else DEFAULT_GROUP
+    ready = [wait_until_ready(server) for server in select_servers(group)]
+
+    # api.connect() starts a background Twisted reactor thread that outlives
+    # any individual client connection -- without stopping it here this
+    # script hangs on exit instead of finishing.
+    api.shutdown()
+
+    return 0 if all(ready) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/servers/screen-sharing/README.md
+++ b/tests/servers/screen-sharing/README.md
@@ -37,11 +37,17 @@ machine.
 
 ## Readiness
 
-An open RFB port is not always the same thing as a server with something to
-show -- the Docker servers need an extra readiness marker for exactly that
-reason (`tests/servers/draw-content.sh`). Here the port is all there is to
-wait for, and all it can mean: the framebuffer this runner serves is blank
-whether or not the server is ready (see below).
+An open RFB port is not readiness here, and neither is a per-request
+timeout. Screen Sharing is socket-activated, so the first connection is
+what starts the server -- and that connection sometimes never finishes its
+handshake, while the very next one succeeds in seconds. A test that opened
+the first connection failed with a timeout after two minutes, and the
+screenshot step immediately afterwards captured fine.
+
+So `setup.sh` waits for the port, and CI then runs
+`tests/functional/wait_for_servers.py os`, which retries whole connections
+until one completes an RFB round trip. Only then do the tests run, and a
+timeout inside a test means something real.
 
 ## What it proves, and what it doesn't
 

--- a/tests/servers/screen-sharing/README.md
+++ b/tests/servers/screen-sharing/README.md
@@ -35,6 +35,14 @@ machine.
 * **Screen Sharing is socket-activated on 5900.** Nothing has to be started
   beyond `kickstart -activate`; waiting for the port is enough.
 
+## Readiness
+
+An open RFB port is not always the same thing as a server with something to
+show -- the Docker servers need an extra readiness marker for exactly that
+reason (`tests/servers/draw-content.sh`). Here the port is all there is to
+wait for, and all it can mean: the framebuffer this runner serves is blank
+whether or not the server is ready (see below).
+
 ## What it proves, and what it doesn't
 
 Connect, RFB handshake, ARD authentication and key events all work. The

--- a/tests/servers/screen-sharing/README.md
+++ b/tests/servers/screen-sharing/README.md
@@ -27,6 +27,11 @@ machine.
   demands ARD auth afterwards. Don't reach for it as a way to avoid needing
   a username.
 
+* **It answers input slowly.** A key event took over five seconds to be
+  acknowledged on a hosted runner, where a container answers in
+  milliseconds. `vncservers.py` therefore gives OS-hosted servers a much
+  longer per-request timeout (`VNCDOTOOL_OS_SERVER_TIMEOUT`, 60s).
+
 * **Screen Sharing is socket-activated on 5900.** Nothing has to be started
   beyond `kickstart -activate`; waiting for the port is enough.
 

--- a/tests/servers/screen-sharing/README.md
+++ b/tests/servers/screen-sharing/README.md
@@ -1,0 +1,40 @@
+# Apple Screen Sharing on macOS
+
+An OS-hosted VNC server for vncdotool to test against on a macOS machine (a
+GitHub `macos-latest` runner in CI). `setup.sh` enables Remote Management
+and creates the user vncdotool authenticates as;
+`tests/functional/test_os_servers.py` then runs the same connect/type/capture
+round trip used for the Docker servers, and `collect-diagnostics.sh` gathers
+the evidence when something goes wrong.
+
+```sh
+sudo bash tests/servers/screen-sharing/setup.sh
+python -m unittest discover -v -s tests/functional -t . -p 'test_os_servers.py'
+```
+
+This turns the machine into an unattended remote-control target with a
+password checked into version control, so only run it on a throwaway
+machine.
+
+## What the setup has to get right
+
+* **Authentication is ARD/Diffie-Hellman (security type 30), with a
+  username.** vncdotool's existing ARD support handles the whole round trip;
+  the server is reached as a local user created by `setup.sh`.
+
+* **The legacy VNC password is dead.** `kickstart -setvnclegacy -vnclegacy
+  yes -setvncpw` is accepted silently on current macOS, but the server still
+  demands ARD auth afterwards. Don't reach for it as a way to avoid needing
+  a username.
+
+* **Screen Sharing is socket-activated on 5900.** Nothing has to be started
+  beyond `kickstart -activate`; waiting for the port is enough.
+
+## What it proves, and what it doesn't
+
+Connect, RFB handshake, ARD authentication and key events all work. The
+framebuffer, however, comes back fully black: a hosted runner has no
+rendered desktop session behind it. So `vncservers.py` marks this server
+`renders_desktop=False` and the test asserts the protocol round trip
+without asserting pixels. Attaching a display to the runner, so pixel
+assertions can be enabled here too, is a follow-up.

--- a/tests/servers/screen-sharing/collect-diagnostics.sh
+++ b/tests/servers/screen-sharing/collect-diagnostics.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Collect Screen Sharing / Remote Management logs and display state into a
+# directory, so CI can upload it as an artifact.
+#
+# Never fails: a run that has already gone wrong must not lose the evidence
+# to a second error.
+#
+# Usage: bash tests/servers/screen-sharing/collect-diagnostics.sh [destination]
+set -u
+
+DESTINATION="${1:-diagnostics}"
+PORT="${VNCDOTOOL_OS_SERVER_PORT:-5900}"
+
+mkdir -p "$DESTINATION"
+
+log show --last 10m --predicate \
+    'process CONTAINS "ARDAgent" OR process CONTAINS "screensharingd" OR process CONTAINS "AppleVNCServer" OR process CONTAINS "loginwindow" OR process CONTAINS "WindowServer"' \
+    >"$DESTINATION/system.log" 2>&1
+
+sudo lsof -iTCP:"$PORT" -sTCP:LISTEN -P >"$DESTINATION/port$PORT.log" 2>&1
+who >"$DESTINATION/who.log" 2>&1
+stat -f "console owner: %Su" /dev/console >"$DESTINATION/console.log" 2>&1
+pmset -g >"$DESTINATION/pmset.log" 2>&1
+system_profiler SPDisplaysDataType >"$DESTINATION/displays.log" 2>&1
+
+echo "collected Screen Sharing diagnostics into $DESTINATION"
+ls -l "$DESTINATION"
+exit 0

--- a/tests/servers/screen-sharing/setup.sh
+++ b/tests/servers/screen-sharing/setup.sh
@@ -49,10 +49,12 @@ keep_display_awake() {
 }
 
 wait_for_port() {
+    # bash's own /dev/tcp rather than nc, matching how the Docker servers
+    # probe themselves -- one less tool the machine has to have.
     echo "--- waiting up to ${WAIT_SECONDS}s for port $PORT"
     local deadline=$((SECONDS + WAIT_SECONDS))
     while [ "$SECONDS" -lt "$deadline" ]; do
-        if nc -z -w2 127.0.0.1 "$PORT" 2>/dev/null; then
+        if (exec 3<>"/dev/tcp/127.0.0.1/$PORT") 2>/dev/null; then
             echo "port $PORT is open"
             return 0
         fi

--- a/tests/servers/screen-sharing/setup.sh
+++ b/tests/servers/screen-sharing/setup.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Enable Apple Screen Sharing / Remote Management on this macOS machine and
+# create the local user vncdotool authenticates as.
+#
+# Used to give vncdotool's functional tests (tests/functional/test_os_servers.py)
+# a live macOS server on 127.0.0.1; see README.md in this directory for what
+# does and doesn't work on a hosted runner.
+#
+# This turns the machine into an unattended remote-control target with a
+# throwaway password, so run it only on a throwaway machine.
+#
+# Usage: sudo bash tests/servers/screen-sharing/setup.sh
+set -euo pipefail
+
+# Defaults match tests/functional/vncservers.py, which reads the same
+# environment variables.
+USERNAME="${VNCDOTOOL_OS_SERVER_USERNAME:-vncspike}"
+PASSWORD="${VNCDOTOOL_OS_SERVER_PASSWORD:-vncspike1}"
+PORT="${VNCDOTOOL_OS_SERVER_PORT:-5900}"
+WAIT_SECONDS="${VNCDOTOOL_OS_SERVER_WAIT:-60}"
+
+KICKSTART=/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart
+
+create_user() {
+    echo "--- creating local user $USERNAME"
+    if id "$USERNAME" >/dev/null 2>&1; then
+        echo "user $USERNAME already exists"
+        return
+    fi
+    sudo sysadminctl -addUser "$USERNAME" -fullName "vncdotool test user" -password "$PASSWORD"
+}
+
+enable_remote_management() {
+    echo "--- activating Remote Management for $USERNAME"
+    # -users/-privs grants that user full control; Screen Sharing itself is
+    # socket-activated on 5900 and needs no separate enabling.
+    sudo "$KICKSTART" \
+        -activate -configure -access -on \
+        -users "$USERNAME" -privs -all \
+        -restart -agent
+}
+
+keep_display_awake() {
+    # Rules out display sleep / App Nap as a cause of an empty framebuffer.
+    echo "--- holding the display awake in the background"
+    nohup caffeinate -d -i -u -t "${VNCDOTOOL_OS_SERVER_CAFFEINATE:-1200}" \
+        >/dev/null 2>&1 &
+    disown
+}
+
+wait_for_port() {
+    echo "--- waiting up to ${WAIT_SECONDS}s for port $PORT"
+    local deadline=$((SECONDS + WAIT_SECONDS))
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        if nc -z -w2 127.0.0.1 "$PORT" 2>/dev/null; then
+            echo "port $PORT is open"
+            return 0
+        fi
+        sleep 2
+    done
+    echo "Screen Sharing never started listening on port $PORT" >&2
+    return 1
+}
+
+create_user
+enable_remote_management
+keep_display_awake
+wait_for_port
+
+echo "Screen Sharing is serving on 127.0.0.1:$PORT for user $USERNAME"

--- a/tests/servers/servers.mk
+++ b/tests/servers/servers.mk
@@ -2,6 +2,9 @@ SERVERS_COMPOSE?=tests/servers/docker-compose.yml
 DOCKER_COMPOSE?=docker compose
 PYTHON?=python3
 SCREENSHOT_DIR?=tests/servers/screenshots
+# Which servers `screenshots` captures: docker, os, or all. See
+# tests/functional/vncservers.py.
+SCREENSHOT_GROUP?=docker
 
 .PHONY: servers-up
 servers-up:
@@ -15,9 +18,16 @@ servers-down:
 test-servers:
 	$(PYTHON) -m unittest discover $(UNITTEST_ARGS) -s tests/functional -t . -p 'test_servers.py'
 
+# The VNC server hosted by this OS (UltraVNC on Windows, Screen Sharing on
+# macOS), set up beforehand by the scripts in tests/servers/ultravnc and
+# tests/servers/screen-sharing.
+.PHONY: test-os-server
+test-os-server:
+	$(PYTHON) -m unittest discover $(UNITTEST_ARGS) -s tests/functional -t . -p 'test_os_servers.py'
+
 # Screenshot every running test server into $(SCREENSHOT_DIR), including an
 # index.html gallery of them all, for eyeballing what the servers render.
 .PHONY: screenshots
 screenshots:
-	VNCDOTOOL_SCREENSHOT_DIR=$(SCREENSHOT_DIR) $(PYTHON) tests/functional/capture_screenshots.py
+	VNCDOTOOL_SCREENSHOT_DIR=$(SCREENSHOT_DIR) $(PYTHON) tests/functional/capture_screenshots.py $(SCREENSHOT_GROUP)
 	@echo "open $(SCREENSHOT_DIR)/index.html"

--- a/tests/servers/ultravnc/README.md
+++ b/tests/servers/ultravnc/README.md
@@ -41,6 +41,14 @@ down:
   `Start-Service` is UltraVNC's unattended-deployment path and serves
   headlessly.
 
+## Readiness
+
+An open RFB port is not always the same thing as a server with something to
+show -- the Docker servers need an extra readiness marker for exactly that
+reason (`tests/servers/draw-content.sh`). Here the port is enough: the
+desktop session exists before the VNC server is ever started, so there is
+no window between "accepting connections" and "has content".
+
 ## What it proves
 
 The Windows runner has a real rendered desktop, so captures come back with

--- a/tests/servers/ultravnc/README.md
+++ b/tests/servers/ultravnc/README.md
@@ -1,0 +1,43 @@
+# UltraVNC on Windows
+
+An OS-hosted VNC server for vncdotool to test against on a Windows machine
+(a GitHub `windows-latest` runner in CI). `setup.ps1` installs, configures
+and starts it; `tests/functional/test_os_servers.py` then runs the same
+connect/type/capture round trip used for the Docker servers, and
+`collect-diagnostics.ps1` gathers the evidence when something goes wrong.
+
+```powershell
+pwsh tests/servers/ultravnc/setup.ps1
+python -m unittest discover -v -s tests/functional -t . -p 'test_os_servers.py'
+```
+
+This turns the machine into an unattended remote-control target with a
+password checked into version control, so only run it on a throwaway
+machine.
+
+## What the setup has to get right
+
+Each of these cost a CI round to find, so they are worth keeping written
+down:
+
+* **The install path is fixed; don't search for it.** Chocolatey always
+  installs to `C:\Program Files\uvnc bvba\UltraVNC`. A recursive scan of
+  `C:\Program Files` for `winvnc.exe` takes over five minutes on the loaded
+  runner image.
+
+* **A password is mandatory.** UltraVNC refuses every incoming connection
+  until one is set, regardless of `AuthRequired` — the server replies
+  "Until a password is set, incoming connections cannot be accepted". There
+  is no no-auth shortcut, so the `passwd=` entry in `ultravnc.ini` has to be
+  computed; `vnc_passwd_hex.py` does that and explains the format.
+
+* **It has to run as a service.** `winvnc.exe -run` on a fresh install opens
+  an interactive Settings dialog instead of serving. `-install` plus
+  `Start-Service` is UltraVNC's unattended-deployment path and serves
+  headlessly.
+
+## What it proves
+
+The Windows runner has a real rendered desktop, so captures come back with
+genuine, non-black content: `test_os_servers.py` asserts screen content
+here, unlike on macOS (see `../screen-sharing`).

--- a/tests/servers/ultravnc/README.md
+++ b/tests/servers/ultravnc/README.md
@@ -25,6 +25,11 @@ down:
   `C:\Program Files` for `winvnc.exe` takes over five minutes on the loaded
   runner image.
 
+* **The Chocolatey feed is flaky.** It intermittently returns a response
+  that isn't valid XML, which choco reports as "Unable to find package"
+  while still exiting 0. `setup.ps1` retries, and decides success by
+  whether `winvnc.exe` exists rather than by the exit code.
+
 * **A password is mandatory.** UltraVNC refuses every incoming connection
   until one is set, regardless of `AuthRequired` — the server replies
   "Until a password is set, incoming connections cannot be accepted". There

--- a/tests/servers/ultravnc/README.md
+++ b/tests/servers/ultravnc/README.md
@@ -43,11 +43,13 @@ down:
 
 ## Readiness
 
-An open RFB port is not always the same thing as a server with something to
-show -- the Docker servers need an extra readiness marker for exactly that
-reason (`tests/servers/draw-content.sh`). Here the port is enough: the
-desktop session exists before the VNC server is ever started, so there is
-no window between "accepting connections" and "has content".
+An open RFB port is not readiness -- the Docker servers need a
+drawn-content marker on top of it, and macOS needs whole-connection
+retries (see `../screen-sharing`). UltraVNC has been reliable once the
+port opens, since the Windows desktop session exists before the server is
+ever started, but CI still runs the shared gate
+(`tests/functional/wait_for_servers.py os`) here so a slow start shows up
+as a wait rather than as a timeout inside a test.
 
 ## What it proves
 

--- a/tests/servers/ultravnc/collect-diagnostics.ps1
+++ b/tests/servers/ultravnc/collect-diagnostics.ps1
@@ -1,0 +1,43 @@
+<#
+.SYNOPSIS
+    Collect UltraVNC logs, config and service state into a directory.
+
+.DESCRIPTION
+    Everything worth looking at when the Windows server misbehaves, in one
+    place so CI can upload it as an artifact. Never fails: a run that has
+    already gone wrong must not lose the evidence to a second error.
+
+.EXAMPLE
+    pwsh tests/servers/ultravnc/collect-diagnostics.ps1 -Destination diagnostics
+#>
+[CmdletBinding()]
+param(
+    [string]$Destination = 'diagnostics',
+    [string]$InstallDir = 'C:\Program Files\uvnc bvba\UltraVNC'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Continue'
+
+New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+
+Copy-Item (Join-Path $InstallDir 'ultravnc.ini') $Destination -ErrorAction SilentlyContinue
+Get-ChildItem $InstallDir -Filter *.log -ErrorAction SilentlyContinue |
+    Copy-Item -Destination $Destination -ErrorAction SilentlyContinue
+
+Get-Service -ErrorAction SilentlyContinue |
+    Where-Object { $_.Name -match 'uvnc|winvnc' -or $_.DisplayName -match 'UltraVNC' } |
+    Format-List * |
+    Out-File (Join-Path $Destination 'service.txt')
+
+Get-Process -Name winvnc -ErrorAction SilentlyContinue |
+    Out-File (Join-Path $Destination 'process.txt')
+
+Get-EventLog -LogName Application -Source '*vnc*' -Newest 20 -ErrorAction SilentlyContinue |
+    Out-File (Join-Path $Destination 'eventlog.txt')
+
+Get-NetTCPConnection -LocalPort 5900 -ErrorAction SilentlyContinue |
+    Out-File (Join-Path $Destination 'port5900.txt')
+
+Write-Host "collected UltraVNC diagnostics into $Destination"
+Get-ChildItem $Destination | Format-Table Name, Length

--- a/tests/servers/ultravnc/setup.ps1
+++ b/tests/servers/ultravnc/setup.ps1
@@ -61,10 +61,15 @@ function Install-UltraVNC {
 
 function Write-UltraVncIni {
     Write-Host '--- writing ultravnc.ini'
-    $passwdHex = python $PasswdScript $Password
-    if ($LASTEXITCODE -ne 0 -or -not $passwdHex) {
+    # The helper writes the hex to a file rather than to stdout, so the
+    # value never lands in the step log; read it back and drop the file.
+    $passwdFile = Join-Path ([System.IO.Path]::GetTempPath()) 'ultravnc-passwd.hex'
+    python $PasswdScript $Password $passwdFile
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $passwdFile)) {
         throw 'could not compute the ultravnc.ini password hex'
     }
+    $passwdHex = (Get-Content $passwdFile -Raw).Trim()
+    Remove-Item $passwdFile -Force
 
     $ini = @"
 [admin]

--- a/tests/servers/ultravnc/setup.ps1
+++ b/tests/servers/ultravnc/setup.ps1
@@ -1,0 +1,129 @@
+<#
+.SYNOPSIS
+    Install, configure and start UltraVNC as a Windows service.
+
+.DESCRIPTION
+    Sets up an UltraVNC server on the machine this runs on -- a GitHub
+    windows-latest runner in CI -- so that vncdotool's functional tests
+    (tests/functional/test_os_servers.py) have a live Windows server to
+    talk to on 127.0.0.1.
+
+    See README.md in this directory for why the server is installed as a
+    service, and why a password is mandatory.
+
+    This configures a machine for unattended remote control with a
+    throwaway password, so run it only on a throwaway machine.
+
+.EXAMPLE
+    pwsh tests/servers/ultravnc/setup.ps1 -Password hunter2
+#>
+[CmdletBinding()]
+param(
+    # Defaults match tests/functional/vncservers.py, which the tests read
+    # from VNCDOTOOL_OS_SERVER_PASSWORD/PORT too.
+    [string]$Password = $(if ($env:VNCDOTOOL_OS_SERVER_PASSWORD) { $env:VNCDOTOOL_OS_SERVER_PASSWORD } else { 'vncspike1' }),
+    [int]$Port = $(if ($env:VNCDOTOOL_OS_SERVER_PORT) { [int]$env:VNCDOTOOL_OS_SERVER_PORT } else { 5900 }),
+    [int]$WaitSeconds = 60
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Chocolatey always installs UltraVNC here. Do not go looking for
+# winvnc.exe under C:\Program Files instead: a recursive scan of that tree
+# takes over five minutes on the loaded runner image.
+$InstallDir = 'C:\Program Files\uvnc bvba\UltraVNC'
+$WinVnc = Join-Path $InstallDir 'winvnc.exe'
+# Some UltraVNC builds read the ini from ProgramData rather than from the
+# install directory, so it gets written to both.
+$ProgramDataDir = 'C:\ProgramData\uvnc bvba\UltraVNC'
+
+$PasswdScript = Join-Path $PSScriptRoot 'vnc_passwd_hex.py'
+
+
+function Install-UltraVNC {
+    Write-Host '--- installing UltraVNC'
+    choco install ultravnc -y --no-progress
+    if ($LASTEXITCODE -ne 0) {
+        throw "choco install ultravnc failed with exit code $LASTEXITCODE"
+    }
+    if (-not (Test-Path $WinVnc)) {
+        throw "winvnc.exe not found at $WinVnc after installing UltraVNC"
+    }
+    Write-Host "installed $WinVnc"
+}
+
+function Write-UltraVncIni {
+    Write-Host '--- writing ultravnc.ini'
+    $passwdHex = python $PasswdScript $Password
+    if ($LASTEXITCODE -ne 0 -or -not $passwdHex) {
+        throw 'could not compute the ultravnc.ini password hex'
+    }
+
+    $ini = @"
+[admin]
+UseRegistry=0
+
+[ultravnc]
+PortNumber=$Port
+HTTPPortNumber=0
+passwd=$passwdHex
+AllowLoopback=1
+AuthHosts=+127.0.0.1
+NewMSLogon=0
+RemoveWallpaper=1
+NeverShutdown=1
+DebugMode=1
+DebugLevel=9
+FileTransferEnabled=1
+"@
+
+    $iniPath = Join-Path $InstallDir 'ultravnc.ini'
+    Set-Content -Path $iniPath -Value $ini -Encoding ASCII
+    New-Item -ItemType Directory -Force -Path $ProgramDataDir | Out-Null
+    Copy-Item $iniPath (Join-Path $ProgramDataDir 'ultravnc.ini') -Force
+    Write-Host "wrote $iniPath (port $Port, password set)"
+}
+
+function Start-UltraVncService {
+    Write-Host '--- installing and starting the UltraVNC service'
+    # Out-Host, or winvnc's own console output would end up in this
+    # function's return value alongside the service name.
+    & $WinVnc -install | Out-Host
+    Start-Sleep -Seconds 3
+
+    $service = Get-Service |
+        Where-Object { $_.Name -match 'uvnc|winvnc' -or $_.DisplayName -match 'UltraVNC' } |
+        Select-Object -First 1
+    if (-not $service) {
+        Get-Service | Format-Table Name, DisplayName, Status
+        throw 'no UltraVNC service exists after winvnc.exe -install'
+    }
+
+    Start-Service -Name $service.Name
+    Write-Host "started service $($service.Name) ($($service.DisplayName))"
+}
+
+function Wait-ForPort {
+    param([int]$PortNumber, [int]$Seconds)
+
+    Write-Host "--- waiting up to $Seconds seconds for port $PortNumber"
+    $deadline = (Get-Date).AddSeconds($Seconds)
+    while ((Get-Date) -lt $deadline) {
+        $probe = Test-NetConnection -ComputerName 127.0.0.1 -Port $PortNumber -WarningAction SilentlyContinue
+        if ($probe.TcpTestSucceeded) {
+            Write-Host "port $PortNumber is open"
+            return
+        }
+        Start-Sleep -Seconds 2
+    }
+    throw "UltraVNC never started listening on port $PortNumber"
+}
+
+
+Install-UltraVNC
+Write-UltraVncIni
+Start-UltraVncService
+Wait-ForPort -PortNumber $Port -Seconds $WaitSeconds
+
+Write-Host "UltraVNC is serving on 127.0.0.1:$Port"

--- a/tests/servers/ultravnc/setup.ps1
+++ b/tests/servers/ultravnc/setup.ps1
@@ -23,7 +23,8 @@ param(
     # from VNCDOTOOL_OS_SERVER_PASSWORD/PORT too.
     [string]$Password = $(if ($env:VNCDOTOOL_OS_SERVER_PASSWORD) { $env:VNCDOTOOL_OS_SERVER_PASSWORD } else { 'vncspike1' }),
     [int]$Port = $(if ($env:VNCDOTOOL_OS_SERVER_PORT) { [int]$env:VNCDOTOOL_OS_SERVER_PORT } else { 5900 }),
-    [int]$WaitSeconds = 60
+    [int]$WaitSeconds = 60,
+    [int]$InstallAttempts = 3
 )
 
 Set-StrictMode -Version Latest
@@ -43,14 +44,19 @@ $PasswdScript = Join-Path $PSScriptRoot 'vnc_passwd_hex.py'
 
 function Install-UltraVNC {
     Write-Host '--- installing UltraVNC'
-    choco install ultravnc -y --no-progress
-    if ($LASTEXITCODE -ne 0) {
-        throw "choco install ultravnc failed with exit code $LASTEXITCODE"
+    # The community feed intermittently answers with something that isn't
+    # valid XML, which choco reports as "Unable to find package" and, worse,
+    # still exits 0 -- so retry, and judge success by the installed file.
+    for ($attempt = 1; $attempt -le $InstallAttempts; $attempt++) {
+        choco install ultravnc -y --no-progress
+        if (Test-Path $WinVnc) {
+            Write-Host "installed $WinVnc"
+            return
+        }
+        Write-Host "::warning::UltraVNC install attempt $attempt did not produce $WinVnc"
+        Start-Sleep -Seconds (5 * $attempt)
     }
-    if (-not (Test-Path $WinVnc)) {
-        throw "winvnc.exe not found at $WinVnc after installing UltraVNC"
-    }
-    Write-Host "installed $WinVnc"
+    throw "winvnc.exe not found at $WinVnc after $InstallAttempts install attempts"
 }
 
 function Write-UltraVncIni {

--- a/tests/servers/ultravnc/vnc_passwd_hex.py
+++ b/tests/servers/ultravnc/vnc_passwd_hex.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""Print the ``passwd=`` value ultravnc.ini needs for a given password.
+"""Compute the ``passwd=`` value ultravnc.ini needs for a given password.
+
+Run as a script it writes that hex to the file named as its second
+argument, for setup.ps1 to read back into the ini.
 
 UltraVNC refuses every incoming connection until a password is set, and it
 stores that password in ultravnc.ini using the classic VNC password-*file*
@@ -38,10 +41,16 @@ def vnc_passwd_hex(password: str) -> str:
 
 
 def main(argv: list) -> int:
-    if len(argv) != 2:
-        print(f"usage: {Path(argv[0]).name} PASSWORD", file=sys.stderr)
+    if len(argv) != 3:
+        print(f"usage: {Path(argv[0]).name} PASSWORD OUTPUT_FILE", file=sys.stderr)
         return 2
-    print(vnc_passwd_hex(argv[1]))
+
+    # Written to a file rather than printed: the hex is as good as the
+    # password to anyone who has it, and stdout of a CI step is the last
+    # place a credential should end up.
+    password, output = argv[1], Path(argv[2])
+    output.write_text(vnc_passwd_hex(password), encoding="ascii")
+    print(f"wrote the ultravnc.ini password hex to {output}")
     return 0
 
 

--- a/tests/servers/ultravnc/vnc_passwd_hex.py
+++ b/tests/servers/ultravnc/vnc_passwd_hex.py
@@ -49,7 +49,8 @@ def main(argv: list) -> int:
     # password to anyone who has it, and stdout of a CI step is the last
     # place a credential should end up.
     password, output = argv[1], Path(argv[2])
-    output.write_text(vnc_passwd_hex(password), encoding="ascii")
+    ini_value = vnc_passwd_hex(password)
+    output.write_text(ini_value, encoding="ascii")
     print(f"wrote the ultravnc.ini password hex to {output}")
     return 0
 

--- a/tests/servers/ultravnc/vnc_passwd_hex.py
+++ b/tests/servers/ultravnc/vnc_passwd_hex.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Print the ``passwd=`` value ultravnc.ini needs for a given password.
+
+UltraVNC refuses every incoming connection until a password is set, and it
+stores that password in ultravnc.ini using the classic VNC password-*file*
+obfuscation -- the one behind ~/.vnc/passwd across the whole VNC family,
+originally AT&T's vncauth.c: the password, null padded to 8 bytes, DES
+encrypted under a fixed well-known key.
+
+Note this is the opposite pairing to the RFB authentication challenge
+response in vncdotool.rfb, where the *password* derives the key and the
+server's challenge is the plaintext. Both apply the same per-byte bit
+reversal to the key, which is why reverse_bits() is shared between them.
+
+The obfuscation is not encryption: anyone who can read the ini can recover
+the password. That is inherent to how UltraVNC stores it, and is why this
+is only ever used with throwaway credentials on a throwaway machine.
+"""
+
+import sys
+from pathlib import Path
+
+# Allow running straight from a checkout, without vncdotool installed.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from vncdotool.rfb import des_encrypt, reverse_bits  # noqa: E402
+
+# The fixed key from vncauth.c, shared by every VNC password file.
+VNCAUTH_KEY = bytes([23, 82, 107, 6, 35, 78, 88, 7])
+
+
+def vnc_passwd_hex(password: str) -> str:
+    """Obfuscated hex for ``password``, as ultravnc.ini stores it."""
+    plaintext = f"{password:\0<8.8}".encode("ascii")
+    obfuscated = des_encrypt(reverse_bits(VNCAUTH_KEY), plaintext)
+    # UltraVNC writes a trailing null byte after the 8 encrypted ones.
+    return (obfuscated + b"\x00").hex()
+
+
+def main(argv: list) -> int:
+    if len(argv) != 2:
+        print(f"usage: {Path(argv[0]).name} PASSWORD", file=sys.stderr)
+        return 2
+    print(vnc_passwd_hex(argv[1]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -327,13 +327,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
 
     def sendPassword(self, password: str) -> None:
         """send password"""
-        key = _vnc_des(password)
-        # Triple-DES with the same 56-bit key repeated three times is
-        # equivalent to single-DES
-        des = Cipher(algorithms.TripleDES(key * 3), modes.ECB())
-        encryptor = des.encryptor()
-        response = encryptor.update(self._challenge) + encryptor.finalize()
-        self.transport.write(response)
+        self.transport.write(des_encrypt(_vnc_des(password), self._challenge))
 
     def _handleVNCAuthResult(self, block: bytes) -> None:
         (result,) = unpack("!I", block)
@@ -1103,6 +1097,25 @@ class RFBFactory(protocol.ClientFactory):  # type: ignore[misc]
         self.shared = shared
 
 
+def des_encrypt(key: bytes, data: bytes) -> bytes:
+    """Encrypt with single DES, as the VNC family's password handling uses."""
+    # Triple-DES with the same 56-bit key repeated three times is
+    # equivalent to single-DES
+    encryptor = Cipher(algorithms.TripleDES(key * 3), modes.ECB()).encryptor()
+    return encryptor.update(data) + encryptor.finalize()
+
+
+def reverse_bits(data: bytes) -> bytes:
+    """Reverse the bit order within each byte.
+
+    The bit-reversal the VNC family applies to a DES key before using it,
+    both for the authentication challenge response here and for the
+    password obfuscation in ~/.vnc/passwd files."""
+    return bytes(
+        sum((128 >> i) if (k & (1 << i)) else 0 for i in range(8)) for k in data
+    )
+
+
 def _vnc_des(password: str) -> bytes:
     """Custom DES variant for RFB protocol.
 
@@ -1114,8 +1127,7 @@ def _vnc_des(password: str) -> bytes:
     key = pw.encode(
         "ASCII"
     )  # unspecified https://www.rfc-editor.org/rfc/rfc6143#section-7.2.2
-    key = bytes(sum((128 >> i) if (k & (1 << i)) else 0 for i in range(8)) for k in key)
-    return key
+    return reverse_bits(key)
 
 
 # --- test code only, see vncviewer.py

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -1098,10 +1098,17 @@ class RFBFactory(protocol.ClientFactory):  # type: ignore[misc]
 
 
 def des_encrypt(key: bytes, data: bytes) -> bytes:
-    """Encrypt with single DES, as the VNC family's password handling uses."""
+    """Encrypt with single DES, as the VNC family's password handling uses.
+
+    Single DES in ECB is weak, and is what RFB specifies: both the
+    authentication challenge response (RFC 6143 section 7.2.2) and the
+    password file format are defined in terms of it, so a stronger
+    algorithm here would simply fail to talk to any VNC server."""
     # Triple-DES with the same 56-bit key repeated three times is
     # equivalent to single-DES
-    encryptor = Cipher(algorithms.TripleDES(key * 3), modes.ECB()).encryptor()
+    encryptor = Cipher(  # codeql[py/weak-cryptographic-algorithm]
+        algorithms.TripleDES(key * 3), modes.ECB()
+    ).encryptor()
     return encryptor.update(data) + encryptor.finalize()
 
 


### PR DESCRIPTION
## What this is

Tier 2 of the server compatibility plan: the VNC server the OS itself provides — UltraVNC installed as a Windows service, Apple Screen Sharing on macOS — set up on hosted runners and tested with the same round trip as the Tier 1 Docker servers.

This replaces #335, which proved the approach as a single 425-line workflow with the recipe embedded in it as inline PowerShell, inline Python and comment blocks. Here that content is checked-in scripts and READMEs, and the test harness is shared with the Docker servers rather than written twice.

## Reuse rather than a second copy

- `tests/functional/vncservers.py` (new) holds the server descriptions, connect/capture helpers and the per-server round trip. `test_servers.py` (Docker) and `test_os_servers.py` (OS-hosted) are thin registrations over it, as is the screenshot gallery.
- `VNCServer` grew the fields the OS servers need, so their differences are data rather than a forked code path: `username` (ARD auth), `size=None` (the host's resolution, not one we configure), `renders_desktop=False` (a blank framebuffer is the expected result, not a failure), and `timeout` (an OS-hosted server answers input far more slowly than a container).
- `capture_screenshots.py` takes a server group (`docker` / `os` / `all`), so the gallery and job-summary table work unchanged on Windows and macOS.
- `reverse_bits()` and `des_encrypt()` are factored out of `rfb.py`'s challenge response; the UltraVNC password-file script reuses them instead of reimplementing DES.

## Scripts, not inline YAML

- `tests/servers/ultravnc/` — `setup.ps1` (install → write `ultravnc.ini` → install/start the service → wait for the port), `vnc_passwd_hex.py`, `collect-diagnostics.ps1`, and a README recording why each step is what it is.
- `tests/servers/screen-sharing/` — `setup.sh` (create user → `kickstart` → hold the display awake → wait for the port), `collect-diagnostics.sh`, README.
- `.github/workflows/spike-os-servers.yml` is wiring only, and the two OSes are one matrix job (`fail-fast: false`) rather than two near-identical ones.
- `make test-os-server` runs the same tests locally.

## What each OS proves

| | Windows / UltraVNC | macOS / Screen Sharing |
|---|---|---|
| Auth | VNC password (mandatory — UltraVNC refuses all connections without one) | ARD/Diffie-Hellman with a username; the legacy VNC password is silently accepted but non-functional |
| Input | asserted | asserted |
| Pixels | asserted — the runner has a real desktop | **not** asserted — a hosted runner has no rendered desktop, so captures are black |

## Findings, kept next to the code

Each of these cost a CI round and is written into the relevant README: the fixed Chocolatey install path (a recursive `Program Files` scan takes 5+ minutes), the flaky community feed that reports failure while exiting 0, UltraVNC's mandatory password and service-only headless mode, macOS's ARD-only auth, its blank framebuffer, and its multi-second input latency.

## Verification

[Run 31748681595](https://github.com/sibson/vncdotool/actions/runs/31748681595) was green on both `windows-latest` and `macos-latest` before the rebase onto merged #334; the run for this PR's head re-proves it. Locally: unit tests pass, flake8 clean, PowerShell scripts parse, and the shared harness passes end-to-end against live x11vnc servers on both the no-auth and VNC-password paths.

## Follow-ups

Graduation out of spike status is unchanged from the plan: move both jobs under the change-triggered path-filtered policy, move the throwaway passwords into repository secrets, and investigate attaching a display to the macOS runner so pixels can be asserted there too.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2PPxkQw8HZ6YUU4hbeigc

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2PPxkQw8HZ6YUU4hbeigc)_