### PR TITLE
Add a server-parameterized scenario framework (Phase 0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,28 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
 
-      - name: Build and start the VNC test servers
-        run: docker compose -f tests/servers/docker-compose.yml up -d --build --wait
+      # GitHub-hosted runners start every job with an empty Docker layer
+      # cache, so `up --build` rebuilds the images from scratch on every
+      # run (~35s of local no-op work). Building through buildx with the
+      # GitHub Actions cache backend (scoped to this repo, keyed by layer)
+      # turns that into a cache hit whenever the Dockerfile and its build
+      # context haven't changed, while still rebuilding correctly whenever
+      # they have. `docker buildx bake` reads targets straight out of the
+      # compose file, so there is exactly one definition of each image.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build the VNC test server images (cached)
+        uses: docker/bake-action@v5
+        with:
+          files: tests/servers/docker-compose.yml
+          load: true
+          set: |
+            *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max
+
+      - name: Start the VNC test servers
+        run: docker compose -f tests/servers/docker-compose.yml up -d --wait
 
       # The steps below are diagnostics and teardown, so they carry
       # `if: always()`: when a test fails, the container status, the

--- a/docs/server-compatibility-plan.md
+++ b/docs/server-compatibility-plan.md
@@ -372,6 +372,15 @@ Tier 1 follow-ups:
   folds into the digest-pinning item below.
 - Pin base images by digest and fold this workflow into the main CI one.
 - Deepen what the per-server scenario actually asserts (see Phase 0).
+- **Done:** the `servers` job's base image is now pinned by digest
+  (`tests/servers/Dockerfile`), and the build uses `docker/setup-buildx-action`
+  + `docker/bake-action` with `cache-from`/`cache-to: type=gha` ahead of a
+  build-less `docker compose up --wait`, so a run with no Dockerfile changes
+  hits the Actions cache instead of rebuilding. Every pin this plan asks for
+  — base image digests, distro server packages, `LIBVNCSERVER_VERSION`, the
+  UltraVNC Chocolatey package, and the Tier 2 runner images — is now
+  inventoried in `tests/servers/versions.md`, with where each pin lives and
+  how to bump it.
 
 **Tier 2 — VIABLE on both OSes**, proven on branch
 `claude/spike-os-servers` (commit `2de3252`, workflow

--- a/docs/server-compatibility-plan.md
+++ b/docs/server-compatibility-plan.md
@@ -372,6 +372,19 @@ Tier 1 follow-ups:
   folds into the digest-pinning item below.
 - Pin base images by digest and fold this workflow into the main CI one.
 - Deepen what the per-server scenario actually asserts (see Phase 0).
+- **The input-reactive test surface, deferred.** The scenario framework
+  (`tests/functional/scenarios.py`) defines a `PIXEL` assertion level -- a
+  *specific region* of the framebuffer changed in response to input -- but
+  no Tier 1 server declares the `input_reactive` capability that would
+  enable it: `tests/servers/draw-content.sh` paints static content once at
+  startup, so nothing in the fleet reacts to a keystroke or click at a
+  known screen position. Getting there needs a deterministic reactive
+  surface in the container desktop (e.g. a full-screen `xterm` echoing
+  keystrokes at a fixed position, plus a pointer-tracking app for mouse
+  input), which is image work with real flakiness risk (font rendering,
+  timing) -- its own spike, not part of the PR that establishes the
+  scenario abstraction. Until it lands, keyboard/mouse scenarios assert at
+  the weaker `CHANGE` (any repaint) or `PROTOCOL` (no disconnect) level.
 - **Done:** the `servers` job's base image is now pinned by digest
   (`tests/servers/Dockerfile`), and the build uses `docker/setup-buildx-action`
   + `docker/bake-action` with `cache-from`/`cache-to: type=gha` ahead of a

--- a/tests/functional/scenarios.py
+++ b/tests/functional/scenarios.py
@@ -2,25 +2,9 @@
 
 `tests/functional/vncservers.py` describes *servers*; this module describes
 *scenarios* -- the things we do against a server and the assertions that
-follow. Splitting them out (rather than adding `test_mouse`, `test_expect`,
-... as sibling methods on the existing test mixin) matters because the same
-scenario list has to serve three consumers, only one of which is unittest:
-
-1. **unittest** -- ``vncservers.register_server_tests()`` builds the servers
-   x scenarios cross product, one ``test_<scenario>`` per server, so CI
-   reports a pass/fail/skip grid.
-2. **the recorder** -- the compatibility plan's `vncdo record` wrapper over
-   `loggingproxy` drives a scenario against a server and writes a fixture
-   directory. That only works if a scenario is callable outside a
-   ``TestCase``.
-3. **the Tier 3 checklist** -- the "short scripted scenario checklist" a
-   community contributor runs by hand against a server we cannot host. It
-   has to be printable/enumerable, i.e. data (name + description), not
-   buried in test method bodies.
-
-So a ``Scenario`` is a `NamedTuple` (data) wrapping a plain function (the
-callable), and ``SCENARIOS`` is the ordered registry both unittest and the
-future recorder consume.
+follow. A ``Scenario`` is a ``NamedTuple`` (data) wrapping a plain function
+(the callable), consumed by unittest, the recorder, and the Tier 3
+checklist alike. See docs/server-compatibility-plan.md.
 """
 
 from pathlib import Path
@@ -42,8 +26,8 @@ MAX_COLOURS = 256
 # ---------------------------------------------------------------------------
 # Assertion-level helpers
 #
-# Input scenarios (keyboard/mouse, PR 3b) assert at the strongest level the
-# server's capabilities support. Each level raises plain ``AssertionError``
+# Input scenarios assert at the strongest level the server's capabilities
+# support. Each level raises plain ``AssertionError``
 # rather than using ``self.assertX`` -- a ``Scenario.run`` body is a plain
 # function, not a ``TestCase`` method, and unittest treats an
 # ``AssertionError`` raised inside a generated test method as an ordinary
@@ -130,11 +114,7 @@ class Scenario(NamedTuple):
 
 
 def _run_connect(client: "api.ThreadedVNCClientProxy", ctx: ScenarioContext) -> None:
-    """Handshake completes; record what was negotiated.
-
-    This is the seed of the ``vncdo probe`` output Phase 4 wants: which
-    protocol version and security type a server actually speaks.
-    """
+    """Handshake completes; record the negotiated protocol version and security type."""
     PROTOCOL(client)
 
     version = getattr(client, "_version", None)
@@ -188,10 +168,6 @@ def _run_capture(client: "api.ThreadedVNCClientProxy", ctx: ScenarioContext) -> 
 
 # Order is stable and meaningful (connect first) because the recorder
 # replays scenarios in order and the Tier 3 checklist prints them in order.
-#
-# Only connect/capture are here in this PR -- authenticate/keyboard/mouse/
-# expect land in the follow-up PR once this abstraction has been reviewed
-# with a small number of users rather than six at once.
 SCENARIOS: List[Scenario] = [
     Scenario(
         name="connect",

--- a/tests/functional/scenarios.py
+++ b/tests/functional/scenarios.py
@@ -1,0 +1,208 @@
+"""Server-parameterized scenarios: the data + callable pair everything else drives.
+
+`tests/functional/vncservers.py` describes *servers*; this module describes
+*scenarios* -- the things we do against a server and the assertions that
+follow. Splitting them out (rather than adding `test_mouse`, `test_expect`,
+... as sibling methods on the existing test mixin) matters because the same
+scenario list has to serve three consumers, only one of which is unittest:
+
+1. **unittest** -- ``vncservers.register_server_tests()`` builds the servers
+   x scenarios cross product, one ``test_<scenario>`` per server, so CI
+   reports a pass/fail/skip grid.
+2. **the recorder** -- the compatibility plan's `vncdo record` wrapper over
+   `loggingproxy` drives a scenario against a server and writes a fixture
+   directory. That only works if a scenario is callable outside a
+   ``TestCase``.
+3. **the Tier 3 checklist** -- the "short scripted scenario checklist" a
+   community contributor runs by hand against a server we cannot host. It
+   has to be printable/enumerable, i.e. data (name + description), not
+   buried in test method bodies.
+
+So a ``Scenario`` is a `NamedTuple` (data) wrapping a plain function (the
+callable), and ``SCENARIOS`` is the ordered registry both unittest and the
+future recorder consume.
+"""
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, FrozenSet, List, NamedTuple, Tuple
+
+from PIL import Image
+
+if TYPE_CHECKING:
+    from vncdotool import api
+
+    from .vncservers import VNCServer
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+# getcolors() returns None above this many distinct colours, which is itself
+# proof the capture isn't a flat colour, so the cap only needs to be cheap.
+MAX_COLOURS = 256
+
+
+# ---------------------------------------------------------------------------
+# Assertion-level helpers
+#
+# Input scenarios (keyboard/mouse, PR 3b) assert at the strongest level the
+# server's capabilities support. Each level raises plain ``AssertionError``
+# rather than using ``self.assertX`` -- a ``Scenario.run`` body is a plain
+# function, not a ``TestCase`` method, and unittest treats an
+# ``AssertionError`` raised inside a generated test method as an ordinary
+# failure either way.
+# ---------------------------------------------------------------------------
+
+
+def PROTOCOL(client: "api.ThreadedVNCClientProxy") -> None:
+    """Weakest level, always available: the session is alive and answers.
+
+    No capability required -- every server that connects at all supports
+    this. Proves the connection survived whatever the scenario just did and
+    that a framebuffer update still arrives; proves nothing about what that
+    update contains.
+    """
+    client.refreshScreen()
+
+
+def CHANGE(before: Image.Image, after: Image.Image) -> None:
+    """The framebuffer differs at all between two captures.
+
+    Enabled by ``renders_desktop``. Honest about its weakness: a repainting
+    clock or a blinking cursor also changes the framebuffer, so this proves
+    *some* repaint happened after the action, not that the action itself is
+    what got rendered.
+    """
+    if before.tobytes() == after.tobytes():
+        raise AssertionError(
+            "framebuffer is byte-identical before and after the action -- "
+            "CHANGE only proves some repaint occurred following the action, "
+            "and here none did"
+        )
+
+
+def PIXEL(before: Image.Image, after: Image.Image, region: Tuple[int, int, int, int]) -> None:
+    """A *specific region* changed between two captures.
+
+    Enabled by ``input_reactive``. Unreachable today: no Tier 1 server
+    declares ``input_reactive`` because ``tests/servers/draw-content.sh``
+    paints static content, so nothing in the fleet reacts to input in a
+    known region. See the "input-reactive test surface" follow-up in
+    docs/server-compatibility-plan.md. This level is implemented now so
+    that follow-up spike only has to flip a capability flag, not invent an
+    assertion.
+    """
+    if before.crop(region).tobytes() == after.crop(region).tobytes():
+        raise AssertionError(f"region {region} did not change after the action")
+
+
+class ScenarioContext(NamedTuple):
+    """What a scenario body gets besides the connected client.
+
+    Bundled here rather than reached for as globals so a scenario body is a
+    pure function of ``(client, ctx)`` -- the property that lets the
+    recorder and the unittest generator share it.
+    """
+
+    server: "VNCServer"
+    # Where this scenario, for this server, writes its artifacts:
+    # screenshots/<server>/<scenario>/.
+    artifact_dir: Path
+    # The assertion-level helpers above, bundled for convenience so a
+    # scenario body can write ``ctx.CHANGE(...)`` without a separate import.
+    PROTOCOL: Callable = PROTOCOL
+    CHANGE: Callable = CHANGE
+    PIXEL: Callable = PIXEL
+
+
+ScenarioRun = Callable[["api.ThreadedVNCClientProxy", ScenarioContext], None]
+
+
+class Scenario(NamedTuple):
+    # Used in test ids ("test_connect") and fixture dirs.
+    name: str
+    # One line, printed in the Tier 3 checklist.
+    description: str
+    # Capabilities (see VNCServer.capabilities) the server must declare for
+    # this scenario to run at all; a server missing one skips rather than
+    # runs a weakened version. Scenarios below whose assertions merely
+    # *degrade* gracefully per-capability (capture) require nothing here --
+    # the degrading is inside the scenario body instead.
+    requires: FrozenSet[str]
+    run: ScenarioRun
+
+
+def _run_connect(client: "api.ThreadedVNCClientProxy", ctx: ScenarioContext) -> None:
+    """Handshake completes; record what was negotiated.
+
+    This is the seed of the ``vncdo probe`` output Phase 4 wants: which
+    protocol version and security type a server actually speaks.
+    """
+    PROTOCOL(client)
+
+    version = getattr(client, "_version", None)
+    version_str = "%d.%d" % version if version else "unknown"
+    report = (
+        f"server: {ctx.server.name}\n"
+        f"protocol_version: {version_str}\n"
+        f"security_type: {ctx.server.auth_capability}\n"
+    )
+    (ctx.artifact_dir / "connect.txt").write_text(report)
+
+
+def _run_capture(client: "api.ThreadedVNCClientProxy", ctx: ScenarioContext) -> None:
+    """Capture the framebuffer to a PNG and check it.
+
+    Always checked: the file is non-empty and starts with the PNG magic
+    bytes. Checked when the server's capabilities allow it: the image size
+    matches what the server is known to serve (``known_size``), and the
+    capture is not a single flat colour (``renders_desktop`` -- a server
+    with no rendered desktop, e.g. a hosted macOS runner, is expected to
+    produce a flat framebuffer and is not treated as a failure for it).
+    """
+    server = ctx.server
+    png = ctx.artifact_dir / "capture.png"
+    client.captureScreen(str(png))
+
+    data = png.read_bytes()
+    if not data:
+        raise AssertionError(f"{server.name}: captured screenshot is empty")
+    if data[:8] != PNG_MAGIC:
+        raise AssertionError(f"{server.name}: captured file is not a valid PNG")
+
+    with Image.open(png) as image:
+        if "known_size" in server.capabilities:
+            if image.size != server.size:
+                raise AssertionError(f"{server.name}: capture is not the size the server serves")
+        colours = image.convert("RGB").getcolors(maxcolors=MAX_COLOURS)
+
+    if "renders_desktop" not in server.capabilities:
+        distinct = colours if colours is None else len(colours)
+        print(
+            f"{server.name}: {distinct} colours captured; content is not "
+            "asserted, this server has no rendered desktop behind it"
+        )
+        return
+
+    distinct = colours if colours is None else len(colours)
+    if distinct == 1:
+        raise AssertionError(f"{server.name}: capture is a single flat colour, no screen content was decoded")
+
+
+# Order is stable and meaningful (connect first) because the recorder
+# replays scenarios in order and the Tier 3 checklist prints them in order.
+#
+# Only connect/capture are here in this PR -- authenticate/keyboard/mouse/
+# expect land in the follow-up PR once this abstraction has been reviewed
+# with a small number of users rather than six at once.
+SCENARIOS: List[Scenario] = [
+    Scenario(
+        name="connect",
+        description="RFB handshake completes and a security type is negotiated",
+        requires=frozenset(),
+        run=_run_connect,
+    ),
+    Scenario(
+        name="capture",
+        description="framebuffer capture decodes to a valid PNG, sized and non-flat where the server allows",
+        requires=frozenset(),
+        run=_run_capture,
+    ),
+]

--- a/tests/functional/vncservers.py
+++ b/tests/functional/vncservers.py
@@ -20,12 +20,19 @@ import socket
 import sys
 import time
 from pathlib import Path
-from typing import Dict, List, NamedTuple, Optional, Tuple
+from typing import Dict, FrozenSet, List, NamedTuple, Optional, Tuple
 from unittest import TestCase
 
-from PIL import Image
-
 from vncdotool import api
+
+try:
+    from .scenarios import SCENARIOS, Scenario, ScenarioContext
+except ImportError:
+    # capture_screenshots.py runs this module as a plain top-level script
+    # (it puts this directory on sys.path itself) rather than importing it
+    # as part of the tests.functional package, so the relative import above
+    # fails there; fall back to an absolute one against the same sys.path.
+    from scenarios import SCENARIOS, Scenario, ScenarioContext  # type: ignore[no-redef]
 
 HOST = "127.0.0.1"
 CONNECT_TIMEOUT = 5.0
@@ -38,13 +45,19 @@ READY_DEADLINE = 180.0
 
 DEFAULT_SCREENSHOT_DIR = Path(__file__).resolve().parents[1] / "servers" / "screenshots"
 
-PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
-# getcolors() returns None above this many distinct colours, which is itself
-# proof the capture isn't a flat colour, so the cap only needs to be cheap.
-MAX_COLOURS = 256
-
 
 class VNCServer(NamedTuple):
+    """What a server is and what it can do.
+
+    ``capabilities`` (see below) is the one obvious place a server declares
+    what it can do; scenarios (tests/functional/scenarios.py) declare what
+    they ``require`` and a server missing a capability skips rather than
+    running a test that can't mean anything for it. ``size`` and
+    ``renders_desktop`` stay as plain fields because a scenario body needs
+    the actual values, not just a yes/no -- ``capabilities`` is derived from
+    them rather than duplicating them.
+    """
+
     name: str
     port: int
     password: Optional[str] = None
@@ -59,12 +72,39 @@ class VNCServer(NamedTuple):
     # flat, usually all-black, framebuffer is expected rather than a
     # failure -- see the macOS note in tests/servers/screen-sharing.
     renders_desktop: bool = True
+    # Whether the desktop visibly changes in a *known region* in response
+    # to input. Deferred: no Tier 1 server sets this yet, because
+    # tests/servers/draw-content.sh paints static content -- see the
+    # "input-reactive test surface" follow-up in
+    # docs/server-compatibility-plan.md.
+    input_reactive: bool = False
     # How long to wait for the server to answer a single request. The
     # default suits a container on loopback; an OS-hosted server sharing a
     # busy machine's real desktop can be far slower.
     timeout: float = CONNECT_TIMEOUT
     # How to get this server running, quoted when a test skips itself.
     how_to_start: str = "start the servers first with `make servers-up`"
+
+    @property
+    def auth_capability(self) -> str:
+        """The ``auth:*`` capability this server's credentials negotiate."""
+        if self.username is not None:
+            return "auth:ard"
+        if self.password is not None:
+            return "auth:vncpass"
+        return "auth:none"
+
+    @property
+    def capabilities(self) -> FrozenSet[str]:
+        """What this server can do, as the set scenarios match ``requires`` against."""
+        caps = {self.auth_capability}
+        if self.size is not None:
+            caps.add("known_size")
+        if self.renders_desktop:
+            caps.add("renders_desktop")
+        if self.input_reactive:
+            caps.add("input_reactive")
+        return frozenset(caps)
 
 
 # One entry per service in tests/servers/docker-compose.yml.
@@ -209,12 +249,24 @@ def wait_until_ready(
     return False
 
 
+def scenario_artifact_dir(server: VNCServer, scenario_name: str) -> Path:
+    """Where one server's one scenario writes its artifacts, created if needed."""
+    path = screenshot_dir() / server.name / scenario_name
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
 class _VNCServerTestMixin:
     """Shared test body, parameterized per-server by register_server_tests().
 
     Deliberately does NOT subclass TestCase: only the generated per-server
     classes should (otherwise `unittest discover` also collects this shared
     base as its own, serverless test case).
+
+    register_server_tests() adds one `test_<scenario.name>` method per
+    scenario on top of this mixin -- see _make_scenario_test() below -- so
+    this class only carries what every one of those methods needs: the
+    server-reachability skip shared by all of them.
     """
 
     server: VNCServer
@@ -226,73 +278,52 @@ class _VNCServerTestMixin:
                 f"{self.server.how_to_start}"
             )
 
-    def test_connect_key_and_capture(self) -> None:
-        """End-to-end round trip against one real server.
 
-        Passing means, in order:
+def _make_scenario_test(scenario: Scenario) -> object:
+    """Build one `test_<scenario.name>` method bound to `scenario`.
 
-        * the RFB handshake completed against this server's protocol version
-          and security type (none, VNC password, or ARD/Diffie-Hellman);
-        * a key event was accepted without the server dropping the session;
-        * a framebuffer update was received and encoded to a PNG file;
-        * that PNG is the size the server said it serves, and -- for a server
-          with a desktop rendered behind it -- is not a single flat colour,
-          i.e. we decoded real screen content rather than the all-black
-          framebuffer you get when updates never arrive.
-        """
-        png = screenshot_dir() / f"{self.server.name}.png"
+    A missing required capability is a `skipTest` naming the capability,
+    never a silent pass -- that distinction is what keeps a skip from
+    reading as coverage in the compatibility matrix (e.g. macOS Screen
+    Sharing's black framebuffer must not read as green).
+    """
 
-        with connect(self.server) as client:
-            client.keyPress("x")
-            client.captureScreen(str(png))
-
-        data = png.read_bytes()
-        print(f"{self.server.name}: screenshot written to {png}")
-
-        self.assertTrue(data, f"{self.server.name}: captured screenshot is empty")
-        self.assertEqual(
-            data[:8],
-            PNG_MAGIC,
-            f"{self.server.name}: captured file is not a valid PNG",
-        )
-
-        with Image.open(png) as image:
-            if self.server.size is not None:
-                self.assertEqual(
-                    image.size,
-                    self.server.size,
-                    f"{self.server.name}: capture is not the size the server serves",
-                )
-            colours = image.convert("RGB").getcolors(maxcolors=MAX_COLOURS)
-
-        distinct = colours if colours is None else len(colours)
-        if not self.server.renders_desktop:
-            print(
-                f"{self.server.name}: {distinct} colours captured; content is not "
-                "asserted, this server has no rendered desktop behind it"
+    def test_scenario(self: _VNCServerTestMixin) -> None:
+        missing = scenario.requires - self.server.capabilities
+        if missing:
+            self.skipTest(
+                f"{self.server.name} does not support required capabilit"
+                f"{'y' if len(missing) == 1 else 'ies'} {sorted(missing)} "
+                f"for scenario {scenario.name!r}"
             )
-            return
 
-        self.assertNotEqual(
-            distinct,
-            1,
-            f"{self.server.name}: capture is a single flat colour, "
-            "no screen content was decoded",
-        )
+        artifact_dir = scenario_artifact_dir(self.server, scenario.name)
+        ctx = ScenarioContext(server=self.server, artifact_dir=artifact_dir)
+        with connect(self.server) as client:
+            scenario.run(client, ctx)
+
+    test_scenario.__name__ = f"test_{scenario.name}"
+    test_scenario.__doc__ = scenario.description
+    return test_scenario
 
 
 def register_server_tests(servers: List[VNCServer], namespace: Dict[str, object]) -> None:
     """Add one TestCase subclass per server to a test module's namespace.
 
-    Gives `unittest discover` a separate pass/fail/skip per server instead of
-    one test that stops at the first server that misbehaves.
+    Each subclass gets one `test_<scenario>` method per entry in
+    `scenarios.SCENARIOS`, so `unittest discover` reports a separate
+    pass/fail/skip per server *and* per scenario (e.g.
+    `TestServer_tigervnc.test_capture`) instead of one test per server that
+    stops at the first thing that misbehaves.
     """
     for server in servers:
         name = "TestServer_" + server.name.replace("-", "_")
-        namespace[name] = type(
-            name,
-            (_VNCServerTestMixin, TestCase),
+        attrs: Dict[str, object] = {
+            "server": server,
             # __module__ so test ids name the module that registered the
             # case rather than this one.
-            {"server": server, "__module__": namespace.get("__name__", __name__)},
-        )
+            "__module__": namespace.get("__name__", __name__),
+        }
+        for scenario in SCENARIOS:
+            attrs[f"test_{scenario.name}"] = _make_scenario_test(scenario)
+        namespace[name] = type(name, (_VNCServerTestMixin, TestCase), attrs)

--- a/tests/functional/vncservers.py
+++ b/tests/functional/vncservers.py
@@ -73,9 +73,7 @@ class VNCServer(NamedTuple):
     # failure -- see the macOS note in tests/servers/screen-sharing.
     renders_desktop: bool = True
     # Whether the desktop visibly changes in a *known region* in response
-    # to input. Deferred: no Tier 1 server sets this yet, because
-    # tests/servers/draw-content.sh paints static content -- see the
-    # "input-reactive test surface" follow-up in
+    # to input. Deferred; see "input-reactive test surface" in
     # docs/server-compatibility-plan.md.
     input_reactive: bool = False
     # How long to wait for the server to answer a single request. The

--- a/tests/servers/Dockerfile
+++ b/tests/servers/Dockerfile
@@ -10,7 +10,12 @@
 # so captures aren't pure black, and the readiness probe -- so adding a
 # server means one stage, not another near-copy of this file.
 
-FROM debian:bookworm-slim AS base
+# Pinned by digest rather than tag so "debian:bookworm-slim" can't
+# silently move to a new point release underneath us -- reproducible test
+# server images are what make gold-file regeneration meaningful (see
+# docs/server-compatibility-plan.md, "Gold files"). Bump via
+# tests/servers/versions.md, which explains how to resolve a fresh digest.
+FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241 AS base
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         x11-apps \

--- a/tests/servers/versions.md
+++ b/tests/servers/versions.md
@@ -1,0 +1,42 @@
+# Version pins: source of truth
+
+Every pinned version, base image digest, and package used to build or run
+a test VNC server is listed here, per
+`docs/server-compatibility-plan.md` ("One source of version truth"). CI,
+the `make` targets under `tests/servers/servers.mk`, and any fixture
+`manifest.yaml` that names a server version should point back to this
+table rather than re-stating the pin -- when a pin moves, this file and
+the one place it lives (below) are the only two things that need to
+change together.
+
+| What | Pin | Where it lives | How to bump |
+|---|---|---|---|
+| Base image for all Tier 1 containers | `debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241` | `tests/servers/Dockerfile`, `FROM` line of the `base` stage | Resolve a fresh digest with `docker manifest inspect debian:bookworm-slim` (or `crane digest debian:bookworm-slim`, or the registry HTTP API -- see below), update the `FROM` line and this row together, then `make servers-up` and re-run `make test-servers` to confirm the fleet still builds and passes. |
+| `tigervnc-standalone-server`, `tigervnc-common`, `tigervnc-tools` | whatever `apt-get install` resolves in `bookworm` at build time (unpinned patch version -- Debian stable's own security-update policy is trusted here rather than a second, harder-to-audit pin) | `tests/servers/Dockerfile`, `tigervnc` stage `RUN apt-get install` | Bump by moving the base image pin (Debian release/point-release); to pin an exact package version instead, add `=<version>` to each package name and hold it with `apt-mark hold` in the same `RUN`. |
+| `x11vnc`, `xvfb` | same as above: whatever `bookworm` has | `tests/servers/Dockerfile`, `x11vnc` stage `RUN apt-get install` | Same as the TigerVNC row. |
+| `x11-apps`, `xauth`, `procps` (shared `base` stage tooling) | same as above | `tests/servers/Dockerfile`, `base` stage `RUN apt-get install` | Same as the TigerVNC row. |
+| `LIBVNCSERVER_VERSION` (native source build, the no-Docker fallback and the "current git LibVNCServer" case the containers pin away from) | `0.9.14` | `libvncserver.mk`, top of file (`LIBVNCSERVER_VERSION?=0.9.14`) | Edit the variable to a new tag from https://github.com/LibVNC/libvncserver/tags, then `make libvnc-examples` (or `make test-libvnc`) to confirm it still builds; the CI cache key in `.github/workflows/ci.yml` (`functional` job, "Cache LibVNCServer build" step) is keyed on `hashFiles('libvncserver.mk')`, so bumping this line alone invalidates the cache correctly. |
+| UltraVNC (Tier 2, Windows) | latest available on the Chocolatey community feed at run time (no version pin -- the feed's own versioning and the "report drift, don't block" trade-off documented in `docs/server-compatibility-plan.md`, Tier 2, cover this) | `tests/servers/ultravnc/setup.ps1`, `Install-UltraVNC`'s `choco install ultravnc -y --no-progress` | To pin, change to `choco install ultravnc --version <x.y.z.z> -y --no-progress` and record the chosen version in this row; until then, drift surfaces via the change-triggered `os-servers.yml` job rather than silently. |
+| `windows-latest` runner image | GitHub-managed rolling tag, not a digest (hosted runners don't expose one to pin against) | `.github/workflows/os-servers.yml`, matrix entry `runner: windows-latest` | Switch to a dated image alias (e.g. `windows-2025`) if GitHub Actions' runner-image catalog offers one and reproducibility matters more than always testing the newest image; note the trade-off (older image, later CVE/feature drift) in this row if you do. |
+| `macos-latest` runner image | GitHub-managed rolling tag, not a digest | `.github/workflows/os-servers.yml`, matrix entry `runner: macos-latest` | Same as the `windows-latest` row (e.g. `macos-15`). |
+
+## Resolving a fresh Docker digest without a local daemon
+
+`docker manifest inspect <image>:<tag>` needs a running daemon. Without
+one (e.g. this repo's sandboxed dev environments), the registry's HTTP
+API v2 gives the same answer directly:
+
+```sh
+IMAGE=library/debian TAG=bookworm-slim
+TOKEN=$(curl -sS "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${IMAGE}:pull" \
+  | python3 -c "import json,sys;print(json.load(sys.stdin)['token'])")
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json" \
+  "https://registry-1.docker.io/v2/${IMAGE}/manifests/${TAG}" -D - -o /dev/null \
+  | grep -i docker-content-digest
+```
+
+The digest returned is the manifest *list* (multi-arch index) digest --
+the same value `docker pull debian:bookworm-slim` resolves to and the
+right one to pin in a `FROM` line, since Docker picks the matching
+per-platform manifest from it automatically.


### PR DESCRIPTION
## What changed

This is PR 3a of the Phase 0 stack, stacked on PR 2 (#340). It extracts the abstraction the plan's Phase 0 bullet asks for ("extract the common scenarios... into a server-parameterized base class") — **framework only**; the scenarios beyond `connect`/`capture` land in a follow-up PR 3b.

### The problem with plain test methods

`tests/functional/vncservers.py` had one shared test body, `test_connect_key_and_capture`, generated per server by `register_server_tests()`. Adding `test_mouse`, `test_expect`, … as sibling methods is the obvious next step, but the plan needs the *same* scenario list to serve three consumers, only one of which is unittest:

1. **unittest** — the servers × scenarios grid CI reports.
2. **the recorder** — the plan's `vncdo record` wrapper over `loggingproxy` drives a scenario against a server and writes a fixture directory; it needs a scenario callable outside a `TestCase`.
3. **the Tier 3 checklist** — the "short scripted scenario checklist" a community contributor runs by hand against a server we can't host; it needs to be enumerable data, not logic buried in test bodies.

So `tests/functional/scenarios.py` makes a `Scenario` a `NamedTuple` (name, description, required capabilities) wrapping a plain `run(client, ctx) -> None` function, and `SCENARIOS` is the ordered registry both unittest and the future recorder consume.

### Capability model

`VNCServer` (in `vncservers.py`) grows a `capabilities` property — the one obvious place a server declares what it can do — derived from its existing fields (`auth:none`/`auth:vncpass`/`auth:ard` from username/password, `known_size` from `size`, `renders_desktop`, and an as-yet-unused `input_reactive`). A `Scenario.requires` a subset of that; a server missing a required capability **skips with a reason naming the capability**, never a silent pass. That distinction matters because a skip has to render differently from a pass in the compatibility matrix — otherwise macOS Screen Sharing's black framebuffer reads as green coverage instead of "not applicable here."

`register_server_tests()` now generates the servers × scenarios cross product: one `TestCase` subclass per server, one `test_<scenario>` method per scenario, so test ids read like `TestServer_tigervnc.test_capture` — a per-server, per-scenario pass/fail/skip cell.

### Why `PIXEL` exists but is unused

`scenarios.py` defines three assertion-level helpers for input scenarios: `PROTOCOL` (session survives, always available), `CHANGE` (framebuffer differs at all — honest that a blinking cursor would also pass this), and `PIXEL` (a *specific region* changed — the strongest level). No Tier 1 server declares `input_reactive` yet: `tests/servers/draw-content.sh` paints static content, so nothing in the fleet reacts to input in a known region. That's deferred to its own spike (image work with real flakiness risk — font rendering, timing) rather than folded into the PR that establishes the abstraction. `PIXEL` is implemented now so that spike only has to flip a capability flag, not invent an assertion. I added this as an explicit Tier 1 follow-up in `docs/server-compatibility-plan.md`.

### Scope: only `connect` and `capture`

Ported only the existing round trip, split into its natural scenarios (`connect`: handshake + negotiated version/security type recorded to the artifact dir; `capture`: the existing PNG assertions — valid PNG, size when `known_size`, not-flat when `renders_desktop`). Deliberately **not** adding `authenticate`/`keyboard`/`mouse`/`expect` here — that's PR 3b, once this abstraction has been reviewed with two users instead of six.

### Screenshot gallery

Left `tests/functional/capture_screenshots.py` as-is (flat `screenshots/<server>.png`, one gallery). The unittest-generated tests now write into the finer-grained `screenshots/<server>/<scenario>/` the spec describes, but folding the standalone gallery script into that same per-scenario layout is a bigger change (it would need to walk `SCENARIOS` and call scenario bodies rather than just `capture_screenshot()`) and is left for 3b alongside the new scenarios it would need to display.

## Verification

- `flake8 --count --statistics vncdotool tests` — clean (0).
- `make test` (`python -m unittest discover tests/unit`) — 67 tests pass, unaffected (all changes are under `tests/functional/`).
- `python -m unittest discover -v -s tests/functional -t . -p 'test_servers.py'` with no servers running: all 6 generated tests (`tigervnc`/`tigervnc-auth`/`x11vnc` × `connect`/`capture`) **skip** with a clear "not reachable... start the servers first" message, and the process exits normally (no hang).
- Test ids confirmed via `TestLoader().discover(...)`:
  ```
  tests.functional.test_servers.TestServer_tigervnc.test_capture
  tests.functional.test_servers.TestServer_tigervnc.test_connect
  tests.functional.test_servers.TestServer_tigervnc_auth.test_capture
  tests.functional.test_servers.TestServer_tigervnc_auth.test_connect
  tests.functional.test_servers.TestServer_x11vnc.test_capture
  tests.functional.test_servers.TestServer_x11vnc.test_connect
  ```
- `tests/functional/capture_screenshots.py docker` still runs end-to-end (skips cleanly with no servers up, writes the gallery `index.html`).
- No Docker daemon available in this sandbox (same limitation noted in the plan doc's spike results), so the actual Tier 1 fleet wasn't exercised live here; the skip-path verification above is the sandbox-reachable proxy for "the cross-product generation and skip logic work."

## Scope note

Per instructions, `docs/server-compatibility-plan.md` gets only the one new Tier 1 follow-up bullet (the deferred input-reactive spike) — no other restructuring.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfqHjnFvPM6g1RspPk4uBo)_