### PR TITLE
Report vncdo failures accurately, with exit codes grouped by cause

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,9 @@
 1.4.0 (UNRELEASED)
 ----------------------
+  - [BREAKING] vncdo exit codes are grouped by cause: 10s connection, 20s protocol, 30s command, 40s timeout, documented in docs/usage.rst.  Scripts reading the exit code see new values: authentication failure is now 21 and a session cut short 11, both of which used to be 0; an unknown action is now 2, previously 1 (@sibson, #345)
   - Fix: vncdo reports failure instead of success when the connection closes before the requested commands finish, including on VNC authentication failure (@sibson, #345)
   - Fix: vncdo reports the error and exits non-zero when a command fails, rather than hanging (@sibson, #345)
-  - vncdo exit codes are grouped by cause: 10s connection, 20s protocol, 30s command, 40s timeout, see docs/usage.rst (@sibson, #345)
-  - Protocol errors are reported through the new ``RFBClient.vncProtocolError`` hook instead of only being logged (@sibson, #345)
+  - Protocol errors abort the session instead of only being logged, reported through the new ``RFBClient.vncProtocolError`` hook (@sibson, #345)
 
 1.3.0 (2026-04-03)
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 1.3.1 (UNRELEASED)
 ----------------------
-  - Fix: vncdo now exits non-zero when VNC authentication fails instead of reporting success (@sibson)
+  - Fix: vncdo reports failure instead of success when the connection closes before the requested commands finish, including on VNC authentication failure (@sibson, #345)
+  - Fix: vncdo reports the error and exits non-zero when a command fails, rather than hanging (@sibson, #345)
 
 1.3.0 (2026-04-03)
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 1.3.1 (UNRELEASED)
 ----------------------
+  - Fix: vncdo now exits non-zero when VNC authentication fails instead of reporting success (@sibson)
 
 1.3.0 (2026-04-03)
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 ----------------------
   - Fix: vncdo reports failure instead of success when the connection closes before the requested commands finish, including on VNC authentication failure (@sibson, #345)
   - Fix: vncdo reports the error and exits non-zero when a command fails, rather than hanging (@sibson, #345)
+  - vncdo exit codes are grouped by cause: 10s connection, 20s protocol, 30s command, 40s timeout, see docs/usage.rst (@sibson, #345)
+  - Protocol errors are reported through the new ``RFBClient.vncProtocolError`` hook instead of only being logged (@sibson, #345)
 
 1.3.0 (2026-04-03)
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 1.4.0 (UNRELEASED)
 ----------------------
-  - [BREAKING] vncdo exit codes are grouped by cause: 10s connection, 20s protocol, 30s command, 40s timeout, documented in docs/usage.rst.  Scripts reading the exit code see new values: authentication failure is now 21 and a session cut short 11, both of which used to be 0; an unknown action is now 2, previously 1 (@sibson, #345)
+  - [BREAKING] vncdo exit codes now say what went wrong: single digits for bad input, including 3 for authentication, and tens grouped by cause out on the wire, 10s connection, 20s protocol, 30s command, 40s timeout, documented in docs/usage.rst.  Scripts reading the exit code see new values: authentication failure is now 3 and a session cut short 11, both of which used to be 0; an unknown action is now 2, previously 1 (@sibson, #345)
   - Fix: vncdo reports failure instead of success when the connection closes before the requested commands finish, including on VNC authentication failure (@sibson, #345)
   - Fix: vncdo reports the error and exits non-zero when a command fails, rather than hanging (@sibson, #345)
   - Protocol errors abort the session instead of only being logged, reported through the new ``RFBClient.vncProtocolError`` hook (@sibson, #345)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-1.3.1 (UNRELEASED)
+1.4.0 (UNRELEASED)
 ----------------------
   - Fix: vncdo reports failure instead of success when the connection closes before the requested commands finish, including on VNC authentication failure (@sibson, #345)
   - Fix: vncdo reports the error and exits non-zero when a command fails, rather than hanging (@sibson, #345)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -63,7 +63,7 @@ a script can tell a server that is down from one that rejected the password::
     > vncdo -s $HOST -p $PASSWORD type hello
     > case $? in
     >   0)  echo "done" ;;
-    >   21) echo "wrong password" ;;
+    >   3)  echo "wrong password" ;;
     >   1?) echo "cannot reach $HOST" ;;
     >   *)  echo "failed" ;;
     > esac
@@ -74,16 +74,18 @@ Code  Meaning
 0     all actions completed
 1     unexpected error
 2     bad command line or unknown action
+3     authentication failed, usually a wrong password
 10    could not connect: refused, unreachable, or name lookup failed
 11    connection closed before the actions finished
 20    server spoke something we could not understand
-21    authentication failed, usually a wrong password
 30    an action failed, such as writing a capture to an unwritable path
 40    ``--timeout`` elapsed before the actions finished
 ===== ==================================================================
 
-Codes are grouped in tens by cause, so new codes can be added to a group
-later.  Match on the group when you only care about the category.
+Single digits are for things you told us: the command line and the
+credentials.  Failures out on the wire are grouped in tens by cause, so
+new codes can be added to a group later.  Match on the group when you
+only care about the category.
 
 
 Running Scripts

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -55,6 +55,37 @@ x=100, y=200 and is 400 pixels wide by 250 high you could do::
     > vncdo rexpect region.png 100 200 0
 
 
+Exit Status
+-------------------
+vncdo exits 0 when every action completed.  Failures are grouped by cause, so
+a script can tell a server that is down from one that rejected the password::
+
+    > vncdo -s $HOST -p $PASSWORD type hello
+    > case $? in
+    >   0)  echo "done" ;;
+    >   21) echo "wrong password" ;;
+    >   1?) echo "cannot reach $HOST" ;;
+    >   *)  echo "failed" ;;
+    > esac
+
+===== ==================================================================
+Code  Meaning
+===== ==================================================================
+0     all actions completed
+1     unexpected error
+2     bad command line or unknown action
+10    could not connect: refused, unreachable, or name lookup failed
+11    connection closed before the actions finished
+20    server spoke something we could not understand
+21    authentication failed, usually a wrong password
+30    an action failed, such as writing a capture to an unwritable path
+40    ``--timeout`` elapsed before the actions finished
+===== ==================================================================
+
+Codes are grouped in tens by cause, so new codes can be added to a group
+later.  Match on the group when you only care about the category.
+
+
 Running Scripts
 -------------------
 For more complex automation you can read commands from stdin or a file.

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -221,6 +221,15 @@ class TestVNCDoToolClient(TestCase):
         reason = cli.factory.clientConnectionFailed.call_args[0][1]
         assert isinstance(reason.value, client.AuthenticationError)
 
+    def test_vncProtocolError_reports_connection_failed(self):
+        cli = self.client
+        cli.vncProtocolError('unknown encoding received')
+
+        assert cli.factory.clientConnectionFailed.called
+        reason = cli.factory.clientConnectionFailed.call_args[0][1]
+        assert isinstance(reason.value, client.ProtocolError)
+        assert 'unknown encoding' in str(reason.value)
+
 
 class TestVNCDoToolFactory(TestCase):
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -213,6 +213,14 @@ class TestVNCDoToolClient(TestCase):
         cli.vncRequestPassword()
         cli.sendPassword.assert_called_once_with(cli.factory.password)
 
+    def test_vncAuthFailed_reports_connection_failed(self):
+        cli = self.client
+        cli.vncAuthFailed(b'Authentication failure')
+
+        assert cli.factory.clientConnectionFailed.called
+        reason = cli.factory.clientConnectionFailed.call_args[0][1]
+        assert isinstance(reason.value, client.AuthenticationError)
+
 
 class TestVNCDoToolFactory(TestCase):
 

--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -2,7 +2,11 @@ import socket
 import unittest
 from unittest import mock, skipUnless
 
+from twisted.internet.error import ConnectionDone
+from twisted.python.failure import Failure
+
 from vncdotool import command
+from vncdotool.client import AuthenticationError
 
 
 class TestBuildCommandList(unittest.TestCase):
@@ -252,3 +256,21 @@ class TestVNCDoCLIClient(unittest.TestCase):
         assert command.getpass.getpass.called
         assert cli.factory.password == password
         cli.sendPassword.assert_called_once_with(password)
+
+
+class TestVNCDoCLIFactory(unittest.TestCase):
+
+    @mock.patch('vncdotool.command.reactor')
+    def test_auth_failure_exits_nonzero(self, reactor):
+        factory = command.VNCDoCLIFactory()
+        factory.clientConnectionFailed(
+            None, Failure(AuthenticationError('Authentication failure'))
+        )
+
+        assert reactor.exit_status == 10
+
+        # the server closing the rejected connection afterwards must not
+        # overwrite the failure exit status with a clean-close success
+        factory.clientConnectionLost(None, Failure(ConnectionDone()))
+
+        assert reactor.exit_status == 10

--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -260,17 +260,78 @@ class TestVNCDoCLIClient(unittest.TestCase):
 
 class TestVNCDoCLIFactory(unittest.TestCase):
 
-    @mock.patch('vncdotool.command.reactor')
-    def test_auth_failure_exits_nonzero(self, reactor):
-        factory = command.VNCDoCLIFactory()
-        factory.clientConnectionFailed(
+    def setUp(self) -> None:
+        patcher = mock.patch('vncdotool.command.reactor')
+        self.reactor = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.reactor.exit_status = None
+        self.factory = command.VNCDoCLIFactory()
+
+    def test_auth_failure_exits_nonzero(self) -> None:
+        self.factory.clientConnectionFailed(
             None, Failure(AuthenticationError('Authentication failure'))
         )
 
-        assert reactor.exit_status == 10
+        assert self.reactor.exit_status == 10
 
-        # the server closing the rejected connection afterwards must not
-        # overwrite the failure exit status with a clean-close success
-        factory.clientConnectionLost(None, Failure(ConnectionDone()))
+    def test_clean_close_before_commands_run_exits_nonzero(self) -> None:
+        # the server hanging up cleanly is not evidence the commands ran
+        self.factory.clientConnectionLost(None, Failure(ConnectionDone()))
 
-        assert reactor.exit_status == 10
+        assert self.reactor.exit_status == 10
+
+    def test_clean_close_after_commands_run_keeps_success(self) -> None:
+        self.factory.done(0)
+        self.factory.clientConnectionLost(None, Failure(ConnectionDone()))
+
+        assert self.reactor.exit_status == 0
+
+    def test_first_outcome_wins(self) -> None:
+        self.factory.error(Failure(AuthenticationError('denied')))
+        self.factory.done(0)
+
+        assert self.reactor.exit_status == 10
+
+
+class TestBuildTool(unittest.TestCase):
+
+    def setUp(self) -> None:
+        patcher = mock.patch('vncdotool.command.reactor')
+        self.reactor = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.reactor.exit_status = 'unset'
+
+        connect_patcher = mock.patch('vncdotool.command.factory_connect')
+        connect_patcher.start()
+        self.addCleanup(connect_patcher.stop)
+
+        self.options = mock.Mock(
+            verbose=False,
+            delay=None,
+            warp=1.0,
+            incremental_refreshes=0,
+            host='127.0.0.1',
+            port=5900,
+            address_family=socket.AF_INET,
+        )
+
+    def test_undecided_exit_status_starts_none(self) -> None:
+        command.build_tool(self.options, [])
+
+        assert self.reactor.exit_status is None
+
+    def test_completed_commands_close_connection_and_exit_zero(self) -> None:
+        factory = command.build_tool(self.options, [])
+        client = mock.Mock()
+
+        factory.deferred.callback(client)
+
+        client.transport.loseConnection.assert_called_once_with()
+        assert self.reactor.exit_status == 0
+
+    def test_failed_command_exits_nonzero(self) -> None:
+        factory = command.build_tool(self.options, [])
+
+        factory.deferred.errback(Failure(IOError('cannot write capture')))
+
+        assert self.reactor.exit_status == 10

--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -258,6 +258,23 @@ class TestVNCDoCLIClient(unittest.TestCase):
         cli.sendPassword.assert_called_once_with(password)
 
 
+class TestExitStatus(unittest.TestCase):
+
+    def test_documented_values(self) -> None:
+        # these are a published interface, see docs/usage.rst
+        assert dict(command.ExitStatus.__members__.items()) == {
+            'SUCCESS': 0,
+            'ERROR': 1,
+            'USAGE': 2,
+            'AUTHENTICATION_FAILED': 3,
+            'CONNECTION_FAILED': 10,
+            'CONNECTION_LOST': 11,
+            'PROTOCOL_ERROR': 20,
+            'COMMAND_FAILED': 30,
+            'TIMEOUT': 40,
+        }
+
+
 class FakeReactor:
     """Records the exit status instead of stopping the real reactor.
 

--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -2,11 +2,11 @@ import socket
 import unittest
 from unittest import mock, skipUnless
 
-from twisted.internet.error import ConnectionDone
+from twisted.internet.error import ConnectionDone, ConnectionRefusedError, DNSLookupError
 from twisted.python.failure import Failure
 
 from vncdotool import command
-from vncdotool.client import AuthenticationError
+from vncdotool.client import AuthenticationError, ProtocolError
 
 
 class TestBuildCommandList(unittest.TestCase):
@@ -267,30 +267,57 @@ class TestVNCDoCLIFactory(unittest.TestCase):
         self.reactor.exit_status = None
         self.factory = command.VNCDoCLIFactory()
 
-    def test_auth_failure_exits_nonzero(self) -> None:
+    def test_auth_failure(self) -> None:
         self.factory.clientConnectionFailed(
             None, Failure(AuthenticationError('Authentication failure'))
         )
 
-        assert self.reactor.exit_status == 10
+        assert self.reactor.exit_status == command.ExitStatus.AUTHENTICATION_FAILED
 
-    def test_clean_close_before_commands_run_exits_nonzero(self) -> None:
+    def test_protocol_error(self) -> None:
+        self.factory.clientConnectionFailed(
+            None, Failure(ProtocolError('unknown encoding received'))
+        )
+
+        assert self.reactor.exit_status == command.ExitStatus.PROTOCOL_ERROR
+
+    def test_connection_refused(self) -> None:
+        self.factory.clientConnectionFailed(None, Failure(ConnectionRefusedError()))
+
+        assert self.reactor.exit_status == command.ExitStatus.CONNECTION_FAILED
+
+    def test_dns_lookup_failure(self) -> None:
+        self.factory.clientConnectionFailed(None, Failure(DNSLookupError()))
+
+        assert self.reactor.exit_status == command.ExitStatus.CONNECTION_FAILED
+
+    def test_clean_close_before_commands_run(self) -> None:
         # the server hanging up cleanly is not evidence the commands ran
         self.factory.clientConnectionLost(None, Failure(ConnectionDone()))
 
-        assert self.reactor.exit_status == 10
+        assert self.reactor.exit_status == command.ExitStatus.CONNECTION_LOST
+
+    def test_command_failure(self) -> None:
+        self.factory.error(Failure(IOError('cannot write capture')))
+
+        assert self.reactor.exit_status == command.ExitStatus.COMMAND_FAILED
+
+    def test_timeout(self) -> None:
+        self.factory.error(Failure(command.TimeoutError('TIMEOUT Exceeded (5s)')))
+
+        assert self.reactor.exit_status == command.ExitStatus.TIMEOUT
 
     def test_clean_close_after_commands_run_keeps_success(self) -> None:
-        self.factory.done(0)
+        self.factory.done(command.ExitStatus.SUCCESS)
         self.factory.clientConnectionLost(None, Failure(ConnectionDone()))
 
-        assert self.reactor.exit_status == 0
+        assert self.reactor.exit_status == command.ExitStatus.SUCCESS
 
     def test_first_outcome_wins(self) -> None:
         self.factory.error(Failure(AuthenticationError('denied')))
-        self.factory.done(0)
+        self.factory.done(command.ExitStatus.SUCCESS)
 
-        assert self.reactor.exit_status == 10
+        assert self.reactor.exit_status == command.ExitStatus.AUTHENTICATION_FAILED
 
 
 class TestBuildTool(unittest.TestCase):
@@ -327,11 +354,17 @@ class TestBuildTool(unittest.TestCase):
         factory.deferred.callback(client)
 
         client.transport.loseConnection.assert_called_once_with()
-        assert self.reactor.exit_status == 0
+        assert self.reactor.exit_status == command.ExitStatus.SUCCESS
 
-    def test_failed_command_exits_nonzero(self) -> None:
+    def test_failed_command_exits_command_failed(self) -> None:
         factory = command.build_tool(self.options, [])
 
         factory.deferred.errback(Failure(IOError('cannot write capture')))
 
-        assert self.reactor.exit_status == 10
+        assert self.reactor.exit_status == command.ExitStatus.COMMAND_FAILED
+
+    def test_unparsable_command_exits_usage(self) -> None:
+        with self.assertRaises(SystemExit) as raised:
+            command.build_tool(self.options, ['nosuchcommand'])
+
+        assert raised.exception.code == command.ExitStatus.USAGE

--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -258,80 +258,87 @@ class TestVNCDoCLIClient(unittest.TestCase):
         cli.sendPassword.assert_called_once_with(password)
 
 
+class FakeReactor:
+    """Records the exit status instead of stopping the real reactor.
+
+    A bare Mock would report an auto-created attribute for exit_status, which
+    the factory reads as an outcome having already been decided.
+    """
+
+    def __init__(self) -> None:
+        self.exit_status = None
+
+    def callLater(self, delay, fn, *args, **kwargs) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+
+@mock.patch('vncdotool.command.reactor', new_callable=FakeReactor)
 class TestVNCDoCLIFactory(unittest.TestCase):
 
     def setUp(self) -> None:
-        patcher = mock.patch('vncdotool.command.reactor')
-        self.reactor = patcher.start()
-        self.addCleanup(patcher.stop)
-        self.reactor.exit_status = None
         self.factory = command.VNCDoCLIFactory()
 
-    def test_auth_failure(self) -> None:
+    def test_auth_failure(self, reactor) -> None:
         self.factory.clientConnectionFailed(
             None, Failure(AuthenticationError('Authentication failure'))
         )
 
-        assert self.reactor.exit_status == command.ExitStatus.AUTHENTICATION_FAILED
+        assert reactor.exit_status == command.ExitStatus.AUTHENTICATION_FAILED
 
-    def test_protocol_error(self) -> None:
+    def test_protocol_error(self, reactor) -> None:
         self.factory.clientConnectionFailed(
             None, Failure(ProtocolError('unknown encoding received'))
         )
 
-        assert self.reactor.exit_status == command.ExitStatus.PROTOCOL_ERROR
+        assert reactor.exit_status == command.ExitStatus.PROTOCOL_ERROR
 
-    def test_connection_refused(self) -> None:
+    def test_connection_refused(self, reactor) -> None:
         self.factory.clientConnectionFailed(None, Failure(ConnectionRefusedError()))
 
-        assert self.reactor.exit_status == command.ExitStatus.CONNECTION_FAILED
+        assert reactor.exit_status == command.ExitStatus.CONNECTION_FAILED
 
-    def test_dns_lookup_failure(self) -> None:
+    def test_dns_lookup_failure(self, reactor) -> None:
         self.factory.clientConnectionFailed(None, Failure(DNSLookupError()))
 
-        assert self.reactor.exit_status == command.ExitStatus.CONNECTION_FAILED
+        assert reactor.exit_status == command.ExitStatus.CONNECTION_FAILED
 
-    def test_clean_close_before_commands_run(self) -> None:
+    def test_clean_close_before_commands_run(self, reactor) -> None:
         # the server hanging up cleanly is not evidence the commands ran
         self.factory.clientConnectionLost(None, Failure(ConnectionDone()))
 
-        assert self.reactor.exit_status == command.ExitStatus.CONNECTION_LOST
+        assert reactor.exit_status == command.ExitStatus.CONNECTION_LOST
 
-    def test_command_failure(self) -> None:
+    def test_command_failure(self, reactor) -> None:
         self.factory.error(Failure(IOError('cannot write capture')))
 
-        assert self.reactor.exit_status == command.ExitStatus.COMMAND_FAILED
+        assert reactor.exit_status == command.ExitStatus.COMMAND_FAILED
 
-    def test_timeout(self) -> None:
+    def test_timeout(self, reactor) -> None:
         self.factory.error(Failure(command.TimeoutError('TIMEOUT Exceeded (5s)')))
 
-        assert self.reactor.exit_status == command.ExitStatus.TIMEOUT
+        assert reactor.exit_status == command.ExitStatus.TIMEOUT
 
-    def test_clean_close_after_commands_run_keeps_success(self) -> None:
+    def test_clean_close_after_commands_run_keeps_success(self, reactor) -> None:
         self.factory.done(command.ExitStatus.SUCCESS)
         self.factory.clientConnectionLost(None, Failure(ConnectionDone()))
 
-        assert self.reactor.exit_status == command.ExitStatus.SUCCESS
+        assert reactor.exit_status == command.ExitStatus.SUCCESS
 
-    def test_first_outcome_wins(self) -> None:
+    def test_first_outcome_wins(self, reactor) -> None:
         self.factory.error(Failure(AuthenticationError('denied')))
         self.factory.done(command.ExitStatus.SUCCESS)
 
-        assert self.reactor.exit_status == command.ExitStatus.AUTHENTICATION_FAILED
+        assert reactor.exit_status == command.ExitStatus.AUTHENTICATION_FAILED
 
 
+@mock.patch('vncdotool.command.factory_connect')
+@mock.patch('vncdotool.command.reactor', new_callable=FakeReactor)
 class TestBuildTool(unittest.TestCase):
 
     def setUp(self) -> None:
-        patcher = mock.patch('vncdotool.command.reactor')
-        self.reactor = patcher.start()
-        self.addCleanup(patcher.stop)
-        self.reactor.exit_status = 'unset'
-
-        connect_patcher = mock.patch('vncdotool.command.factory_connect')
-        connect_patcher.start()
-        self.addCleanup(connect_patcher.stop)
-
         self.options = mock.Mock(
             verbose=False,
             delay=None,
@@ -342,28 +349,32 @@ class TestBuildTool(unittest.TestCase):
             address_family=socket.AF_INET,
         )
 
-    def test_undecided_exit_status_starts_none(self) -> None:
+    def test_undecided_exit_status_starts_none(self, reactor, connect) -> None:
+        reactor.exit_status = 'left over from an earlier run'
+
         command.build_tool(self.options, [])
 
-        assert self.reactor.exit_status is None
+        assert reactor.exit_status is None
 
-    def test_completed_commands_close_connection_and_exit_zero(self) -> None:
+    def test_completed_commands_close_connection_and_exit_zero(
+        self, reactor, connect
+    ) -> None:
         factory = command.build_tool(self.options, [])
         client = mock.Mock()
 
         factory.deferred.callback(client)
 
         client.transport.loseConnection.assert_called_once_with()
-        assert self.reactor.exit_status == command.ExitStatus.SUCCESS
+        assert reactor.exit_status == command.ExitStatus.SUCCESS
 
-    def test_failed_command_exits_command_failed(self) -> None:
+    def test_failed_command_exits_command_failed(self, reactor, connect) -> None:
         factory = command.build_tool(self.options, [])
 
         factory.deferred.errback(Failure(IOError('cannot write capture')))
 
-        assert self.reactor.exit_status == command.ExitStatus.COMMAND_FAILED
+        assert reactor.exit_status == command.ExitStatus.COMMAND_FAILED
 
-    def test_unparsable_command_exits_usage(self) -> None:
+    def test_unparsable_command_exits_usage(self, reactor, connect) -> None:
         with self.assertRaises(SystemExit) as raised:
             command.build_tool(self.options, ['nosuchcommand'])
 

--- a/tests/unit/test_rfb.py
+++ b/tests/unit/test_rfb.py
@@ -15,6 +15,36 @@ class TestRFB(TestCase):
         self.client._handler()
         self.client.transport.loseConnection.assert_called_once()
 
+    def test_invalid_server_response_reports_protocol_error(self):
+        self.client.vncProtocolError = mock.Mock()
+        self.client._packet += b"X"
+        self.client._handler()
+        self.client.vncProtocolError.assert_called_once()
+
+    def test_unknown_security_types_reports_protocol_error(self):
+        self.client.vncProtocolError = mock.Mock()
+        self.client._packet += (
+            b"RFB 003.007\n"  # header
+            b"\x01"  # num-auth-types
+            b"\x7f"  # an auth type we do not support
+        )
+        self.client._handler()
+        self.client.vncProtocolError.assert_called_once()
+
+    def test_unknown_auth_type_reports_protocol_error(self):
+        self.client.vncProtocolError = mock.Mock()
+        self.client._packet += (
+            b"RFB 003.003\n"  # header
+            b"\x00\x00\x00\x7f"  # an auth type we do not support
+        )
+        self.client._handler()
+        self.client.vncProtocolError.assert_called_once()
+
+    def test_unknown_message_reports_protocol_error(self):
+        self.client.vncProtocolError = mock.Mock()
+        self.client._handleConnection(b"\x7f")
+        self.client.vncProtocolError.assert_called_once()
+
     def test_auth_incmplete(self):
         self.client._packet += b"RFB 000.000"
         self.client._handler()

--- a/vncdotool/__init__.py
+++ b/vncdotool/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.3.1.dev0"
+__version__ = "1.4.0.dev0"

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -57,6 +57,10 @@ class AuthenticationError(VNCDoException):
     """VNC Server requires Authentication"""
 
 
+class ProtocolError(VNCDoException):
+    """VNC Server sent something we cannot handle"""
+
+
 RGB32 = rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 0, 8, 16)
 RGB24 = rfb.PixelFormat(24, 24, False, True, 255, 255, 255, 0, 8, 16)
 BGR16 = rfb.PixelFormat(16, 16, False, True, 31, 63, 31, 11, 5, 0)
@@ -330,6 +334,10 @@ class VNCDoToolClient(rfb.RFBClient):
         if isinstance(reason, bytes):
             reason = reason.decode("utf-8", "replace")
         self.factory.clientConnectionFailed(self, Failure(AuthenticationError(reason)))
+
+    def vncProtocolError(self, reason: str) -> None:
+        super().vncProtocolError(reason)
+        self.factory.clientConnectionFailed(self, Failure(ProtocolError(reason)))
 
     def vncConnectionMade(self) -> None:
         self.setImageMode()

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -325,6 +325,12 @@ class VNCDoToolClient(rfb.RFBClient):
             return
         self.sendPassword(self.factory.password)
 
+    def vncAuthFailed(self, reason: bytes | str) -> None:
+        super().vncAuthFailed(reason)
+        if isinstance(reason, bytes):
+            reason = reason.decode("utf-8", "replace")
+        self.factory.clientConnectionFailed(self, Failure(AuthenticationError(reason)))
+
     def vncConnectionMade(self) -> None:
         self.setImageMode()
         encodings = [self.encoding]

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import getpass
 import ipaddress
+import enum
 import logging
 import logging.handlers
 import optparse
@@ -20,11 +21,19 @@ import sys
 from types import TracebackType
 
 from twisted.internet import protocol, reactor
+from twisted.internet.error import ConnectError, ConnectionClosed, DNSLookupError
 from twisted.internet.interfaces import IConnector
 from twisted.python.failure import Failure
 from twisted.python.log import PythonLoggingObserver
 
-from .client import TClient, VNCDoToolClient, VNCDoToolFactory, factory_connect
+from .client import (
+    AuthenticationError,
+    ProtocolError,
+    TClient,
+    VNCDoToolClient,
+    VNCDoToolFactory,
+    factory_connect,
+)
 from .loggingproxy import VNCLoggingServerFactory
 
 log = logging.getLogger()
@@ -34,6 +43,35 @@ SUPPORTED_FORMATS = ("png", "jpg", "jpeg", "gif", "bmp")
 
 class TimeoutError(RuntimeError):
     pass
+
+
+class ExitStatus(enum.IntEnum):
+    """Exit codes returned by :program:`vncdo`, grouped by cause."""
+
+    SUCCESS = 0
+    ERROR = 1
+    USAGE = 2
+
+    CONNECTION_FAILED = 10
+    CONNECTION_LOST = 11
+
+    PROTOCOL_ERROR = 20
+    AUTHENTICATION_FAILED = 21
+
+    COMMAND_FAILED = 30
+
+    TIMEOUT = 40
+
+
+# more specific causes first; the first match decides the exit status
+EXIT_STATUS_FOR_ERROR: dict[type[BaseException], ExitStatus] = {
+    AuthenticationError: ExitStatus.AUTHENTICATION_FAILED,
+    ProtocolError: ExitStatus.PROTOCOL_ERROR,
+    TimeoutError: ExitStatus.TIMEOUT,
+    ConnectError: ExitStatus.CONNECTION_FAILED,
+    DNSLookupError: ExitStatus.CONNECTION_FAILED,
+    ConnectionClosed: ExitStatus.CONNECTION_LOST,
+}
 
 
 def log_exceptions(
@@ -62,18 +100,28 @@ class VNCDoCLIFactory(VNCDoToolFactory):
         # losing the connection is never itself a success: the command chain
         # reports the outcome, and closing the transport is its last step, so
         # a close arriving first means the commands never finished
-        self.error(reason)
+        self.error(reason, ExitStatus.CONNECTION_LOST)
 
     def clientConnectionFailed(self, connector: IConnector, reason: Failure) -> None:
-        self.error(reason)
+        self.error(reason, ExitStatus.CONNECTION_FAILED)
 
-    def error(self, reason: Failure) -> None:
+    def error(
+        self, reason: Failure, default: ExitStatus = ExitStatus.COMMAND_FAILED
+    ) -> None:
         if reactor.exit_status is not None:
             return
         log.critical(reason.getErrorMessage())
-        self.done(10)
+        self.done(self.status_for(reason, default))
 
-    def done(self, exit_code: int) -> None:
+    @staticmethod
+    def status_for(reason: Failure, default: ExitStatus) -> ExitStatus:
+        """Classify a failure, falling back to where it was reported from."""
+        for error_type, status in EXIT_STATUS_FOR_ERROR.items():
+            if reason.check(error_type):
+                return status
+        return default
+
+    def done(self, exit_code: ExitStatus) -> None:
         # first outcome wins; the expected close follows a completed run
         if reactor.exit_status is not None:
             return
@@ -252,7 +300,8 @@ def build_tool(options: optparse.Values, args: list[str]) -> VNCDoCLIFactory:
             factory, args, options.delay, options.warp, options.incremental_refreshes
         )
     except CommandParseError as exc:
-        sys.exit(str(exc))
+        print(exc, file=sys.stderr)
+        sys.exit(ExitStatus.USAGE)
 
     # no outcome decided yet; set before connecting so a synchronous
     # connection failure has somewhere to record itself
@@ -261,7 +310,7 @@ def build_tool(options: optparse.Values, args: list[str]) -> VNCDoCLIFactory:
 
     # close the connection when we're done, then report how it went
     factory.deferred.addCallback(lambda client: client.transport.loseConnection())
-    factory.deferred.addCallback(lambda _: factory.done(0))
+    factory.deferred.addCallback(lambda _: factory.done(ExitStatus.SUCCESS))
     factory.deferred.addErrback(factory.error)
 
     return factory
@@ -533,7 +582,7 @@ def vncdo() -> None:
     reactor.run()
 
     # the reactor stopping without an outcome is itself a failure
-    sys.exit(1 if reactor.exit_status is None else reactor.exit_status)
+    sys.exit(ExitStatus.ERROR if reactor.exit_status is None else reactor.exit_status)
 
 
 if __name__ == "__main__":

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -50,13 +50,14 @@ class ExitStatus(enum.IntEnum):
 
     SUCCESS = 0
     ERROR = 1
+    # bad input from whoever invoked us, credentials included
     USAGE = 2
+    AUTHENTICATION_FAILED = 3
 
     CONNECTION_FAILED = 10
     CONNECTION_LOST = 11
 
     PROTOCOL_ERROR = 20
-    AUTHENTICATION_FAILED = 21
 
     COMMAND_FAILED = 30
 

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -58,6 +58,7 @@ class VNCDoCLIClient(VNCDoToolClient):
 
 class VNCDoCLIFactory(VNCDoToolFactory):
     protocol = VNCDoCLIClient
+    finished = False
 
     def clientConnectionLost(self, connector: IConnector, reason: Failure) -> None:
         if reason.type == ConnectionDone:
@@ -73,6 +74,11 @@ class VNCDoCLIFactory(VNCDoToolFactory):
         self.done(10)
 
     def done(self, exit_code: int) -> None:
+        # an authentication failure reports its error before the server
+        # closes the socket; the later clean close must not overwrite it
+        if self.finished:
+            return
+        self.finished = True
         reactor.exit_status = exit_code
         reactor.callLater(0.1, reactor.stop)
 

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -20,7 +20,6 @@ import sys
 from types import TracebackType
 
 from twisted.internet import protocol, reactor
-from twisted.internet.error import ConnectionDone
 from twisted.internet.interfaces import IConnector
 from twisted.python.failure import Failure
 from twisted.python.log import PythonLoggingObserver
@@ -58,27 +57,26 @@ class VNCDoCLIClient(VNCDoToolClient):
 
 class VNCDoCLIFactory(VNCDoToolFactory):
     protocol = VNCDoCLIClient
-    finished = False
 
     def clientConnectionLost(self, connector: IConnector, reason: Failure) -> None:
-        if reason.type == ConnectionDone:
-            self.done(0)
-        else:
-            self.error(reason)
+        # losing the connection is never itself a success: the command chain
+        # reports the outcome, and closing the transport is its last step, so
+        # a close arriving first means the commands never finished
+        self.error(reason)
 
     def clientConnectionFailed(self, connector: IConnector, reason: Failure) -> None:
         self.error(reason)
 
     def error(self, reason: Failure) -> None:
+        if reactor.exit_status is not None:
+            return
         log.critical(reason.getErrorMessage())
         self.done(10)
 
     def done(self, exit_code: int) -> None:
-        # an authentication failure reports its error before the server
-        # closes the socket; the later clean close must not overwrite it
-        if self.finished:
+        # first outcome wins; the expected close follows a completed run
+        if reactor.exit_status is not None:
             return
-        self.finished = True
         reactor.exit_status = exit_code
         reactor.callLater(0.1, reactor.stop)
 
@@ -256,11 +254,15 @@ def build_tool(options: optparse.Values, args: list[str]) -> VNCDoCLIFactory:
     except CommandParseError as exc:
         sys.exit(str(exc))
 
+    # no outcome decided yet; set before connecting so a synchronous
+    # connection failure has somewhere to record itself
+    reactor.exit_status = None
     factory_connect(factory, options.host, options.port, options.address_family)
-    reactor.exit_status = 1
 
-    # close the connection when we're done
+    # close the connection when we're done, then report how it went
     factory.deferred.addCallback(lambda client: client.transport.loseConnection())
+    factory.deferred.addCallback(lambda _: factory.done(0))
+    factory.deferred.addErrback(factory.error)
 
     return factory
 
@@ -530,7 +532,8 @@ def vncdo() -> None:
 
     reactor.run()
 
-    sys.exit(reactor.exit_status)
+    # the reactor stopping without an outcome is itself a failure
+    sys.exit(1 if reactor.exit_status is None else reactor.exit_status)
 
 
 if __name__ == "__main__":

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -220,7 +220,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
             else:
                 self.expect(self._handleNumberSecurityTypes, 1)
         elif not self._HEADER.startswith(norm):
-            log.msg(f"invalid initial server response {head!r}")
+            self.vncProtocolError(f"invalid initial server response {head!r}")
             self.transport.loseConnection()
 
     def _handleNumberSecurityTypes(self, block: bytes) -> None:
@@ -248,7 +248,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
             elif sec_type == AuthTypes.DIFFIE_HELLMAN:
                 self.expect(self._handleDHAuth, 4)
         else:
-            log.msg(f"unknown security types: {types!r}")
+            self.vncProtocolError(f"unknown security types: {types!r}")
             self.transport.loseConnection()
 
     def _handleAuth(self, block: bytes) -> None:
@@ -261,7 +261,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
         elif auth == AuthTypes.VNC_AUTHENTICATION:
             self.expect(self._handleVNCAuth, 16)
         else:
-            log.msg(f"unknown auth response {AuthTypes.lookup(auth)!r}")
+            self.vncProtocolError(f"unknown auth response {AuthTypes.lookup(auth)!r}")
             self.transport.loseConnection()
 
     def _handleConnFailed(self, block: bytes) -> None:
@@ -269,7 +269,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
         self.expect(self._handleConnMessage, waitfor)
 
     def _handleConnMessage(self, block: bytes) -> None:
-        log.msg(f"Connection refused: {block!r}")
+        self.vncProtocolError(f"Connection refused: {block!r}")
         self.transport.loseConnection()
 
     def _handleVNCAuth(self, block: bytes) -> None:
@@ -390,7 +390,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
         elif msgid == MsgS2C.SERVER_CUT_TEXT:
             self.expect(self._handleServerCutText, 7)
         else:
-            log.msg(f"unknown message received {MsgS2C.lookup(msgid)!r}")
+            self.vncProtocolError(f"unknown message received {MsgS2C.lookup(msgid)!r}")
             self.transport.loseConnection()
 
     def _handleFramebufferUpdate(self, block: bytes) -> None:
@@ -445,7 +445,9 @@ class RFBClient(Protocol):  # type: ignore[misc]
                 del self.rectanglePos[-1]  # undo append as this is no real update
                 self._doConnection()
             else:
-                log.msg(f"unknown encoding received {Encoding.lookup(encoding)!r}")
+                self.vncProtocolError(
+                    f"unknown encoding received {Encoding.lookup(encoding)!r}"
+                )
                 self.transport.loseConnection()
         else:
             self._doConnection()
@@ -1026,6 +1028,11 @@ class RFBClient(Protocol):  # type: ignore[misc]
         """called when the authentication failed.
         the connection is closed."""
         log.msg(f"Cannot connect {reason}")
+
+    def vncProtocolError(self, reason: str) -> None:
+        """called when the server sends something we cannot handle.
+        the connection is closed."""
+        log.msg(reason)
 
     def beginUpdate(self) -> None:
         """called before a series of :meth:`updateRectangle`,


### PR DESCRIPTION
## What changed

`VNCDoCLIFactory` decided the exit status from transport teardown: `clientConnectionLost` mapped `ConnectionDone` to `done(0)`. A clean TCP close only proves the socket shut down, so any clean close that was not the end of a successful run still exited 0.

Two parts:

**1. Exit status now comes from the `factory.deferred` command chain**, which is what represents the requested work — `done(SUCCESS)` as its final callback, `factory.error` as its errback. `clientConnectionLost` always reports an error and never signals success. First outcome wins, keyed off `reactor.exit_status` (initialised to `None`, mapped to 1 at the `sys.exit` site), checked in `error()` too so the expected close after a completed run does not log CRITICAL.

**2. Exit codes now say what went wrong.** Single digits are for input we were given, tens and up for what happened on the wire, grouped by cause:

| Code | Meaning |
|---|---|
| 0 | all actions completed |
| 1 | unexpected error |
| 2 | bad command line or unknown action |
| 3 | authentication failed |
| 10 | could not connect: refused, unreachable, name lookup failed |
| 11 | connection closed before the actions finished |
| 20 | server spoke something we could not understand |
| 30 | an action failed, e.g. writing a capture to an unwritable path |
| 40 | `--timeout` elapsed |

Authentication sits at 3 rather than inside the protocol family: a wrong password is bad input from whoever invoked vncdo, the same class as a bad flag, not a fault out on the wire. It is also the outcome scripts branch on most.

Classification is by exception type, falling back to the status of the reporting call site, since the same generic exception means different things arriving from `clientConnectionFailed`, `clientConnectionLost`, or the command chain.

Protocol failures previously logged and dropped the connection, so they surfaced as connection losses reading `Connection was closed cleanly`. Six sites in `rfb.py` now go through a new `vncProtocolError` hook, mirroring `vncAuthFailed` — the default implementation still only logs, so library behaviour is unchanged, and `VNCDoToolClient` turns it into a `ProtocolError` on the factory deferred.

`CommandParseError` exits 2 rather than 1. That 1 was never chosen: `sys.exit()` returns 1 for any non-int argument and the line always passed the message text. Both sibling usage errors (bad flag, missing command) already exited 2.

## Why

Measured against a stub listener and the tigervnc-auth compose server:

| Scenario | main | this branch |
|---|---|---|
| Server accepts, hangs up without speaking RFB | exit 0 | exit 11 |
| Server hangs up after the version handshake | exit 0 | exit 11 |
| Server sends a non-RFB header | exit 0 | exit 20 |
| Bad password | exit 0 | exit 3 |
| `capture /nonexistent/dir/x.png` | hangs forever | exit 30 |
| `--timeout` with an expect that never matches | exit 10 | exit 40 |
| Connection refused / DNS failure | exit 10 | exit 10 |
| Unknown action | exit 1 | exit 2 |
| Normal run | exit 0 | exit 0 |

The hang is the same defect seen from the other side: the chain errbacked with nothing attached to handle it, so the `loseConnection` callback was skipped and nothing closed the transport. `--timeout` was the only escape.

Scripts and CI relying on vncdo's exit code got a false OK in every failing row above.

## Reviewer notes

- Every row in that table was verified live, not just unit tested; each also has a unit test.
- Exit codes were previously undocumented, so this establishes the contract: docs/usage.rst gains a table and a worked example, and a unit test pins the numeric values.
- Version bumped to 1.4.0 and the changelog entry is marked `[BREAKING]`, since exit codes that used to be 0 are now non-zero.
- Ordering works because `loseConnection` is async: the `done(SUCCESS)` callback runs before `connectionLost` fires.
- `vnclog` is unaffected: `VNCLoggingServerFactory` extends `portforward.ProxyFactory`, has no `done`/`error`, and `build_proxy` sets `exit_status = 0` explicitly.
- The live `test_bad_password_exits_nonzero` check on the Phase 1 testing-framework branch is still marked `expectedFailure` there; that marker gets dropped once this lands beneath it. Note it should assert 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)