### PR TITLE
Name the docker compose test-servers project

### DIFF
--- a/tests/servers/docker-compose.yml
+++ b/tests/servers/docker-compose.yml
@@ -12,6 +12,8 @@
 # `up --wait` a reliable barrier. Every service publishes its RFB port to
 # localhost only.
 
+name: vncdo-test-servers
+
 services:
   tigervnc:
     build:


### PR DESCRIPTION
## Summary
- Docker Desktop shows the test-server stack as bare "servers" (derived from the directory name), which is unclear next to other projects.
- Add an explicit `name: vncdo-test-servers` field to `tests/servers/docker-compose.yml` so it displays clearly.

## Test plan
- [x] Verified no stack currently running (nothing to migrate)
- [ ] `docker compose up` in `tests/servers/` and confirm Docker Desktop shows "vncdo-test-servers"