### PR TITLE
Ignore .DS_Store, .tool-versions, and .vscode/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ docs/_build
 *~
 #*
 tests/servers/screenshots/
+
+.DS_Store
+.tool-versions
+.vscode/


### PR DESCRIPTION
## Summary
- Add local editor/OS/tool-version artifacts to .gitignore: .DS_Store, .tool-versions, .vscode/

🤖 Generated with [Claude Code](https://claude.com/claude-code)