### PR TITLE
Add vnclog --capture: scrubbed raw wire captures for unhosted servers (Phase 3)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,11 @@
     filing bug reports against servers we can't host. An auth type vncdotool
     cannot scrub aborts the capture unless ``--capture-raw-unsafe-auth`` is
     given. ``meta.json`` records which encodings the server actually sent
+  - Add ``vnclog --one-shot``, serving a single session then exiting; implied
+    by ``--capture-raw``
+  - ``vnclog`` no longer drops a session when its own logging fails to parse a
+    message: the semantic log is an observer, and a server the real client
+    copes with should not be cut off by the proxy
   - Fix ``vnclog`` desyncing against RFB 3.7+ servers using VNC password
     authentication (it ate the 16-byte auth response instead of skipping it,
     then lost track of the client message stream entirely)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@
     given. ``meta.json`` records which encodings the server actually sent
   - Add ``vnclog --one-shot``, serving a single session then exiting; implied
     by ``--capture-raw``
+  - [BREAKING] ``vnclog --forever`` is renamed ``--file-per-client``. It never
+    controlled how long vnclog ran -- vnclog has always accepted connections
+    until stopped -- it selects a separate ``.vdo`` per client connection.
+    Scripts passing ``--forever`` must be updated
   - ``vnclog`` no longer drops a session when its own logging fails to parse a
     message: the semantic log is an observer, and a server the real client
     copes with should not be cut off by the proxy

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@
   - Fix: vncdo reports failure instead of success when the connection closes before the requested commands finish, including on VNC authentication failure (@sibson, #345)
   - Fix: vncdo reports the error and exits non-zero when a command fails, rather than hanging (@sibson, #345)
   - Protocol errors abort the session instead of only being logged, reported through the new ``RFBClient.vncProtocolError`` hook (@sibson, #345)
+  - Add ``vnclog --capture DIR`` for raw wire captures with scrubbed VNC-auth
+    secrets, for filing bug reports against servers we can't host
+  - Fix ``vnclog`` desyncing against RFB 3.7+ servers using VNC password
+    authentication (it ate the 16-byte auth response instead of skipping it,
+    then lost track of the client message stream entirely)
 
 1.3.0 (2026-04-03)
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,10 +4,10 @@
   - Fix: vncdo reports failure instead of success when the connection closes before the requested commands finish, including on VNC authentication failure (@sibson, #345)
   - Fix: vncdo reports the error and exits non-zero when a command fails, rather than hanging (@sibson, #345)
   - Protocol errors abort the session instead of only being logged, reported through the new ``RFBClient.vncProtocolError`` hook (@sibson, #345)
-  - Add ``vnclog --capture FILE.zip`` for raw wire captures, written as one
+  - Add ``vnclog --capture-raw FILE.zip`` for raw wire captures, written as one
     upload-ready archive with VNC-auth and ARD credentials scrubbed, for
     filing bug reports against servers we can't host. An auth type vncdotool
-    cannot scrub aborts the capture unless ``--capture-unsafe-auth`` is
+    cannot scrub aborts the capture unless ``--capture-raw-unsafe-auth`` is
     given. ``meta.json`` records which encodings the server actually sent
   - Fix ``vnclog`` desyncing against RFB 3.7+ servers using VNC password
     authentication (it ate the 16-byte auth response instead of skipping it,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,11 @@
   - Fix: vncdo reports failure instead of success when the connection closes before the requested commands finish, including on VNC authentication failure (@sibson, #345)
   - Fix: vncdo reports the error and exits non-zero when a command fails, rather than hanging (@sibson, #345)
   - Protocol errors abort the session instead of only being logged, reported through the new ``RFBClient.vncProtocolError`` hook (@sibson, #345)
-  - Add ``vnclog --capture DIR`` for raw wire captures with scrubbed VNC-auth
-    secrets, for filing bug reports against servers we can't host
+  - Add ``vnclog --capture FILE.zip`` for raw wire captures, written as one
+    upload-ready archive with VNC-auth and ARD credentials scrubbed, for
+    filing bug reports against servers we can't host. An auth type vncdotool
+    cannot scrub aborts the capture unless ``--capture-unsafe-auth`` is
+    given. ``meta.json`` records which encodings the server actually sent
   - Fix ``vnclog`` desyncing against RFB 3.7+ servers using VNC password
     authentication (it ate the 16-byte auth response instead of skipping it,
     then lost track of the client message stream entirely)

--- a/docs/capture.rst
+++ b/docs/capture.rst
@@ -23,18 +23,13 @@ Making a capture
 
        vnclog --capture-raw ./my-bug-capture.zip --listen 5902 -s YOURSERVER::5900
 
-   ``vnclog`` will refuse to run if ``./my-bug-capture.zip`` already exists
-   -- that's deliberate, so a capture is never silently overwritten.
-
 3. Point your VNC client at the proxy instead of the real server --
    ``localhost::5902`` -- and reproduce the problem. This can be your usual
    GUI viewer, or a ``vncdo`` script if the bug is scriptable::
 
        vncdo -s localhost::5902 key enter type "hello" capture screen.png
 
-4. Stop the proxy (Ctrl-C) once you're done. It writes the archive when your
-   client disconnects, not only on a clean process exit, so a Ctrl-C is
-   safe.
+4. Disconnect. ``vnclog`` writes the archive and exits.
 
 5. Attach ``my-bug-capture.zip`` to the GitHub issue.
 
@@ -51,91 +46,34 @@ What's in the archive
                   # types it offered, which encodings it actually sent,
                   # and the framebuffer geometry
 
-The archive is written whole, under a temporary name and renamed into place,
-so a half-written capture never looks like a complete one.
-
-Only one session is ever recorded per ``--capture-raw``: if a second client
-connects (a viewer retrying after a dropped connection, say) it is refused
-outright rather than silently overwriting the capture you already have.
-Start a fresh ``vnclog --capture-raw`` with a new filename to record another
-session.
-
-``meta.json`` is plain, human-readable JSON -- open it and read it before
-you attach the capture, so you know what is about to leave your machine.
-
-``encodings_seen`` is counted from the rectangles the server actually sent,
-not from what the client asked for -- a server is free to ignore the
-client's ``SetEncodings`` -- so it answers "which encodings does this server
-really use?" directly::
-
-    "encodings_seen": [
-      {"encoding": 0,  "name": "raw",  "rectangles": 3},
-      {"encoding": 16, "name": "zrle", "rectangles": 118}
-    ]
-
-An encoding vncdotool has no name for shows as ``"name": null`` with its
-number intact, which is itself a useful bug report.
-
 What is scrubbed
 ------------------
 
-Credentials are redacted at capture time, before any byte touches disk.
-Redactions are always replaced by the same number of zero bytes, so the
-surrounding byte offsets don't shift and the capture still replays:
+Credentials are redacted at capture time, before any byte touches disk:
 
-* **VNC authentication** -- the 16-byte challenge (from the server) and the
-  16-byte response (from the client);
-* **ARD / Apple Screen Sharing** (``diffie-hellman``, macOS) -- the 128-byte
-  AES block carrying your username and password. The Diffie-Hellman values
-  around it (generator, modulus, both public keys) are public by
-  construction and are kept deliberately: ARD compatibility bugs live in
-  those values.
+* **VNC authentication** -- the 16-byte challenge and the 16-byte response;
+* **ARD / Apple Screen Sharing** -- the AES block carrying your username and
+  password. The Diffie-Hellman values around it are public by construction
+  and are kept: ARD compatibility bugs live in them.
 
-vncdotool can only redact an exchange it can parse. If the session
-negotiates an auth type it cannot -- ``tight``, ``vencrypt``, ``rsa-aes``,
-UltraVNC's MS-Logon -- the capture is aborted and the error tells you how to
-proceed anyway.
+vncdotool implements those two auth types and no others, so it cannot locate
+the secret inside ``tight``, ``vencrypt``, ``rsa-aes`` or UltraVNC's
+MS-Logon. A session negotiating one of those aborts the capture rather than
+write the credential exchange out whole; the error says how to override it.
 
 .. warning::
 
-   ``--capture-raw-unsafe-auth`` writes the credential exchange to the
-   archive verbatim, and ``meta.json``'s ``unscrubbed_auth`` records which
-   type it was. Some of these exchanges are attackable offline -- ARD's
-   512-bit Diffie-Hellman is within reach of ordinary compute today. Use a
-   **disposable password, and rotate it afterwards**, and prefer emailing
-   such a capture to a maintainer over attaching it to a public issue.
+   Overriding writes your credential exchange into the archive verbatim.
+   Some of these are attackable offline -- ARD's 512-bit Diffie-Hellman is
+   within reach of ordinary compute today. Use a **disposable password and
+   rotate it afterwards.**
 
 What is **not** scrubbed
 --------------------------
 
-Scrubbing stops at the end of the handshake. Everything the session itself
-carries is recorded as-is -- deliberately: a capture with its input stream
-rewritten is no longer evidence of what the server did. In particular:
+Scrubbing stops at the end of the handshake. Everything the session carries
+is recorded as sent: screen contents, clipboard text, and every keystroke --
+including anything typed into a password field *inside* the remote desktop.
 
-* **screen contents** -- framebuffer updates are the whole point of the
-  protocol, and they are not redacted;
-* **clipboard text** -- cut/paste text sent in either direction is captured
-  in the clear;
-* **typed text** -- keystrokes you send through the proxy (including
-  anything you type into a password field *inside* the remote session, as
-  opposed to the VNC connection password itself) are recorded exactly as
-  sent.
-
-Do not reproduce a bug through the capture proxy while entering anything you
-would not want to see attached to a public GitHub issue -- in particular, do
-not type a password into the remote desktop during a capture. If your
-reproduction requires it, unzip the archive, redact the relevant bytes from
-``s2c.bin``/``c2s.bin`` by hand, and rezip -- the format is deliberately
-simple (three flat files plus JSON metadata) so that's a plain byte-offset
-edit, not a special tool.
-
-Replaying a capture
----------------------
-
-Captures are discovery evidence attached to an issue, not a fixture that
-lives in the repository or runs in CI -- see ``docs/testing-framework-design.md``
-in the source tree for the full picture. A maintainer investigating your
-issue may replay ``s2c.bin`` at a real client using an in-repo development
-tool to narrow down the bug, and the end result of that investigation is a
-small, deterministic unit test with the relevant bytes inlined -- not the
-capture itself.
+So reproduce the bug and nothing else. Do not type a password into the
+remote desktop while capturing.

--- a/docs/capture.rst
+++ b/docs/capture.rst
@@ -1,0 +1,126 @@
+Capturing a session for a bug report
+=====================================
+
+vncdotool is tested against the servers we can run ourselves (see
+``tests/servers/``). If you hit a bug against a server we can't host --
+RealVNC, Proxmox, a vendor's embedded VNC implementation, whatever -- the
+most useful thing you can attach to the issue is a *capture*: a recording of
+the raw bytes vncdotool exchanged with that server while reproducing the
+problem.
+
+You do not need a checkout of this repository to make one. A released,
+``pip``-installed vncdotool is enough.
+
+Making a capture
+------------------
+
+1. Install vncdotool::
+
+       pip install vncdotool
+
+2. Start the recording proxy, pointed at the server you're seeing the bug
+   against, with an empty (or not-yet-existing) directory to write into::
+
+       vnclog --capture ./my-bug-capture --listen 5902 -s YOURSERVER::5900
+
+   ``vnclog`` will refuse to run if ``./my-bug-capture`` already exists and
+   is non-empty -- that's deliberate, so a capture is never silently mixed
+   with an older one.
+
+3. Point your VNC client at the proxy instead of the real server --
+   ``localhost::5902`` -- and reproduce the problem. This can be your usual
+   GUI viewer, or a ``vncdo`` script if the bug is scriptable::
+
+       vncdo -s localhost::5902 key enter type "hello" capture screen.png
+
+4. Stop the proxy (Ctrl-C) once you're done. It flushes and closes the
+   capture when your client disconnects, not only on a clean process exit,
+   so a Ctrl-C is safe.
+
+5. Attach the whole ``my-bug-capture`` directory to the GitHub issue (zip it
+   first if your attachment tool doesn't take directories).
+
+What's in the directory
+-------------------------
+
+::
+
+    session.vdo   # the vncdo commands/events driven through the proxy
+    s2c.bin       # raw server-to-client byte stream, in arrival order
+    c2s.bin       # raw client-to-server byte stream, in arrival order
+    meta.json     # server address, vncdotool version, capture timestamp,
+                  # the server's protocol version string, the security
+                  # types it offered, the framebuffer geometry, and what
+                  # was (and was not) scrubbed
+
+Only one session is ever recorded per ``--capture DIR``: if a second client
+connects (a viewer retrying after a dropped connection, say) it is refused
+outright rather than silently overwriting the capture you already have.
+Start a fresh ``vnclog --capture`` into a new directory to record another
+session.
+
+``meta.json`` is plain, human-readable JSON -- open it and read it before
+you attach the capture. It tells you exactly what got redacted, so you can
+confirm nothing else in the two ``.bin`` files needs to be trimmed by hand
+before it leaves your machine.
+
+What is scrubbed
+------------------
+
+Two things are redacted at capture time, before any byte touches disk:
+
+* the 16-byte VNC authentication challenge (sent by the server) and the
+  16-byte response (sent by the client), each replaced with an all-zero
+  marker of the same length so the surrounding byte offsets don't shift;
+* any bytes matching the VNC password vncdotool itself was given (via
+  ``-p``/``--password``), wherever they occur in either stream.
+
+Both are also listed by name in ``meta.json``'s ``scrubbed`` field, so you
+don't have to take it on faith -- e.g. ``["vnc-auth-challenge",
+"vnc-auth-response"]``, or ``[]`` if the server used no authentication at
+all.
+
+.. warning::
+
+   **Apple Remote Desktop / Diffie-Hellman auth (macOS Screen Sharing) is
+   not scrubbed.** If ``meta.json``'s ``unscrubbed_auth`` field is set
+   (e.g. ``"diffie-hellman(30)"``) instead of ``null``, the capture
+   contains that key exchange -- including your username and
+   DES/AES-wrapped password -- verbatim in ``s2c.bin``/``c2s.bin``. ARD's
+   512-bit Diffie-Hellman is within reach of offline compute today, so
+   treat such a capture as containing your credentials in a weakly
+   protected form. Do **not** attach it to a public issue; email it to a
+   maintainer instead, or reproduce the bug against a server that uses VNC
+   password auth or no auth if that's an option for you.
+
+What is **not** scrubbed
+--------------------------
+
+Everything else in the capture is recorded as-is. In particular:
+
+* **screen contents** -- framebuffer updates are the whole point of the
+  protocol, and they are not redacted;
+* **clipboard text** -- cut/paste text sent in either direction is captured
+  in the clear;
+* **typed text** -- keystrokes you send through the proxy (including
+  anything you type into a password field *inside* the remote session, as
+  opposed to the VNC connection password itself) are recorded exactly as
+  sent.
+
+Do not reproduce a bug through the capture proxy while entering anything you
+would not want to see attached to a public GitHub issue. If your reproduction
+requires it, redact the relevant bytes from ``s2c.bin``/``c2s.bin`` by hand
+before attaching -- the file format is deliberately simple (three flat
+files plus JSON metadata) so that's a plain byte-offset edit, not a special
+tool.
+
+Replaying a capture
+---------------------
+
+Captures are discovery evidence attached to an issue, not a fixture that
+lives in the repository or runs in CI -- see ``docs/testing-framework-design.md``
+in the source tree for the full picture. A maintainer investigating your
+issue may replay ``s2c.bin`` at a real client using an in-repo development
+tool to narrow down the bug, and the end result of that investigation is a
+small, deterministic unit test with the relevant bytes inlined -- not the
+capture itself.

--- a/docs/capture.rst
+++ b/docs/capture.rst
@@ -19,13 +19,12 @@ Making a capture
        pip install vncdotool
 
 2. Start the recording proxy, pointed at the server you're seeing the bug
-   against, with an empty (or not-yet-existing) directory to write into::
+   against, naming the ``.zip`` to write::
 
-       vnclog --capture ./my-bug-capture --listen 5902 -s YOURSERVER::5900
+       vnclog --capture ./my-bug-capture.zip --listen 5902 -s YOURSERVER::5900
 
-   ``vnclog`` will refuse to run if ``./my-bug-capture`` already exists and
-   is non-empty -- that's deliberate, so a capture is never silently mixed
-   with an older one.
+   ``vnclog`` will refuse to run if ``./my-bug-capture.zip`` already exists
+   -- that's deliberate, so a capture is never silently overwritten.
 
 3. Point your VNC client at the proxy instead of the real server --
    ``localhost::5902`` -- and reproduce the problem. This can be your usual
@@ -33,15 +32,14 @@ Making a capture
 
        vncdo -s localhost::5902 key enter type "hello" capture screen.png
 
-4. Stop the proxy (Ctrl-C) once you're done. It flushes and closes the
-   capture when your client disconnects, not only on a clean process exit,
-   so a Ctrl-C is safe.
+4. Stop the proxy (Ctrl-C) once you're done. It writes the archive when your
+   client disconnects, not only on a clean process exit, so a Ctrl-C is
+   safe.
 
-5. Attach the whole ``my-bug-capture`` directory to the GitHub issue (zip it
-   first if your attachment tool doesn't take directories).
+5. Attach ``my-bug-capture.zip`` to the GitHub issue.
 
-What's in the directory
--------------------------
+What's in the archive
+-----------------------
 
 ::
 
@@ -50,13 +48,17 @@ What's in the directory
     c2s.bin       # raw client-to-server byte stream, in arrival order
     meta.json     # server address, vncdotool version, capture timestamp,
                   # the server's protocol version string, the security
-                  # types it offered, the framebuffer geometry, and what
-                  # was (and was not) scrubbed
+                  # types it offered, which encodings it actually sent,
+                  # the framebuffer geometry, and what was (and was not)
+                  # scrubbed
 
-Only one session is ever recorded per ``--capture DIR``: if a second client
+The archive is written whole, under a temporary name and renamed into place,
+so a half-written capture never looks like a complete one.
+
+Only one session is ever recorded per ``--capture``: if a second client
 connects (a viewer retrying after a dropped connection, say) it is refused
 outright rather than silently overwriting the capture you already have.
-Start a fresh ``vnclog --capture`` into a new directory to record another
+Start a fresh ``vnclog --capture`` with a new filename to record another
 session.
 
 ``meta.json`` is plain, human-readable JSON -- open it and read it before
@@ -64,39 +66,76 @@ you attach the capture. It tells you exactly what got redacted, so you can
 confirm nothing else in the two ``.bin`` files needs to be trimmed by hand
 before it leaves your machine.
 
+``encodings_seen`` is counted from the rectangles the server actually sent,
+not from what the client asked for -- a server is free to ignore the
+client's ``SetEncodings`` -- so it answers "which encodings does this server
+really use?" directly::
+
+    "encodings_seen": [
+      {"encoding": 0,  "name": "raw",  "rectangles": 3},
+      {"encoding": 16, "name": "zrle", "rectangles": 118}
+    ]
+
+An encoding vncdotool has no name for shows as ``"name": null`` with its
+number intact, which is itself a useful bug report.
+
 What is scrubbed
 ------------------
 
-Two things are redacted at capture time, before any byte touches disk:
+Credentials are redacted at capture time, before any byte touches disk.
+Redactions are always replaced by the same number of zero bytes, so the
+surrounding byte offsets don't shift and the capture still replays:
 
-* the 16-byte VNC authentication challenge (sent by the server) and the
-  16-byte response (sent by the client), each replaced with an all-zero
-  marker of the same length so the surrounding byte offsets don't shift;
-* any bytes matching the VNC password vncdotool itself was given (via
-  ``-p``/``--password``), wherever they occur in either stream.
+* **VNC authentication** -- the 16-byte challenge (from the server) and the
+  16-byte response (from the client);
+* **ARD / Apple Screen Sharing** (``diffie-hellman``, macOS) -- the 128-byte
+  AES block carrying your username and password. The Diffie-Hellman values
+  around it (generator, modulus, both public keys) are public by
+  construction and are kept deliberately: ARD compatibility bugs live in
+  those values;
+* **your VNC password** -- any bytes matching the password vncdotool itself
+  was given (via ``-p``/``--password``), wherever they occur in either
+  stream. Best-effort only: VNC auth never puts the password on the wire in
+  the clear, so this is a backstop, not the main defence.
 
-Both are also listed by name in ``meta.json``'s ``scrubbed`` field, so you
-don't have to take it on faith -- e.g. ``["vnc-auth-challenge",
+Each is listed by name in ``meta.json``'s ``scrubbed`` field, so you don't
+have to take it on faith -- e.g. ``["vnc-auth-challenge",
 "vnc-auth-response"]``, or ``[]`` if the server used no authentication at
 all.
 
+Auth types with no scrubber
+-----------------------------
+
+vncdotool can only redact an exchange it can parse. If the session
+negotiates something else -- ``tight``, ``vencrypt``, ``rsa-aes``,
+UltraVNC's MS-Logon -- the capture is **aborted**: nothing is written and
+the connection is closed, with the reason printed to stderr::
+
+    --capture aborted: the session negotiated tight(16), which vncdotool
+    cannot scrub; the capture would contain the credential exchange verbatim.
+
+That is the safe default for a file you are about to attach to a public
+issue tracker. If the bug you are chasing *is* in that auth exchange, you
+can override it::
+
+    vnclog --capture ./my-bug-capture.zip --capture-unsafe-auth \
+        --listen 5902 -s YOURSERVER::5900
+
 .. warning::
 
-   **Apple Remote Desktop / Diffie-Hellman auth (macOS Screen Sharing) is
-   not scrubbed.** If ``meta.json``'s ``unscrubbed_auth`` field is set
-   (e.g. ``"diffie-hellman(30)"``) instead of ``null``, the capture
-   contains that key exchange -- including your username and
-   DES/AES-wrapped password -- verbatim in ``s2c.bin``/``c2s.bin``. ARD's
-   512-bit Diffie-Hellman is within reach of offline compute today, so
-   treat such a capture as containing your credentials in a weakly
-   protected form. Do **not** attach it to a public issue; email it to a
-   maintainer instead, or reproduce the bug against a server that uses VNC
-   password auth or no auth if that's an option for you.
+   ``--capture-unsafe-auth`` writes the credential exchange to the archive
+   verbatim, and ``meta.json``'s ``unscrubbed_auth`` field records which
+   type it was. Some of these exchanges are attackable offline -- ARD's
+   512-bit Diffie-Hellman is within reach of ordinary compute today. Use a
+   **disposable password, and rotate it afterwards**, and prefer emailing
+   such a capture to a maintainer over attaching it to a public issue.
 
 What is **not** scrubbed
 --------------------------
 
-Everything else in the capture is recorded as-is. In particular:
+Scrubbing stops at the end of the handshake. Everything the session itself
+carries is recorded as-is -- deliberately: a capture with its input stream
+rewritten is no longer evidence of what the server did. In particular:
 
 * **screen contents** -- framebuffer updates are the whole point of the
   protocol, and they are not redacted;
@@ -108,11 +147,12 @@ Everything else in the capture is recorded as-is. In particular:
   sent.
 
 Do not reproduce a bug through the capture proxy while entering anything you
-would not want to see attached to a public GitHub issue. If your reproduction
-requires it, redact the relevant bytes from ``s2c.bin``/``c2s.bin`` by hand
-before attaching -- the file format is deliberately simple (three flat
-files plus JSON metadata) so that's a plain byte-offset edit, not a special
-tool.
+would not want to see attached to a public GitHub issue -- in particular, do
+not type a password into the remote desktop during a capture. If your
+reproduction requires it, unzip the archive, redact the relevant bytes from
+``s2c.bin``/``c2s.bin`` by hand, and rezip -- the format is deliberately
+simple (three flat files plus JSON metadata) so that's a plain byte-offset
+edit, not a special tool.
 
 Replaying a capture
 ---------------------

--- a/docs/capture.rst
+++ b/docs/capture.rst
@@ -21,7 +21,7 @@ Making a capture
 2. Start the recording proxy, pointed at the server you're seeing the bug
    against, naming the ``.zip`` to write::
 
-       vnclog --capture ./my-bug-capture.zip --listen 5902 -s YOURSERVER::5900
+       vnclog --capture-raw ./my-bug-capture.zip --listen 5902 -s YOURSERVER::5900
 
    ``vnclog`` will refuse to run if ``./my-bug-capture.zip`` already exists
    -- that's deliberate, so a capture is never silently overwritten.
@@ -49,22 +49,19 @@ What's in the archive
     meta.json     # server address, vncdotool version, capture timestamp,
                   # the server's protocol version string, the security
                   # types it offered, which encodings it actually sent,
-                  # the framebuffer geometry, and what was (and was not)
-                  # scrubbed
+                  # and the framebuffer geometry
 
 The archive is written whole, under a temporary name and renamed into place,
 so a half-written capture never looks like a complete one.
 
-Only one session is ever recorded per ``--capture``: if a second client
+Only one session is ever recorded per ``--capture-raw``: if a second client
 connects (a viewer retrying after a dropped connection, say) it is refused
 outright rather than silently overwriting the capture you already have.
-Start a fresh ``vnclog --capture`` with a new filename to record another
+Start a fresh ``vnclog --capture-raw`` with a new filename to record another
 session.
 
 ``meta.json`` is plain, human-readable JSON -- open it and read it before
-you attach the capture. It tells you exactly what got redacted, so you can
-confirm nothing else in the two ``.bin`` files needs to be trimmed by hand
-before it leaves your machine.
+you attach the capture, so you know what is about to leave your machine.
 
 ``encodings_seen`` is counted from the rectangles the server actually sent,
 not from what the client asked for -- a server is free to ignore the
@@ -92,39 +89,17 @@ surrounding byte offsets don't shift and the capture still replays:
   AES block carrying your username and password. The Diffie-Hellman values
   around it (generator, modulus, both public keys) are public by
   construction and are kept deliberately: ARD compatibility bugs live in
-  those values;
-* **your VNC password** -- any bytes matching the password vncdotool itself
-  was given (via ``-p``/``--password``), wherever they occur in either
-  stream. Best-effort only: VNC auth never puts the password on the wire in
-  the clear, so this is a backstop, not the main defence.
-
-Each is listed by name in ``meta.json``'s ``scrubbed`` field, so you don't
-have to take it on faith -- e.g. ``["vnc-auth-challenge",
-"vnc-auth-response"]``, or ``[]`` if the server used no authentication at
-all.
-
-Auth types with no scrubber
------------------------------
+  those values.
 
 vncdotool can only redact an exchange it can parse. If the session
-negotiates something else -- ``tight``, ``vencrypt``, ``rsa-aes``,
-UltraVNC's MS-Logon -- the capture is **aborted**: nothing is written and
-the connection is closed, with the reason printed to stderr::
-
-    --capture aborted: the session negotiated tight(16), which vncdotool
-    cannot scrub; the capture would contain the credential exchange verbatim.
-
-That is the safe default for a file you are about to attach to a public
-issue tracker. If the bug you are chasing *is* in that auth exchange, you
-can override it::
-
-    vnclog --capture ./my-bug-capture.zip --capture-unsafe-auth \
-        --listen 5902 -s YOURSERVER::5900
+negotiates an auth type it cannot -- ``tight``, ``vencrypt``, ``rsa-aes``,
+UltraVNC's MS-Logon -- the capture is aborted and the error tells you how to
+proceed anyway.
 
 .. warning::
 
-   ``--capture-unsafe-auth`` writes the credential exchange to the archive
-   verbatim, and ``meta.json``'s ``unscrubbed_auth`` field records which
+   ``--capture-raw-unsafe-auth`` writes the credential exchange to the
+   archive verbatim, and ``meta.json``'s ``unscrubbed_auth`` records which
    type it was. Some of these exchanges are attackable offline -- ARD's
    512-bit Diffie-Hellman is within reach of ordinary compute today. Use a
    **disposable password, and rotate it afterwards**, and prefer emailing

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ vncdotool Documentation
    usage
    library
    commands
+   capture
    history
    contributing
    modules

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -143,4 +143,9 @@ This can be useful for quickly recording a number of testcases.::
     # do some other stuff
     > ls /tmp/*.vdo
 
+``vnclog`` keeps accepting connections until you stop it. Use ``--one-shot``
+to record a single session and exit::
+
+    > vnclog --one-shot --listen 6000 keylog.vdo
+
 .. _Pillow: http://www.pythonware.com/products/pil

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -132,11 +132,11 @@ to the correct ports::
     > vncviewer localhost:2  # do something and then exit viewer
     > vncdo keylog.vdo
 
-By running with --forever vnclog will create a new file for every client
-connection and record each clients activity.
+By running with --file-per-client vnclog will create a new file for every
+client connection and record each clients activity.
 This can be useful for quickly recording a number of testcases.::
 
-    > vnclog --forever --listen 6000 /tmp
+    > vnclog --file-per-client --listen 6000 /tmp
     > vncviewer localhost::6000
     # do some stuff then exit and start new session
     > vncviewer localhost::6000

--- a/tests/functional/test_proxy.py
+++ b/tests/functional/test_proxy.py
@@ -44,7 +44,7 @@ def _await_capture(archive: Path) -> zipfile.ZipFile:
 
 
 def _start_vnclog(listen_port: int, server: str, capture_path: Path) -> subprocess.Popen:
-    """Start `vnclog --capture`, waiting until it is actually listening.
+    """Start `vnclog --capture-raw`, waiting until it is actually listening.
 
     Readiness comes from vnclog's stderr, never a port probe: in capture
     mode the probe can race the forwarded greeting into looking like a real
@@ -55,7 +55,7 @@ def _start_vnclog(listen_port: int, server: str, capture_path: Path) -> subproce
             "vnclog",
             "-s", server,
             "--listen", str(listen_port),
-            "--capture", str(capture_path),
+            "--capture-raw", str(capture_path),
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -150,7 +150,7 @@ class TestVnclogProxy(TestCase):
 
 
 class TestVnclogCapture(TestCase):
-    """`vnclog --capture FILE.zip` end to end against vncev.
+    """`vnclog --capture-raw FILE.zip` end to end against vncev.
 
     vncev speaks auth None, so this is the no-scrub path: the archive lands
     with all four members and stays byte-identical when there is nothing to
@@ -189,9 +189,8 @@ class TestVnclogCapture(TestCase):
         self.assertTrue(s2c.startswith(b"RFB "), f"s2c.bin did not start with the server greeting: {s2c[:16]!r}")
         self.assertTrue(c2s.startswith(b"RFB "), f"c2s.bin did not start with the client's version reply: {c2s[:16]!r}")
 
-        for key in ("server", "vncdotool_version", "capture_timestamp", "protocol_version", "security_types", "scrubbed"):
+        for key in ("server", "vncdotool_version", "capture_timestamp", "protocol_version", "security_types"):
             self.assertIn(key, meta)
-        self.assertEqual(meta["scrubbed"], [])  # vncev is auth None: nothing to scrub
 
         # Recorded off the decoded stream, so this is what the server chose,
         # not what the client requested.
@@ -211,7 +210,7 @@ class TestVnclogCapture(TestCase):
                 "vnclog",
                 "-s", f"{HOST}::{VNCEV.port}",
                 "--listen", str(CAPTURE_PROXY_PORT + 1),
-                "--capture", str(self.capture),
+                "--capture-raw", str(self.capture),
             ],
             capture_output=True,
             text=True,
@@ -222,7 +221,7 @@ class TestVnclogCapture(TestCase):
 
 
 class TestVnclogCaptureVncAuth(TestCase):
-    """`vnclog --capture FILE.zip` against tigervnc-auth (VNC password auth).
+    """`vnclog --capture-raw FILE.zip` against tigervnc-auth (VNC password auth).
 
     The unit tests scrub a scripted challenge/response; only a live run
     proves it against tigervnc's real handshake.
@@ -268,7 +267,10 @@ class TestVnclogCaptureVncAuth(TestCase):
         self.assertNotIn(TIGERVNC_AUTH.password.encode(), s2c)
         self.assertNotIn(TIGERVNC_AUTH.password.encode(), c2s)
 
-        self.assertEqual(meta["scrubbed"], ["vnc-auth-challenge", "vnc-auth-response"])
+        # The response sits at a fixed offset on the 3.8 path: 12-byte
+        # version reply, 1-byte security type, then the 16 bytes that must
+        # have been zeroed.
+        self.assertEqual(c2s[13:29], bytes(16), f"auth response was not scrubbed: {c2s[:32]!r}")
         self.assertIsNone(meta["unscrubbed_auth"])
 
         self.assertIn("keydown z", session_vdo, f"vnclog recorded:\n{session_vdo!r}")

--- a/tests/functional/test_proxy.py
+++ b/tests/functional/test_proxy.py
@@ -14,6 +14,7 @@ import select
 import subprocess
 import tempfile
 import time
+import zipfile
 from pathlib import Path
 from unittest import TestCase
 
@@ -28,7 +29,21 @@ PROXY_STARTUP_DEADLINE = 10.0
 PROXY_SHUTDOWN_TIMEOUT = 10.0
 
 
-def _start_vnclog(listen_port: int, server: str, capture_dir: Path) -> subprocess.Popen:
+def _await_capture(archive: Path) -> zipfile.ZipFile:
+    """Wait for the capture archive to be written, then open it.
+
+    The archive is renamed into place only once complete, so its existence
+    is enough -- no polling for individual members.
+    """
+    deadline = time.monotonic() + PROXY_SHUTDOWN_TIMEOUT
+    while time.monotonic() < deadline and not archive.exists():
+        time.sleep(0.2)
+    if not archive.exists():
+        raise AssertionError(f"capture archive {archive} was never written")
+    return zipfile.ZipFile(archive)
+
+
+def _start_vnclog(listen_port: int, server: str, capture_path: Path) -> subprocess.Popen:
     """Start `vnclog --capture`, waiting until it is actually listening.
 
     Readiness comes from vnclog's stderr, never a port probe: in capture
@@ -40,7 +55,7 @@ def _start_vnclog(listen_port: int, server: str, capture_dir: Path) -> subproces
             "vnclog",
             "-s", server,
             "--listen", str(listen_port),
-            "--capture", str(capture_dir),
+            "--capture", str(capture_path),
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -135,10 +150,11 @@ class TestVnclogProxy(TestCase):
 
 
 class TestVnclogCapture(TestCase):
-    """`vnclog --capture DIR` end to end against vncev.
+    """`vnclog --capture FILE.zip` end to end against vncev.
 
-    vncev speaks auth None, so this is the no-scrub path: the four files
-    land and stay byte-identical when there is nothing to redact.
+    vncev speaks auth None, so this is the no-scrub path: the archive lands
+    with all four members and stays byte-identical when there is nothing to
+    redact.
     """
 
     def setUp(self) -> None:
@@ -147,62 +163,66 @@ class TestVnclogCapture(TestCase):
                 f"vncev not reachable on {HOST}:{VNCEV.port} -- "
                 "start the servers first with `make servers-up`"
             )
-        self.capture_dir = Path(tempfile.mkdtemp()) / "capture"
-        self.proxy = _start_vnclog(CAPTURE_PROXY_PORT, f"{HOST}::{VNCEV.port}", self.capture_dir)
+        self.capture = Path(tempfile.mkdtemp()) / "capture.zip"
+        self.proxy = _start_vnclog(CAPTURE_PROXY_PORT, f"{HOST}::{VNCEV.port}", self.capture)
 
     def tearDown(self) -> None:
         _stop_proxy(self.proxy)
 
     def test_capture_writes_scrubbed_streams_and_meta(self) -> None:
         proxied = VNCEV._replace(port=CAPTURE_PROXY_PORT)
-        result = run_vncdo(proxied, "key", "z")
+        # `capture` rather than a bare key press: a screenshot forces a
+        # FramebufferUpdate, which is what puts rectangles on the wire for
+        # meta.json's encodings_seen to count.
+        screenshot = Path(tempfile.mkdtemp()) / "screen.png"
+        result = run_vncdo(proxied, "key", "z", "capture", str(screenshot))
         self.assertEqual(result.returncode, 0, f"vncdo via proxy failed: {result.stderr}")
 
-        expected = {"session.vdo", "s2c.bin", "c2s.bin", "meta.json"}
-        deadline = time.monotonic() + PROXY_SHUTDOWN_TIMEOUT
-        present: set = set()
-        while time.monotonic() < deadline and not expected.issubset(present):
-            present = {p.name for p in self.capture_dir.glob("*")} if self.capture_dir.is_dir() else set()
-            time.sleep(0.2)
-        self.assertEqual(expected, present, f"capture dir has: {sorted(present)}")
+        with _await_capture(self.capture) as archive:
+            self.assertEqual(
+                sorted(archive.namelist()), ["c2s.bin", "meta.json", "s2c.bin", "session.vdo"]
+            )
+            s2c = archive.read("s2c.bin")
+            c2s = archive.read("c2s.bin")
+            meta = json.loads(archive.read("meta.json"))
 
-        s2c = (self.capture_dir / "s2c.bin").read_bytes()
-        c2s = (self.capture_dir / "c2s.bin").read_bytes()
         self.assertTrue(s2c.startswith(b"RFB "), f"s2c.bin did not start with the server greeting: {s2c[:16]!r}")
         self.assertTrue(c2s.startswith(b"RFB "), f"c2s.bin did not start with the client's version reply: {c2s[:16]!r}")
 
-        meta = json.loads((self.capture_dir / "meta.json").read_text())
         for key in ("server", "vncdotool_version", "capture_timestamp", "protocol_version", "security_types", "scrubbed"):
             self.assertIn(key, meta)
         self.assertEqual(meta["scrubbed"], [])  # vncev is auth None: nothing to scrub
 
-    def test_capture_refuses_nonempty_dir(self) -> None:
-        # A second vnclog pointed at the same (now non-empty) capture dir
-        # must refuse rather than silently mixing captures.
+        # Recorded off the decoded stream, so this is what the server chose,
+        # not what the client requested.
+        self.assertTrue(meta["encodings_seen"], "no rectangles were tallied")
+        for seen in meta["encodings_seen"]:
+            self.assertGreater(seen["rectangles"], 0)
+
+    def test_capture_refuses_existing_target(self) -> None:
+        # A second vnclog pointed at a capture that already exists must
+        # refuse rather than overwrite it.
         proxied = VNCEV._replace(port=CAPTURE_PROXY_PORT)
         run_vncdo(proxied, "key", "z")
-        deadline = time.monotonic() + PROXY_SHUTDOWN_TIMEOUT
-        while time.monotonic() < deadline and not (self.capture_dir / "meta.json").exists():
-            time.sleep(0.2)
-        self.assertTrue((self.capture_dir / "meta.json").exists(), "first capture never completed")
+        _await_capture(self.capture).close()
 
         second = subprocess.run(
             [
                 "vnclog",
                 "-s", f"{HOST}::{VNCEV.port}",
                 "--listen", str(CAPTURE_PROXY_PORT + 1),
-                "--capture", str(self.capture_dir),
+                "--capture", str(self.capture),
             ],
             capture_output=True,
             text=True,
             timeout=PROXY_STARTUP_DEADLINE,
         )
         self.assertNotEqual(second.returncode, 0)
-        self.assertIn("empty", second.stderr.lower())
+        self.assertIn("already exists", second.stderr.lower())
 
 
 class TestVnclogCaptureVncAuth(TestCase):
-    """`vnclog --capture DIR` against tigervnc-auth (VNC password auth).
+    """`vnclog --capture FILE.zip` against tigervnc-auth (VNC password auth).
 
     The unit tests scrub a scripted challenge/response; only a live run
     proves it against tigervnc's real handshake.
@@ -214,8 +234,8 @@ class TestVnclogCaptureVncAuth(TestCase):
                 f"tigervnc-auth not reachable on {HOST}:{TIGERVNC_AUTH.port} -- "
                 "start the servers first with `make servers-up`"
             )
-        self.capture_dir = Path(tempfile.mkdtemp()) / "capture"
-        self.proxy = _start_vnclog(CAPTURE_AUTH_PROXY_PORT, f"{HOST}::{TIGERVNC_AUTH.port}", self.capture_dir)
+        self.capture = Path(tempfile.mkdtemp()) / "capture.zip"
+        self.proxy = _start_vnclog(CAPTURE_AUTH_PROXY_PORT, f"{HOST}::{TIGERVNC_AUTH.port}", self.capture)
 
     def tearDown(self) -> None:
         _stop_proxy(self.proxy)
@@ -225,16 +245,15 @@ class TestVnclogCaptureVncAuth(TestCase):
         result = run_vncdo(proxied, "key", "z")
         self.assertEqual(result.returncode, 0, f"vncdo via proxy failed: {result.stderr}")
 
-        expected = {"session.vdo", "s2c.bin", "c2s.bin", "meta.json"}
-        deadline = time.monotonic() + PROXY_SHUTDOWN_TIMEOUT
-        present: set = set()
-        while time.monotonic() < deadline and not expected.issubset(present):
-            present = {p.name for p in self.capture_dir.glob("*")} if self.capture_dir.is_dir() else set()
-            time.sleep(0.2)
-        self.assertEqual(expected, present, f"capture dir has: {sorted(present)}")
+        with _await_capture(self.capture) as archive:
+            self.assertEqual(
+                sorted(archive.namelist()), ["c2s.bin", "meta.json", "s2c.bin", "session.vdo"]
+            )
+            s2c = archive.read("s2c.bin")
+            c2s = archive.read("c2s.bin")
+            meta = json.loads(archive.read("meta.json"))
+            session_vdo = archive.read("session.vdo").decode()
 
-        s2c = (self.capture_dir / "s2c.bin").read_bytes()
-        c2s = (self.capture_dir / "c2s.bin").read_bytes()
         self.assertTrue(s2c.startswith(b"RFB "), f"s2c.bin did not start with the server greeting: {s2c[:16]!r}")
         self.assertTrue(c2s.startswith(b"RFB "), f"c2s.bin did not start with the client's version reply: {c2s[:16]!r}")
 
@@ -249,10 +268,8 @@ class TestVnclogCaptureVncAuth(TestCase):
         self.assertNotIn(TIGERVNC_AUTH.password.encode(), s2c)
         self.assertNotIn(TIGERVNC_AUTH.password.encode(), c2s)
 
-        meta = json.loads((self.capture_dir / "meta.json").read_text())
         self.assertEqual(meta["scrubbed"], ["vnc-auth-challenge", "vnc-auth-response"])
         self.assertIsNone(meta["unscrubbed_auth"])
 
-        session_vdo = (self.capture_dir / "session.vdo").read_text()
         self.assertIn("keydown z", session_vdo, f"vnclog recorded:\n{session_vdo!r}")
         self.assertIn("keyup z", session_vdo, f"vnclog recorded:\n{session_vdo!r}")

--- a/tests/functional/test_proxy.py
+++ b/tests/functional/test_proxy.py
@@ -3,19 +3,73 @@
 A `vnclog` process sits between `vncdo` and the vncev fleet service, and
 the test asserts both sides of the proxy did their job: the events reached
 the server and the recorder wrote them down.
+
+The `--capture` classes run against vncev (auth None) and against
+tigervnc-auth, so the challenge/response scrub is proven against a real
+server's byte stream, not only the scripted bytes in tests/unit/test_capture.py.
 """
 
+import json
+import select
 import subprocess
 import tempfile
 import time
 from pathlib import Path
 from unittest import TestCase
 
-from .vncservers import HOST, VNCEV, port_open, run_vncdo
+from .vncservers import DOCKER_SERVERS, HOST, VNCEV, port_open, run_vncdo
+
+TIGERVNC_AUTH = next(s for s in DOCKER_SERVERS if s.name == "tigervnc-auth")
 
 PROXY_PORT = 5993
+CAPTURE_PROXY_PORT = 5994
+CAPTURE_AUTH_PROXY_PORT = 5995
 PROXY_STARTUP_DEADLINE = 10.0
 PROXY_SHUTDOWN_TIMEOUT = 10.0
+
+
+def _start_vnclog(listen_port: int, server: str, capture_dir: Path) -> subprocess.Popen:
+    """Start `vnclog --capture`, waiting until it is actually listening.
+
+    Readiness comes from vnclog's stderr, never a port probe: in capture
+    mode the probe can race the forwarded greeting into looking like a real
+    session, claim the capture, and get the actual client refused.
+    """
+    proxy = subprocess.Popen(
+        [
+            "vnclog",
+            "-s", server,
+            "--listen", str(listen_port),
+            "--capture", str(capture_dir),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.DEVNULL,
+        text=True,
+    )
+    deadline = time.monotonic() + PROXY_STARTUP_DEADLINE
+    ready = False
+    while time.monotonic() < deadline and not ready:
+        if proxy.poll() is not None:
+            break
+        rlist, _, _ = select.select([proxy.stderr], [], [], 0.2)
+        if rlist and "accepting connections" in proxy.stderr.readline():
+            ready = True
+    if not ready:
+        proxy.kill()
+        proxy.wait(timeout=PROXY_SHUTDOWN_TIMEOUT)
+        raise AssertionError(f"vnclog never listened on {listen_port}; stderr:\n{proxy.stderr.read()}")
+    return proxy
+
+
+def _stop_proxy(proxy: subprocess.Popen) -> None:
+    if proxy.poll() is None:
+        proxy.terminate()
+        try:
+            proxy.wait(timeout=PROXY_SHUTDOWN_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            proxy.kill()
+            proxy.wait(timeout=PROXY_SHUTDOWN_TIMEOUT)
 
 
 class TestVnclogProxy(TestCase):
@@ -78,3 +132,127 @@ class TestVnclogProxy(TestCase):
             time.sleep(0.2)
         self.assertIn("keydown z", recorded, f"vnclog recorded:\n{recorded!r}")
         self.assertIn("keyup z", recorded, f"vnclog recorded:\n{recorded!r}")
+
+
+class TestVnclogCapture(TestCase):
+    """`vnclog --capture DIR` end to end against vncev.
+
+    vncev speaks auth None, so this is the no-scrub path: the four files
+    land and stay byte-identical when there is nothing to redact.
+    """
+
+    def setUp(self) -> None:
+        if not port_open(HOST, VNCEV.port):
+            self.skipTest(
+                f"vncev not reachable on {HOST}:{VNCEV.port} -- "
+                "start the servers first with `make servers-up`"
+            )
+        self.capture_dir = Path(tempfile.mkdtemp()) / "capture"
+        self.proxy = _start_vnclog(CAPTURE_PROXY_PORT, f"{HOST}::{VNCEV.port}", self.capture_dir)
+
+    def tearDown(self) -> None:
+        _stop_proxy(self.proxy)
+
+    def test_capture_writes_scrubbed_streams_and_meta(self) -> None:
+        proxied = VNCEV._replace(port=CAPTURE_PROXY_PORT)
+        result = run_vncdo(proxied, "key", "z")
+        self.assertEqual(result.returncode, 0, f"vncdo via proxy failed: {result.stderr}")
+
+        expected = {"session.vdo", "s2c.bin", "c2s.bin", "meta.json"}
+        deadline = time.monotonic() + PROXY_SHUTDOWN_TIMEOUT
+        present: set = set()
+        while time.monotonic() < deadline and not expected.issubset(present):
+            present = {p.name for p in self.capture_dir.glob("*")} if self.capture_dir.is_dir() else set()
+            time.sleep(0.2)
+        self.assertEqual(expected, present, f"capture dir has: {sorted(present)}")
+
+        s2c = (self.capture_dir / "s2c.bin").read_bytes()
+        c2s = (self.capture_dir / "c2s.bin").read_bytes()
+        self.assertTrue(s2c.startswith(b"RFB "), f"s2c.bin did not start with the server greeting: {s2c[:16]!r}")
+        self.assertTrue(c2s.startswith(b"RFB "), f"c2s.bin did not start with the client's version reply: {c2s[:16]!r}")
+
+        meta = json.loads((self.capture_dir / "meta.json").read_text())
+        for key in ("server", "vncdotool_version", "capture_timestamp", "protocol_version", "security_types", "scrubbed"):
+            self.assertIn(key, meta)
+        self.assertEqual(meta["scrubbed"], [])  # vncev is auth None: nothing to scrub
+
+    def test_capture_refuses_nonempty_dir(self) -> None:
+        # A second vnclog pointed at the same (now non-empty) capture dir
+        # must refuse rather than silently mixing captures.
+        proxied = VNCEV._replace(port=CAPTURE_PROXY_PORT)
+        run_vncdo(proxied, "key", "z")
+        deadline = time.monotonic() + PROXY_SHUTDOWN_TIMEOUT
+        while time.monotonic() < deadline and not (self.capture_dir / "meta.json").exists():
+            time.sleep(0.2)
+        self.assertTrue((self.capture_dir / "meta.json").exists(), "first capture never completed")
+
+        second = subprocess.run(
+            [
+                "vnclog",
+                "-s", f"{HOST}::{VNCEV.port}",
+                "--listen", str(CAPTURE_PROXY_PORT + 1),
+                "--capture", str(self.capture_dir),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=PROXY_STARTUP_DEADLINE,
+        )
+        self.assertNotEqual(second.returncode, 0)
+        self.assertIn("empty", second.stderr.lower())
+
+
+class TestVnclogCaptureVncAuth(TestCase):
+    """`vnclog --capture DIR` against tigervnc-auth (VNC password auth).
+
+    The unit tests scrub a scripted challenge/response; only a live run
+    proves it against tigervnc's real handshake.
+    """
+
+    def setUp(self) -> None:
+        if not port_open(HOST, TIGERVNC_AUTH.port):
+            self.skipTest(
+                f"tigervnc-auth not reachable on {HOST}:{TIGERVNC_AUTH.port} -- "
+                "start the servers first with `make servers-up`"
+            )
+        self.capture_dir = Path(tempfile.mkdtemp()) / "capture"
+        self.proxy = _start_vnclog(CAPTURE_AUTH_PROXY_PORT, f"{HOST}::{TIGERVNC_AUTH.port}", self.capture_dir)
+
+    def tearDown(self) -> None:
+        _stop_proxy(self.proxy)
+
+    def test_capture_scrubs_vnc_auth_challenge_and_response(self) -> None:
+        proxied = TIGERVNC_AUTH._replace(port=CAPTURE_AUTH_PROXY_PORT)
+        result = run_vncdo(proxied, "key", "z")
+        self.assertEqual(result.returncode, 0, f"vncdo via proxy failed: {result.stderr}")
+
+        expected = {"session.vdo", "s2c.bin", "c2s.bin", "meta.json"}
+        deadline = time.monotonic() + PROXY_SHUTDOWN_TIMEOUT
+        present: set = set()
+        while time.monotonic() < deadline and not expected.issubset(present):
+            present = {p.name for p in self.capture_dir.glob("*")} if self.capture_dir.is_dir() else set()
+            time.sleep(0.2)
+        self.assertEqual(expected, present, f"capture dir has: {sorted(present)}")
+
+        s2c = (self.capture_dir / "s2c.bin").read_bytes()
+        c2s = (self.capture_dir / "c2s.bin").read_bytes()
+        self.assertTrue(s2c.startswith(b"RFB "), f"s2c.bin did not start with the server greeting: {s2c[:16]!r}")
+        self.assertTrue(c2s.startswith(b"RFB "), f"c2s.bin did not start with the client's version reply: {c2s[:16]!r}")
+
+        # More than the handshake: post-auth client traffic proves nothing
+        # truncated the recording at the auth exchange.
+        HANDSHAKE_ONLY = 12 + 1 + 16
+        self.assertGreater(
+            len(c2s), HANDSHAKE_ONLY, f"c2s.bin looks truncated at the handshake: {len(c2s)} bytes: {c2s!r}"
+        )
+
+        # the real password must not appear anywhere in the clear
+        self.assertNotIn(TIGERVNC_AUTH.password.encode(), s2c)
+        self.assertNotIn(TIGERVNC_AUTH.password.encode(), c2s)
+
+        meta = json.loads((self.capture_dir / "meta.json").read_text())
+        self.assertEqual(meta["scrubbed"], ["vnc-auth-challenge", "vnc-auth-response"])
+        self.assertIsNone(meta["unscrubbed_auth"])
+
+        session_vdo = (self.capture_dir / "session.vdo").read_text()
+        self.assertIn("keydown z", session_vdo, f"vnclog recorded:\n{session_vdo!r}")
+        self.assertIn("keyup z", session_vdo, f"vnclog recorded:\n{session_vdo!r}")

--- a/tests/functional/test_proxy.py
+++ b/tests/functional/test_proxy.py
@@ -84,7 +84,7 @@ class TestVnclogProxy(TestCase):
                 f"vncev not reachable on {HOST}:{VNCEV.port} -- "
                 "start the servers first with `make servers-up`"
             )
-        # --forever with a directory OUTPUT is the one recorder mode that
+        # --file-per-client with a directory OUTPUT is the one recorder mode that
         # flushes its .vdo file on client disconnect rather than on clean
         # process exit, which a tearDown terminate() can't guarantee.
         self.output_dir = Path(tempfile.mkdtemp())
@@ -93,7 +93,7 @@ class TestVnclogProxy(TestCase):
                 "vnclog",
                 "-s", f"{HOST}::{VNCEV.port}",
                 "--listen", str(PROXY_PORT),
-                "--forever",
+                "--file-per-client",
                 str(self.output_dir),
             ],
             stdout=subprocess.PIPE,

--- a/tests/functional/test_proxy.py
+++ b/tests/functional/test_proxy.py
@@ -1,13 +1,4 @@
-"""The `vnclog` recording proxy, driven end to end as a subprocess.
-
-A `vnclog` process sits between `vncdo` and the vncev fleet service, and
-the test asserts both sides of the proxy did their job: the events reached
-the server and the recorder wrote them down.
-
-The `--capture` classes run against vncev (auth None) and against
-tigervnc-auth, so the challenge/response scrub is proven against a real
-server's byte stream, not only the scripted bytes in tests/unit/test_capture.py.
-"""
+"""The `vnclog` recording proxy, driven end to end as a subprocess."""
 
 import json
 import select
@@ -46,9 +37,8 @@ def _await_capture(archive: Path) -> zipfile.ZipFile:
 def _start_vnclog(listen_port: int, server: str, capture_path: Path) -> subprocess.Popen:
     """Start `vnclog --capture-raw`, waiting until it is actually listening.
 
-    Readiness comes from vnclog's stderr, never a port probe: in capture
-    mode the probe can race the forwarded greeting into looking like a real
-    session, claim the capture, and get the actual client refused.
+    Readiness comes from vnclog's stderr, never a port probe: the probe can
+    race the forwarded greeting into looking like a real session.
     """
     proxy = subprocess.Popen(
         [
@@ -150,12 +140,7 @@ class TestVnclogProxy(TestCase):
 
 
 class TestVnclogCapture(TestCase):
-    """`vnclog --capture-raw FILE.zip` end to end against vncev.
-
-    vncev speaks auth None, so this is the no-scrub path: the archive lands
-    with all four members and stays byte-identical when there is nothing to
-    redact.
-    """
+    """`vnclog --capture-raw FILE.zip` against vncev, which uses auth None."""
 
     def setUp(self) -> None:
         if not port_open(HOST, VNCEV.port):
@@ -220,8 +205,8 @@ class TestVnclogCapture(TestCase):
         self.assertIn("already exists", second.stderr.lower())
 
 
-class TestVnclogCaptureVncAuth(TestCase):
-    """`vnclog --capture-raw FILE.zip` against tigervnc-auth (VNC password auth).
+class TestVnclogCaptureVNCAuth(TestCase):
+    """`vnclog --capture-raw FILE.zip` against tigervnc-auth.
 
     The unit tests scrub a scripted challenge/response; only a live run
     proves it against tigervnc's real handshake.
@@ -271,7 +256,7 @@ class TestVnclogCaptureVncAuth(TestCase):
         # version reply, 1-byte security type, then the 16 bytes that must
         # have been zeroed.
         self.assertEqual(c2s[13:29], bytes(16), f"auth response was not scrubbed: {c2s[:32]!r}")
-        self.assertIsNone(meta["unscrubbed_auth"])
+        self.assertIsNone(meta.get("unscrubbable_auth"))
 
         self.assertIn("keydown z", session_vdo, f"vnclog recorded:\n{session_vdo!r}")
         self.assertIn("keyup z", session_vdo, f"vnclog recorded:\n{session_vdo!r}")

--- a/tests/functional/test_proxy.py
+++ b/tests/functional/test_proxy.py
@@ -248,9 +248,10 @@ class TestVnclogCaptureVNCAuth(TestCase):
             len(c2s), HANDSHAKE_ONLY, f"c2s.bin looks truncated at the handshake: {len(c2s)} bytes: {c2s!r}"
         )
 
-        # the real password must not appear anywhere in the clear
-        self.assertNotIn(TIGERVNC_AUTH.password.encode(), s2c)
-        self.assertNotIn(TIGERVNC_AUTH.password.encode(), c2s)
+        # The challenge sits at a fixed offset too: 12-byte greeting, the
+        # count of security types, the one type on offer, then the 16 bytes
+        # that must have been zeroed.
+        self.assertEqual(s2c[14:30], bytes(16), f"auth challenge was not scrubbed: {s2c[:32]!r}")
 
         # The response sits at a fixed offset on the 3.8 path: 12-byte
         # version reply, 1-byte security type, then the 16 bytes that must

--- a/tests/servers/x11vnc-entrypoint.sh
+++ b/tests/servers/x11vnc-entrypoint.sh
@@ -19,4 +19,10 @@ DISPLAY=:0 /draw-content.sh &
     DISPLAY=:0 xev -root
 ) 2>&1 | sed -u 's/^/xev: /' &
 
+# x11vnc exits 1 if the display isn't up yet, and Xvfb needs a moment.
+for _ in $(seq 1 30); do
+    DISPLAY=:0 xdpyinfo >/dev/null 2>&1 && break
+    sleep 0.5
+done
+
 exec x11vnc -display :0 -forever -shared -nopw -rfbport 5900 -quiet

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -1,0 +1,511 @@
+"""Unit coverage for the vnclog --capture kit.
+
+Drives HandshakeScrubber/CaptureWriter directly, and the two proxy protocol
+classes through a scripted handshake on mocked transports, so both raw
+streams and the challenge/response scrub are covered without a reactor.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from unittest import TestCase, mock
+
+from vncdotool.capture import CaptureWriter, HandshakeScrubber, check_capture_dir, scrub_password, write_meta
+from vncdotool.const import AuthTypes
+from vncdotool.loggingproxy import VNCLoggingClientProxy, VNCLoggingServerProxy
+
+VERSION_33 = b"RFB 003.003\n"
+VERSION_38 = b"RFB 003.008\n"
+CHALLENGE = bytes(range(16))
+RESPONSE = bytes(range(200, 216))
+MARKER = b"\x00" * 16
+SECURITY_RESULT_OK = b"\x00\x00\x00\x00"
+SERVER_INIT_640x480 = (
+    b"\x02\x80\x01\xe0"  # width=640, height=480
+    b"\x20\x18\x00\x01\x00\xff\x00\xff\x00\xff\x00\x08\x10\x00\x00\x00"  # pixel-format
+    b"\x00\x00\x00\x00"  # name-len=0
+)
+
+
+class TestHandshakeScrubber(TestCase):
+    def test_vnc_auth_scrubbed_pre37(self) -> None:
+        s = HandshakeScrubber()
+        self.assertEqual(s.feed("s2c", VERSION_33), VERSION_33)
+        self.assertEqual(s.feed("c2s", VERSION_33), VERSION_33)
+        auth_announce = b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION])
+        self.assertEqual(s.feed("s2c", auth_announce), auth_announce)
+        self.assertEqual(s.feed("s2c", CHALLENGE), MARKER)
+        self.assertEqual(s.feed("c2s", RESPONSE), MARKER)
+
+        self.assertEqual(s.scrubbed, ["vnc-auth-challenge", "vnc-auth-response"])
+        self.assertEqual(s.security_type, AuthTypes.VNC_AUTHENTICATION)
+        self.assertEqual(s.protocol_version, "RFB 003.003")
+        self.assertEqual(s.security_types, [AuthTypes.VNC_AUTHENTICATION])
+        self.assertIsNone(s.unscrubbed_auth)
+
+        # the security-result that follows is still passed through untouched
+        self.assertEqual(s.feed("s2c", SECURITY_RESULT_OK), SECURITY_RESULT_OK)
+
+    def test_vnc_auth_scrubbed_negotiated(self) -> None:
+        s = HandshakeScrubber()
+        s.feed("s2c", VERSION_38)
+        s.feed("c2s", VERSION_38)
+        # server offers None + VNC auth, client picks VNC auth
+        self.assertEqual(
+            s.feed("s2c", bytes([2, AuthTypes.NONE, AuthTypes.VNC_AUTHENTICATION])),
+            bytes([2, AuthTypes.NONE, AuthTypes.VNC_AUTHENTICATION]),
+        )
+        self.assertEqual(s.feed("c2s", bytes([AuthTypes.VNC_AUTHENTICATION])), bytes([AuthTypes.VNC_AUTHENTICATION]))
+        self.assertEqual(s.feed("s2c", CHALLENGE), MARKER)
+        self.assertEqual(s.feed("c2s", RESPONSE), MARKER)
+        self.assertEqual(s.scrubbed, ["vnc-auth-challenge", "vnc-auth-response"])
+        self.assertEqual(s.security_types, [AuthTypes.NONE, AuthTypes.VNC_AUTHENTICATION])
+
+    def test_version_downgrade_still_finds_vnc_auth(self) -> None:
+        """A 3.3 reply to a 3.8 greeting puts the exchange on the pre-3.7
+        direct-auth path. The scrubber must take the same branch or it
+        watches the wrong 16 bytes and lets the real ones through.
+        """
+        s = HandshakeScrubber()
+        s.feed("s2c", VERSION_38)  # server greets 3.8
+        s.feed("c2s", VERSION_33)  # client downgrades to 3.3
+        self.assertEqual(s.negotiated_version, (3, 3))
+
+        # pre-3.7 path: a direct 4-byte auth type announcement, no
+        # client-side security-type selection byte.
+        auth_announce = b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION])
+        self.assertEqual(s.feed("s2c", auth_announce), auth_announce)
+        self.assertEqual(s.feed("s2c", CHALLENGE), MARKER)
+        self.assertEqual(s.feed("c2s", RESPONSE), MARKER)
+
+        self.assertEqual(s.scrubbed, ["vnc-auth-challenge", "vnc-auth-response"])
+        self.assertEqual(s.security_type, AuthTypes.VNC_AUTHENTICATION)
+
+    def test_downgrade_the_other_way_is_also_followed(self) -> None:
+        """A malformed client claiming 3.8 against a 3.3 greeting: track
+        what is on the wire rather than assume either side behaves.
+        """
+        s = HandshakeScrubber()
+        s.feed("s2c", VERSION_33)
+        s.feed("c2s", VERSION_38)
+        self.assertEqual(s.negotiated_version, (3, 8))
+
+        self.assertEqual(s.feed("s2c", bytes([1, AuthTypes.VNC_AUTHENTICATION])), bytes([1, AuthTypes.VNC_AUTHENTICATION]))
+        self.assertEqual(s.feed("c2s", bytes([AuthTypes.VNC_AUTHENTICATION])), bytes([AuthTypes.VNC_AUTHENTICATION]))
+        self.assertEqual(s.feed("s2c", CHALLENGE), MARKER)
+        self.assertEqual(s.feed("c2s", RESPONSE), MARKER)
+        self.assertEqual(s.scrubbed, ["vnc-auth-challenge", "vnc-auth-response"])
+
+    def test_auth_none_untouched(self) -> None:
+        s = HandshakeScrubber()
+        s.feed("s2c", VERSION_38)
+        s.feed("c2s", VERSION_38)
+        s.feed("s2c", bytes([1, AuthTypes.NONE]))
+        out = s.feed("c2s", bytes([AuthTypes.NONE]))
+        self.assertEqual(out, bytes([AuthTypes.NONE]))
+        self.assertEqual(s.scrubbed, [])
+        self.assertEqual(s.security_type, AuthTypes.NONE)
+        self.assertIsNone(s.unscrubbed_auth)
+
+        # security-result(4) + ClientInit(1) + ServerInit(24), still passthrough
+        self.assertEqual(s.feed("s2c", SECURITY_RESULT_OK), SECURITY_RESULT_OK)
+        self.assertEqual(s.feed("c2s", b"\x01"), b"\x01")
+        self.assertEqual(s.feed("s2c", SERVER_INIT_640x480), SERVER_INIT_640x480)
+        self.assertEqual(s.width, 640)
+        self.assertEqual(s.height, 480)
+
+        rest = b"some-server-name-bytes"
+        self.assertEqual(s.feed("s2c", rest), rest)
+
+    def test_unscrubbed_auth_type_is_named(self) -> None:
+        """ARD's key exchange passes through verbatim, so it has to be named
+        rather than leave `scrubbed` empty and read as "nothing sensitive".
+        """
+        s = HandshakeScrubber()
+        s.feed("s2c", VERSION_38)
+        s.feed("c2s", VERSION_38)
+        s.feed("s2c", bytes([1, AuthTypes.DIFFIE_HELLMAN]))
+        s.feed("c2s", bytes([AuthTypes.DIFFIE_HELLMAN]))
+
+        self.assertEqual(s.scrubbed, [])
+        self.assertEqual(s.security_type, AuthTypes.DIFFIE_HELLMAN)
+        self.assertIsNotNone(s.unscrubbed_auth)
+        self.assertIn("diffie-hellman", s.unscrubbed_auth)
+        self.assertIn("30", s.unscrubbed_auth)
+
+        # the DH key material is NOT redacted -- passes straight through
+        dh_params = b"\x00\x02\x00\x08" + b"P" * 8 + b"G" * 8
+        self.assertEqual(s.feed("s2c", dh_params), dh_params)
+
+    def test_split_across_chunks(self) -> None:
+        s = HandshakeScrubber()
+        self.assertEqual(s.feed("s2c", b"RFB 003."), b"")
+        self.assertEqual(s.feed("s2c", b"003\n"), VERSION_33)
+
+    def test_split_challenge_across_chunks(self) -> None:
+        s = HandshakeScrubber()
+        s.feed("s2c", VERSION_33)
+        s.feed("c2s", VERSION_33)
+        s.feed("s2c", b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION]))
+        first = s.feed("s2c", CHALLENGE[:6])
+        second = s.feed("s2c", CHALLENGE[6:])
+        self.assertEqual(first, b"")
+        self.assertEqual(second, MARKER)
+        self.assertEqual(s.scrubbed, ["vnc-auth-challenge"])
+
+    def test_flush_drops_partial_secret(self) -> None:
+        s = HandshakeScrubber()
+        s.feed("s2c", VERSION_33)
+        s.feed("c2s", VERSION_33)
+        s.feed("s2c", b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION]))
+        s.feed("s2c", CHALLENGE[:6])  # connection drops mid-challenge
+
+        pending = s.flush()
+        self.assertEqual(pending["s2c"], b"", "a half-collected secret must never be flushed in the clear")
+        self.assertEqual(pending["c2s"], b"")
+
+    def test_flush_emits_pending_non_secret(self) -> None:
+        s = HandshakeScrubber()
+        s.feed("s2c", VERSION_33)
+        s.feed("c2s", VERSION_33)
+        s.feed("s2c", b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION]))
+        s.feed("s2c", CHALLENGE)
+        s.feed("c2s", RESPONSE)
+        s.feed("s2c", SECURITY_RESULT_OK[:2])  # connection drops mid-result, not a secret
+
+        pending = s.flush()
+        self.assertEqual(pending["s2c"], SECURITY_RESULT_OK[:2])
+        self.assertEqual(pending["c2s"], b"")
+
+
+class TestScrubPassword(TestCase):
+    def test_redacts_password_bytes(self) -> None:
+        out, hit = scrub_password(b"xxsecretxx", b"secret")
+        self.assertTrue(hit)
+        self.assertEqual(out, b"xx" + b"\x00" * 6 + b"xx")
+
+    def test_no_password_configured(self) -> None:
+        out, hit = scrub_password(b"whatever", None)
+        self.assertFalse(hit)
+        self.assertEqual(out, b"whatever")
+
+    def test_password_not_present(self) -> None:
+        out, hit = scrub_password(b"whatever", b"missing")
+        self.assertFalse(hit)
+        self.assertEqual(out, b"whatever")
+
+
+class TestCheckCaptureDir(TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+
+    def test_does_not_create_missing_dir(self) -> None:
+        """Validation only: creating the directory is the CLI's job."""
+        target = os.path.join(self.tmp, "capture")
+        check_capture_dir(target)  # must not raise
+        self.assertFalse(os.path.exists(target))
+
+    def test_accepts_existing_empty_dir(self) -> None:
+        target = os.path.join(self.tmp, "capture")
+        os.makedirs(target)
+        check_capture_dir(target)  # must not raise
+
+    def test_refuses_nonempty_dir(self) -> None:
+        target = os.path.join(self.tmp, "capture")
+        os.makedirs(target)
+        with open(os.path.join(target, "stray.txt"), "w") as fh:
+            fh.write("x")
+        with self.assertRaises(ValueError):
+            check_capture_dir(target)
+
+    def test_refuses_non_directory(self) -> None:
+        target = os.path.join(self.tmp, "notadir")
+        with open(target, "w") as fh:
+            fh.write("x")
+        with self.assertRaises(ValueError):
+            check_capture_dir(target)
+
+
+class TestCaptureWriter(TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+
+    def test_meta_and_write_vnc_auth(self) -> None:
+        cw = CaptureWriter(server="host::5900", password=None)
+        cw.feed_s2c(VERSION_33)
+        cw.feed_c2s(VERSION_33)
+        cw.feed_s2c(b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION]))
+        cw.feed_s2c(CHALLENGE)
+        cw.feed_c2s(RESPONSE)
+        cw.feed_s2c(SECURITY_RESULT_OK)
+        cw.feed_c2s(b"\x01")
+        cw.feed_s2c(SERVER_INIT_640x480)
+
+        expected_s2c = (
+            VERSION_33
+            + b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION])
+            + MARKER
+            + SECURITY_RESULT_OK
+            + SERVER_INIT_640x480
+        )
+        self.assertEqual(bytes(cw.s2c), expected_s2c)
+        self.assertEqual(bytes(cw.c2s), VERSION_33 + MARKER + b"\x01")
+        self.assertEqual(cw.scrubbed_list(), ["vnc-auth-challenge", "vnc-auth-response"])
+
+        cw.write(self.tmp)
+        write_meta(os.path.join(self.tmp, "meta.json"), cw.meta("9.9.9"))
+
+        with open(os.path.join(self.tmp, "s2c.bin"), "rb") as fh:
+            self.assertEqual(fh.read(), bytes(cw.s2c))
+        with open(os.path.join(self.tmp, "c2s.bin"), "rb") as fh:
+            self.assertEqual(fh.read(), bytes(cw.c2s))
+
+        with open(os.path.join(self.tmp, "meta.json")) as fh:
+            meta = json.load(fh)
+        self.assertEqual(meta["server"], "host::5900")
+        self.assertEqual(meta["vncdotool_version"], "9.9.9")
+        self.assertEqual(meta["protocol_version"], "RFB 003.003")
+        self.assertEqual(meta["security_types"], [AuthTypes.VNC_AUTHENTICATION])
+        self.assertEqual(meta["scrubbed"], ["vnc-auth-challenge", "vnc-auth-response"])
+        self.assertIsNone(meta["unscrubbed_auth"])
+        self.assertEqual(meta["geometry"], {"width": 640, "height": 480})
+        self.assertIn("capture_timestamp", meta)
+
+    def test_auth_none_session_untouched_and_unscrubbed(self) -> None:
+        cw = CaptureWriter(server="host::5900", password=None)
+        cw.feed_s2c(VERSION_38)
+        cw.feed_c2s(VERSION_38)
+        cw.feed_s2c(bytes([1, AuthTypes.NONE]))
+        cw.feed_c2s(bytes([AuthTypes.NONE]))
+        cw.feed_s2c(SECURITY_RESULT_OK)
+        cw.feed_c2s(b"\x01")
+        cw.feed_s2c(SERVER_INIT_640x480)
+
+        self.assertEqual(
+            bytes(cw.s2c),
+            VERSION_38 + bytes([1, AuthTypes.NONE]) + SECURITY_RESULT_OK + SERVER_INIT_640x480,
+        )
+        self.assertEqual(bytes(cw.c2s), VERSION_38 + bytes([AuthTypes.NONE]) + b"\x01")
+        self.assertEqual(cw.scrubbed_list(), [])
+
+        cw.write(self.tmp)
+        write_meta(os.path.join(self.tmp, "meta.json"), cw.meta("9.9.9"))
+        with open(os.path.join(self.tmp, "meta.json")) as fh:
+            meta = json.load(fh)
+        self.assertEqual(meta["scrubbed"], [])
+        self.assertEqual(meta["security_types"], [AuthTypes.NONE])
+        self.assertIsNone(meta["unscrubbed_auth"])
+        self.assertEqual(meta["geometry"], {"width": 640, "height": 480})
+
+    def test_unscrubbed_auth_recorded_in_meta(self) -> None:
+        cw = CaptureWriter(server="host::5900", password=None)
+        cw.feed_s2c(VERSION_38)
+        cw.feed_c2s(VERSION_38)
+        cw.feed_s2c(bytes([1, AuthTypes.DIFFIE_HELLMAN]))
+        cw.feed_c2s(bytes([AuthTypes.DIFFIE_HELLMAN]))
+
+        meta = cw.meta("9.9.9")
+        self.assertEqual(meta["scrubbed"], [])
+        self.assertIsNotNone(meta["unscrubbed_auth"])
+        self.assertIn("diffie-hellman", meta["unscrubbed_auth"])
+
+    def test_password_bytes_scrubbed_when_present(self) -> None:
+        cw = CaptureWriter(server="host::5900", password=b"hunter2")
+        cw.feed_c2s(b"clientcuttext-hunter2-trailing")
+        self.assertEqual(bytes(cw.c2s), b"clientcuttext-" + b"\x00" * 7 + b"-trailing")
+        self.assertEqual(cw.scrubbed_list(), ["password"])
+
+    def test_write_flushes_pending_non_secret_but_drops_partial_secret(self) -> None:
+        cw = CaptureWriter(server="host::5900", password=None)
+        cw.feed_s2c(VERSION_33)
+        cw.feed_c2s(VERSION_33)
+        cw.feed_s2c(b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION]))
+        cw.feed_s2c(CHALLENGE[:6])  # client vanishes mid-challenge
+
+        cw.write(self.tmp)  # simulates connectionLost firing right now
+
+        with open(os.path.join(self.tmp, "s2c.bin"), "rb") as fh:
+            s2c = fh.read()
+        # the 6 partial challenge bytes must never land on disk
+        self.assertNotIn(CHALLENGE[:6], s2c)
+        self.assertEqual(s2c, VERSION_33 + b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION]))
+
+
+class TestProxyCaptureWiring(TestCase):
+    """Drive both proxy halves directly, with mocked transports standing in
+    for the peer connections portforward would otherwise wire up.
+    """
+
+    def setUp(self) -> None:
+        self.server_proxy = VNCLoggingServerProxy()
+        self.server_proxy.transport = mock.Mock()
+        self.server_proxy.buffer = bytearray()
+        self.server_proxy._handler = (self.server_proxy._handle_version, 12)
+        self.server_proxy.recorder = mock.Mock()
+
+        self.client_proxy = VNCLoggingClientProxy()
+        self.client_proxy.transport = mock.Mock()
+        # startLogging drags in the whole VNCDoToolClient/recorder machinery,
+        # which is exercised elsewhere (test_client.py); stub it out here so
+        # this test stays focused on the capture tap.
+        self.client_proxy.startLogging = mock.Mock()  # type: ignore[method-assign]
+
+        self.server_proxy.peer = self.client_proxy
+        self.client_proxy.peer = self.server_proxy
+
+        factory = mock.Mock()
+        factory.password_required = True  # matches the RFB 3.3 script below
+        self.server_proxy.factory = factory
+
+        self.server_proxy.capture = CaptureWriter(server="testhost::5900", password=None)
+
+    def test_vnc_auth_challenge_and_response_scrubbed_both_directions(self) -> None:
+        sp, cp = self.server_proxy, self.client_proxy
+
+        cp.dataReceived(VERSION_33)  # server's greeting, relayed to the real client
+        sp.dataReceived(VERSION_33)  # real client's version reply
+        cp.dataReceived(b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION]))
+        cp.dataReceived(CHALLENGE)
+        sp.dataReceived(RESPONSE)  # RFBServer's password_required/3.3 path expects exactly this
+        cp.dataReceived(b"\x00\x00\x00\x00")  # auth OK
+        sp.dataReceived(b"\x01")  # clientInit shared=1
+
+        expected_s2c = VERSION_33 + b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION]) + MARKER + b"\x00\x00\x00\x00"
+        expected_c2s = VERSION_33 + MARKER + b"\x01"
+        self.assertEqual(bytes(sp.capture.s2c), expected_s2c)
+        self.assertEqual(bytes(sp.capture.c2s), expected_c2s)
+        self.assertEqual(sp.capture.scrubbed_list(), ["vnc-auth-challenge", "vnc-auth-response"])
+
+        # Unscrubbed bytes still reach the peer transports: capture must
+        # never mutate what the proxy forwards.
+        sp.transport.write.assert_any_call(VERSION_33)
+        cp.transport.write.assert_any_call(RESPONSE)
+
+        # the client-init handoff still happened
+        cp.startLogging.assert_called_once_with(sp)
+
+    def test_no_capture_configured_is_a_no_op(self) -> None:
+        sp, cp = self.server_proxy, self.client_proxy
+        sp.capture = None
+
+        # should not raise even though nothing is listening for bytes
+        cp.dataReceived(VERSION_33)
+        sp.dataReceived(VERSION_33)
+
+    def test_vnc_auth_over_negotiated_security_does_not_desync_rfbserver(self) -> None:
+        """_handle_security used to jump from the security-type selection
+        straight to ClientInit without skipping the 16-byte VNC-auth
+        response, desyncing everything after it. Asserts the fix: ClientInit
+        is reached cleanly and startLogging fires.
+        """
+        sp, cp = self.server_proxy, self.client_proxy
+        sp.factory.password_required = False  # force the 3.7+ security-byte path
+
+        cp.dataReceived(VERSION_38)
+        sp.dataReceived(VERSION_38)
+        cp.dataReceived(bytes([1, AuthTypes.VNC_AUTHENTICATION]))
+        sp.dataReceived(bytes([AuthTypes.VNC_AUTHENTICATION]))
+        cp.dataReceived(CHALLENGE)
+        sp.dataReceived(RESPONSE)  # now correctly consumed as the auth response, not `shared`
+        cp.dataReceived(b"\x00\x00\x00\x00")  # security result OK
+        sp.dataReceived(b"\x01")  # ClientInit: shared=1, reached cleanly this time
+
+        expected_c2s = VERSION_38 + bytes([AuthTypes.VNC_AUTHENTICATION]) + MARKER + b"\x01"
+        self.assertEqual(bytes(sp.capture.c2s), expected_c2s)
+        expected_s2c = VERSION_38 + bytes([1, AuthTypes.VNC_AUTHENTICATION]) + MARKER + b"\x00\x00\x00\x00"
+        self.assertEqual(bytes(sp.capture.s2c), expected_s2c)
+        self.assertEqual(sp.capture.scrubbed_list(), ["vnc-auth-challenge", "vnc-auth-response"])
+
+        # ClientInit was reached (not desynced into _handle_protocol on the
+        # response bytes), so the client-init handoff fired normally.
+        cp.startLogging.assert_called_once_with(sp)
+
+    def test_capture_survives_a_parser_that_raises(self) -> None:
+        """The tap must not depend on RFBServer's semantic parser: an
+        unknown ptype raises ProtocolError, and capture and forwarding both
+        have to survive it.
+        """
+        sp, cp = self.server_proxy, self.client_proxy
+        sp.factory.password_required = False
+
+        cp.dataReceived(VERSION_38)
+        sp.dataReceived(VERSION_38)
+        cp.dataReceived(bytes([1, AuthTypes.NONE]))
+        sp.dataReceived(bytes([AuthTypes.NONE]))
+        sp.dataReceived(b"\x01")  # ClientInit: shared=1
+
+        garbage = bytes([250])  # not a recognised MsgC2S value
+        sp.dataReceived(garbage)  # RFBServer._handle_protocol raises ProtocolError(250) here
+
+        expected_c2s = VERSION_38 + bytes([AuthTypes.NONE]) + b"\x01" + garbage
+        self.assertEqual(bytes(sp.capture.c2s), expected_c2s)
+
+        # forwarding still happened despite the parser raising
+        cp.transport.write.assert_any_call(garbage)
+
+    def test_second_connection_refused_when_capture_already_claimed(self) -> None:
+        """One session per directory: a second connection is refused rather
+        than clobbering the capture, without reaching connectionMade's
+        reactor.connectTCP half.
+        """
+        factory = mock.Mock()
+        factory.capture_dir = "/tmp/some-capture-dir"
+        factory.capture_claimed = True
+
+        sp = VNCLoggingServerProxy()
+        sp.factory = factory
+        sp.transport = mock.Mock()
+        sp.transport.getPeer.return_value = mock.Mock(host="10.0.0.5")
+
+        sp.connectionMade()
+
+        sp.transport.loseConnection.assert_called_once()
+        self.assertIsNone(sp.capture)
+        factory.getRecorder.assert_not_called()
+
+    def test_empty_connection_does_not_permanently_claim_capture(self) -> None:
+        """A bare TCP probe must not lock out the real connection behind it.
+        Found live: the functional suite's own port-polling startup wait was
+        claiming the capture before vncdo ever connected.
+        """
+        factory = mock.Mock()
+        factory.capture_dir = "/tmp/some-capture-dir"
+        factory.capture_claimed = True  # what connectionMade would have set
+
+        probe = VNCLoggingServerProxy()
+        probe.factory = factory
+        probe.capture = CaptureWriter(server="testhost::5900", password=None)  # never fed any bytes
+
+        probe.connectionLost(mock.Mock())
+
+        self.assertFalse(factory.capture_claimed)
+        self.assertIsNone(probe.capture)
+
+    def test_greeting_only_session_is_still_written(self) -> None:
+        """A server rejecting the client before it speaks (TigerVNC's "Too
+        many security failures" is greeting + reason + close) is a real
+        session: the s2c-only capture is written, not discarded as a probe.
+        """
+        capture_dir = tempfile.mkdtemp()
+        factory = mock.Mock()
+        factory.capture_dir = capture_dir
+        factory.capture_claimed = True
+
+        session = VNCLoggingServerProxy()
+        session.factory = factory
+        session.capture = CaptureWriter(server="testhost::5900", password=None)
+        session.capture.feed_s2c(b"RFB 003.003\n")  # greeting arrived; client never got a byte through
+
+        session.connectionLost(mock.Mock())
+
+        self.assertTrue(factory.capture_claimed, "a real (if one-sided) session keeps the claim")
+        with open(os.path.join(capture_dir, "s2c.bin"), "rb") as fh:
+            self.assertEqual(fh.read(), b"RFB 003.003\n")
+        with open(os.path.join(capture_dir, "c2s.bin"), "rb") as fh:
+            self.assertEqual(fh.read(), b"")
+        self.assertTrue(os.path.exists(os.path.join(capture_dir, "meta.json")))

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -11,10 +11,19 @@ import json
 import os
 import shutil
 import tempfile
+import zipfile
+from struct import pack
 from unittest import TestCase, mock
 
-from vncdotool.capture import CaptureWriter, HandshakeScrubber, check_capture_dir, scrub_password, write_meta
-from vncdotool.const import AuthTypes
+from vncdotool.client import VNCDoToolClient
+from vncdotool.capture import (
+    ARD_CREDENTIALS_LEN,
+    CaptureWriter,
+    HandshakeScrubber,
+    check_capture_target,
+    scrub_password,
+)
+from vncdotool.const import AuthTypes, Encoding
 from vncdotool.loggingproxy import VNCLoggingClientProxy, VNCLoggingServerProxy
 
 VERSION_33 = b"RFB 003.003\n"
@@ -120,25 +129,74 @@ class TestHandshakeScrubber(TestCase):
         rest = b"some-server-name-bytes"
         self.assertEqual(s.feed("s2c", rest), rest)
 
-    def test_unscrubbed_auth_type_is_named(self) -> None:
-        """ARD's key exchange passes through verbatim, so it has to be named
-        rather than leave `scrubbed` empty and read as "nothing sensitive".
-        """
-        s = HandshakeScrubber()
+    def _ard_to_credentials(self, s: HandshakeScrubber, key_len: int = 8) -> None:
+        """Drive an ARD handshake up to the client's credential block."""
         s.feed("s2c", VERSION_38)
         s.feed("c2s", VERSION_38)
         s.feed("s2c", bytes([1, AuthTypes.DIFFIE_HELLMAN]))
         s.feed("c2s", bytes([AuthTypes.DIFFIE_HELLMAN]))
+        self.dh_params = b"\x00\x02" + key_len.to_bytes(2, "big")
+        self.modulus = b"P" * key_len
+        self.server_key = b"G" * key_len
 
-        self.assertEqual(s.scrubbed, [])
-        self.assertEqual(s.security_type, AuthTypes.DIFFIE_HELLMAN)
-        self.assertIsNotNone(s.unscrubbed_auth)
-        self.assertIn("diffie-hellman", s.unscrubbed_auth)
-        self.assertIn("30", s.unscrubbed_auth)
+    def test_ard_credentials_scrubbed_key_exchange_kept(self) -> None:
+        """The AES block carrying username+password goes; the DH values stay.
 
-        # the DH key material is NOT redacted -- passes straight through
-        dh_params = b"\x00\x02\x00\x08" + b"P" * 8 + b"G" * 8
-        self.assertEqual(s.feed("s2c", dh_params), dh_params)
+        Keeping the exchange is deliberate: ARD compatibility bugs live in
+        those values, and they are public by construction.
+        """
+        s = HandshakeScrubber()
+        self._ard_to_credentials(s)
+
+        self.assertEqual(s.feed("s2c", self.dh_params), self.dh_params)
+        self.assertEqual(s.feed("s2c", self.modulus), self.modulus)
+        self.assertEqual(s.feed("s2c", self.server_key), self.server_key)
+
+        credentials = bytes(range(256))[:ARD_CREDENTIALS_LEN]
+        client_key = b"Y" * 8
+        self.assertEqual(s.feed("c2s", credentials + client_key), bytes(ARD_CREDENTIALS_LEN) + client_key)
+
+        self.assertEqual(s.scrubbed, ["ard-credentials"])
+        self.assertIsNone(s.unscrubbed_auth)
+        self.assertIsNone(s.abort_reason)
+        self.assertEqual(s.feed("s2c", SECURITY_RESULT_OK), SECURITY_RESULT_OK)
+
+    def test_scrubbing_preserves_byte_offsets(self) -> None:
+        """A redaction that changed length would break replay of the capture."""
+        s = HandshakeScrubber()
+        self._ard_to_credentials(s)
+        s.feed("s2c", self.dh_params + self.modulus + self.server_key)
+
+        credentials = b"\xab" * ARD_CREDENTIALS_LEN
+        out = s.feed("c2s", credentials)
+        self.assertEqual(len(out), ARD_CREDENTIALS_LEN)
+        self.assertNotIn(b"\xab", out)
+
+    def test_unscrubbable_auth_aborts_by_default(self) -> None:
+        s = HandshakeScrubber()
+        s.feed("s2c", VERSION_38)
+        s.feed("c2s", VERSION_38)
+        s.feed("s2c", bytes([1, AuthTypes.TIGHT]))
+        s.feed("c2s", bytes([AuthTypes.TIGHT]))
+
+        self.assertIsNotNone(s.abort_reason)
+        self.assertIn("tight", s.abort_reason)
+        self.assertIn("--capture-unsafe-auth", s.abort_reason)
+        self.assertIn("tight", s.unscrubbed_auth)
+        self.assertIn("16", s.unscrubbed_auth)
+
+    def test_unscrubbable_auth_allowed_when_opted_in(self) -> None:
+        s = HandshakeScrubber(allow_unsafe_auth=True)
+        s.feed("s2c", VERSION_38)
+        s.feed("c2s", VERSION_38)
+        s.feed("s2c", bytes([1, AuthTypes.TIGHT]))
+        s.feed("c2s", bytes([AuthTypes.TIGHT]))
+
+        self.assertIsNone(s.abort_reason)
+        self.assertIn("tight", s.unscrubbed_auth)
+        # key exchange passes through verbatim -- that is what was opted into
+        exchange = b"\x01\x02\x03\x04"
+        self.assertEqual(s.feed("s2c", exchange), exchange)
 
     def test_split_across_chunks(self) -> None:
         s = HandshakeScrubber()
@@ -198,42 +256,45 @@ class TestScrubPassword(TestCase):
         self.assertEqual(out, b"whatever")
 
 
-class TestCheckCaptureDir(TestCase):
+class TestCheckCaptureTarget(TestCase):
     def setUp(self) -> None:
         self.tmp = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
 
-    def test_does_not_create_missing_dir(self) -> None:
-        """Validation only: creating the directory is the CLI's job."""
-        target = os.path.join(self.tmp, "capture")
-        check_capture_dir(target)  # must not raise
+    def test_accepts_missing_zip_and_creates_nothing(self) -> None:
+        """Validation only: the archive is written when the session ends."""
+        target = os.path.join(self.tmp, "capture.zip")
+        check_capture_target(target)  # must not raise
         self.assertFalse(os.path.exists(target))
 
-    def test_accepts_existing_empty_dir(self) -> None:
-        target = os.path.join(self.tmp, "capture")
-        os.makedirs(target)
-        check_capture_dir(target)  # must not raise
-
-    def test_refuses_nonempty_dir(self) -> None:
-        target = os.path.join(self.tmp, "capture")
-        os.makedirs(target)
-        with open(os.path.join(target, "stray.txt"), "w") as fh:
-            fh.write("x")
+    def test_refuses_non_zip_suffix(self) -> None:
         with self.assertRaises(ValueError):
-            check_capture_dir(target)
+            check_capture_target(os.path.join(self.tmp, "capture"))
 
-    def test_refuses_non_directory(self) -> None:
-        target = os.path.join(self.tmp, "notadir")
+    def test_refuses_existing_file(self) -> None:
+        target = os.path.join(self.tmp, "capture.zip")
         with open(target, "w") as fh:
             fh.write("x")
         with self.assertRaises(ValueError):
-            check_capture_dir(target)
+            check_capture_target(target)
+
+    def test_refuses_missing_parent_directory(self) -> None:
+        with self.assertRaises(ValueError):
+            check_capture_target(os.path.join(self.tmp, "nope", "capture.zip"))
 
 
 class TestCaptureWriter(TestCase):
     def setUp(self) -> None:
         self.tmp = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.archive = os.path.join(self.tmp, "capture.zip")
+
+    def read_archive(self, name: str) -> bytes:
+        with zipfile.ZipFile(self.archive) as zf:
+            return zf.read(name)
+
+    def read_meta(self) -> dict:
+        return json.loads(self.read_archive("meta.json"))
 
     def test_meta_and_write_vnc_auth(self) -> None:
         cw = CaptureWriter(server="host::5900", password=None)
@@ -257,16 +318,17 @@ class TestCaptureWriter(TestCase):
         self.assertEqual(bytes(cw.c2s), VERSION_33 + MARKER + b"\x01")
         self.assertEqual(cw.scrubbed_list(), ["vnc-auth-challenge", "vnc-auth-response"])
 
-        cw.write(self.tmp)
-        write_meta(os.path.join(self.tmp, "meta.json"), cw.meta("9.9.9"))
+        cw.write_archive(self.archive, cw.meta("9.9.9"), session_vdo=b"pause 0.1 key a\n")
 
-        with open(os.path.join(self.tmp, "s2c.bin"), "rb") as fh:
-            self.assertEqual(fh.read(), bytes(cw.s2c))
-        with open(os.path.join(self.tmp, "c2s.bin"), "rb") as fh:
-            self.assertEqual(fh.read(), bytes(cw.c2s))
+        with zipfile.ZipFile(self.archive) as zf:
+            self.assertEqual(
+                sorted(zf.namelist()), ["c2s.bin", "meta.json", "s2c.bin", "session.vdo"]
+            )
+        self.assertEqual(self.read_archive("s2c.bin"), bytes(cw.s2c))
+        self.assertEqual(self.read_archive("c2s.bin"), bytes(cw.c2s))
+        self.assertEqual(self.read_archive("session.vdo"), b"pause 0.1 key a\n")
 
-        with open(os.path.join(self.tmp, "meta.json")) as fh:
-            meta = json.load(fh)
+        meta = self.read_meta()
         self.assertEqual(meta["server"], "host::5900")
         self.assertEqual(meta["vncdotool_version"], "9.9.9")
         self.assertEqual(meta["protocol_version"], "RFB 003.003")
@@ -293,26 +355,56 @@ class TestCaptureWriter(TestCase):
         self.assertEqual(bytes(cw.c2s), VERSION_38 + bytes([AuthTypes.NONE]) + b"\x01")
         self.assertEqual(cw.scrubbed_list(), [])
 
-        cw.write(self.tmp)
-        write_meta(os.path.join(self.tmp, "meta.json"), cw.meta("9.9.9"))
-        with open(os.path.join(self.tmp, "meta.json")) as fh:
-            meta = json.load(fh)
+        cw.write_archive(self.archive, cw.meta("9.9.9"))
+        meta = self.read_meta()
         self.assertEqual(meta["scrubbed"], [])
         self.assertEqual(meta["security_types"], [AuthTypes.NONE])
         self.assertIsNone(meta["unscrubbed_auth"])
         self.assertEqual(meta["geometry"], {"width": 640, "height": 480})
 
-    def test_unscrubbed_auth_recorded_in_meta(self) -> None:
-        cw = CaptureWriter(server="host::5900", password=None)
+    def test_unscrubbed_auth_recorded_in_meta_when_opted_in(self) -> None:
+        cw = CaptureWriter(
+            server="host::5900",
+            password=None,
+            scrubber=HandshakeScrubber(allow_unsafe_auth=True),
+        )
         cw.feed_s2c(VERSION_38)
         cw.feed_c2s(VERSION_38)
-        cw.feed_s2c(bytes([1, AuthTypes.DIFFIE_HELLMAN]))
-        cw.feed_c2s(bytes([AuthTypes.DIFFIE_HELLMAN]))
+        cw.feed_s2c(bytes([1, AuthTypes.TIGHT]))
+        cw.feed_c2s(bytes([AuthTypes.TIGHT]))
 
         meta = cw.meta("9.9.9")
         self.assertEqual(meta["scrubbed"], [])
         self.assertIsNotNone(meta["unscrubbed_auth"])
-        self.assertIn("diffie-hellman", meta["unscrubbed_auth"])
+        self.assertIn("tight", meta["unscrubbed_auth"])
+        self.assertIsNone(cw.abort_reason)
+
+    def test_encodings_seen_recorded_in_meta(self) -> None:
+        """What the server actually sent, named where we know the name."""
+        cw = CaptureWriter(server="host::5900", password=None)
+        cw.note_encoding(Encoding.RAW)
+        cw.note_encoding(Encoding.RAW)
+        cw.note_encoding(Encoding.ZRLE)
+        cw.note_encoding(12345)  # a server sending something we do not know
+
+        self.assertEqual(
+            cw.meta("9.9.9")["encodings_seen"],
+            [
+                {"encoding": int(Encoding.RAW), "name": "raw", "rectangles": 2},
+                {"encoding": int(Encoding.ZRLE), "name": "zrle", "rectangles": 1},
+                {"encoding": 12345, "name": None, "rectangles": 1},
+            ],
+        )
+
+    def test_no_partial_archive_left_when_write_fails(self) -> None:
+        cw = CaptureWriter(server="host::5900", password=None)
+        cw.feed_s2c(VERSION_33)
+        with mock.patch("vncdotool.capture.json.dumps", side_effect=RuntimeError("boom")):
+            with self.assertRaises(RuntimeError):
+                cw.write_archive(self.archive, cw.meta("9.9.9"))
+
+        self.assertFalse(os.path.exists(self.archive))
+        self.assertFalse(os.path.exists(self.archive + ".part"))
 
     def test_password_bytes_scrubbed_when_present(self) -> None:
         cw = CaptureWriter(server="host::5900", password=b"hunter2")
@@ -327,10 +419,9 @@ class TestCaptureWriter(TestCase):
         cw.feed_s2c(b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION]))
         cw.feed_s2c(CHALLENGE[:6])  # client vanishes mid-challenge
 
-        cw.write(self.tmp)  # simulates connectionLost firing right now
+        cw.write_archive(self.archive, cw.meta("9.9.9"))  # connectionLost fires right now
 
-        with open(os.path.join(self.tmp, "s2c.bin"), "rb") as fh:
-            s2c = fh.read()
+        s2c = self.read_archive("s2c.bin")
         # the 6 partial challenge bytes must never land on disk
         self.assertNotIn(CHALLENGE[:6], s2c)
         self.assertEqual(s2c, VERSION_33 + b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION]))
@@ -425,6 +516,51 @@ class TestProxyCaptureWiring(TestCase):
         # response bytes), so the client-init handoff fired normally.
         cp.startLogging.assert_called_once_with(sp)
 
+    def test_unscrubbable_auth_aborts_and_writes_nothing(self) -> None:
+        """Chosen on the client side (3.7+), so it surfaces in the c2s tap."""
+        sp, cp = self.server_proxy, self.client_proxy
+        sp.factory.capture_path = os.path.join(tempfile.mkdtemp(), "capture.zip")
+        sp.factory.capture_claimed = True
+
+        cp.dataReceived(VERSION_38)
+        sp.dataReceived(VERSION_38)
+        cp.dataReceived(bytes([1, AuthTypes.TIGHT]))
+        sp.dataReceived(bytes([AuthTypes.TIGHT]))
+
+        self.assertIsNone(sp.capture, "the capture must be dropped, not written")
+        sp.transport.loseConnection.assert_called_once()
+        self.assertFalse(os.path.exists(sp.factory.capture_path))
+
+    def test_unscrubbable_auth_chosen_by_a_pre37_server_also_aborts(self) -> None:
+        """Pre-3.7 the server dictates the type, so the s2c tap has to catch it."""
+        sp, cp = self.server_proxy, self.client_proxy
+        sp.factory.capture_path = os.path.join(tempfile.mkdtemp(), "capture.zip")
+
+        cp.dataReceived(VERSION_33)
+        sp.dataReceived(VERSION_33)
+        cp.dataReceived(b"\x00\x00\x00" + bytes([AuthTypes.TIGHT]))
+
+        self.assertIsNone(sp.capture)
+        sp.transport.loseConnection.assert_called_once()
+        self.assertFalse(os.path.exists(sp.factory.capture_path))
+
+    def test_encodings_are_tallied_from_what_the_server_sent(self) -> None:
+        """Not from SetEncodings: a server may answer in anything it likes."""
+        from vncdotool.loggingproxy import VNCLoggingClient
+
+        capture = CaptureWriter(server="testhost::5900", password=None)
+        vnclog = VNCLoggingClient()
+        vnclog.capture = capture
+        # Stop after the tally; the decode path itself is test_client.py's job.
+        with mock.patch.object(VNCDoToolClient, "_handleRectangle"):
+            for encoding in (Encoding.ZRLE, Encoding.ZRLE, Encoding.HEXTILE):
+                vnclog._handleRectangle(pack("!HHHHi", 0, 0, 4, 4, int(encoding)))
+
+        self.assertEqual(
+            capture.encodings_seen,
+            {int(Encoding.ZRLE): 2, int(Encoding.HEXTILE): 1},
+        )
+
     def test_capture_survives_a_parser_that_raises(self) -> None:
         """The tap must not depend on RFBServer's semantic parser: an
         unknown ptype raises ProtocolError, and capture and forwarding both
@@ -454,7 +590,7 @@ class TestProxyCaptureWiring(TestCase):
         reactor.connectTCP half.
         """
         factory = mock.Mock()
-        factory.capture_dir = "/tmp/some-capture-dir"
+        factory.capture_path = "/tmp/some-capture.zip"
         factory.capture_claimed = True
 
         sp = VNCLoggingServerProxy()
@@ -474,7 +610,7 @@ class TestProxyCaptureWiring(TestCase):
         claiming the capture before vncdo ever connected.
         """
         factory = mock.Mock()
-        factory.capture_dir = "/tmp/some-capture-dir"
+        factory.capture_path = "/tmp/some-capture.zip"
         factory.capture_claimed = True  # what connectionMade would have set
 
         probe = VNCLoggingServerProxy()
@@ -491,10 +627,13 @@ class TestProxyCaptureWiring(TestCase):
         many security failures" is greeting + reason + close) is a real
         session: the s2c-only capture is written, not discarded as a probe.
         """
-        capture_dir = tempfile.mkdtemp()
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        archive = os.path.join(tmp, "capture.zip")
         factory = mock.Mock()
-        factory.capture_dir = capture_dir
+        factory.capture_path = archive
         factory.capture_claimed = True
+        factory.getRecordedSession.return_value = b""
 
         session = VNCLoggingServerProxy()
         session.factory = factory
@@ -504,8 +643,7 @@ class TestProxyCaptureWiring(TestCase):
         session.connectionLost(mock.Mock())
 
         self.assertTrue(factory.capture_claimed, "a real (if one-sided) session keeps the claim")
-        with open(os.path.join(capture_dir, "s2c.bin"), "rb") as fh:
-            self.assertEqual(fh.read(), b"RFB 003.003\n")
-        with open(os.path.join(capture_dir, "c2s.bin"), "rb") as fh:
-            self.assertEqual(fh.read(), b"")
-        self.assertTrue(os.path.exists(os.path.join(capture_dir, "meta.json")))
+        with zipfile.ZipFile(archive) as zf:
+            self.assertEqual(zf.read("s2c.bin"), b"RFB 003.003\n")
+            self.assertEqual(zf.read("c2s.bin"), b"")
+            self.assertIn("meta.json", zf.namelist())

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -1,4 +1,4 @@
-"""Unit coverage for the vnclog --capture kit.
+"""Unit coverage for the vnclog --capture-raw kit.
 
 Drives HandshakeScrubber/CaptureWriter directly, and the two proxy protocol
 classes through a scripted handshake on mocked transports, so both raw
@@ -21,7 +21,6 @@ from vncdotool.capture import (
     CaptureWriter,
     HandshakeScrubber,
     check_capture_target,
-    scrub_password,
 )
 from vncdotool.const import AuthTypes, Encoding
 from vncdotool.loggingproxy import VNCLoggingClientProxy, VNCLoggingServerProxy
@@ -49,7 +48,6 @@ class TestHandshakeScrubber(TestCase):
         self.assertEqual(s.feed("s2c", CHALLENGE), MARKER)
         self.assertEqual(s.feed("c2s", RESPONSE), MARKER)
 
-        self.assertEqual(s.scrubbed, ["vnc-auth-challenge", "vnc-auth-response"])
         self.assertEqual(s.security_type, AuthTypes.VNC_AUTHENTICATION)
         self.assertEqual(s.protocol_version, "RFB 003.003")
         self.assertEqual(s.security_types, [AuthTypes.VNC_AUTHENTICATION])
@@ -70,7 +68,6 @@ class TestHandshakeScrubber(TestCase):
         self.assertEqual(s.feed("c2s", bytes([AuthTypes.VNC_AUTHENTICATION])), bytes([AuthTypes.VNC_AUTHENTICATION]))
         self.assertEqual(s.feed("s2c", CHALLENGE), MARKER)
         self.assertEqual(s.feed("c2s", RESPONSE), MARKER)
-        self.assertEqual(s.scrubbed, ["vnc-auth-challenge", "vnc-auth-response"])
         self.assertEqual(s.security_types, [AuthTypes.NONE, AuthTypes.VNC_AUTHENTICATION])
 
     def test_version_downgrade_still_finds_vnc_auth(self) -> None:
@@ -90,7 +87,6 @@ class TestHandshakeScrubber(TestCase):
         self.assertEqual(s.feed("s2c", CHALLENGE), MARKER)
         self.assertEqual(s.feed("c2s", RESPONSE), MARKER)
 
-        self.assertEqual(s.scrubbed, ["vnc-auth-challenge", "vnc-auth-response"])
         self.assertEqual(s.security_type, AuthTypes.VNC_AUTHENTICATION)
 
     def test_downgrade_the_other_way_is_also_followed(self) -> None:
@@ -106,7 +102,6 @@ class TestHandshakeScrubber(TestCase):
         self.assertEqual(s.feed("c2s", bytes([AuthTypes.VNC_AUTHENTICATION])), bytes([AuthTypes.VNC_AUTHENTICATION]))
         self.assertEqual(s.feed("s2c", CHALLENGE), MARKER)
         self.assertEqual(s.feed("c2s", RESPONSE), MARKER)
-        self.assertEqual(s.scrubbed, ["vnc-auth-challenge", "vnc-auth-response"])
 
     def test_auth_none_untouched(self) -> None:
         s = HandshakeScrubber()
@@ -115,7 +110,6 @@ class TestHandshakeScrubber(TestCase):
         s.feed("s2c", bytes([1, AuthTypes.NONE]))
         out = s.feed("c2s", bytes([AuthTypes.NONE]))
         self.assertEqual(out, bytes([AuthTypes.NONE]))
-        self.assertEqual(s.scrubbed, [])
         self.assertEqual(s.security_type, AuthTypes.NONE)
         self.assertIsNone(s.unscrubbed_auth)
 
@@ -156,7 +150,6 @@ class TestHandshakeScrubber(TestCase):
         client_key = b"Y" * 8
         self.assertEqual(s.feed("c2s", credentials + client_key), bytes(ARD_CREDENTIALS_LEN) + client_key)
 
-        self.assertEqual(s.scrubbed, ["ard-credentials"])
         self.assertIsNone(s.unscrubbed_auth)
         self.assertIsNone(s.abort_reason)
         self.assertEqual(s.feed("s2c", SECURITY_RESULT_OK), SECURITY_RESULT_OK)
@@ -181,7 +174,7 @@ class TestHandshakeScrubber(TestCase):
 
         self.assertIsNotNone(s.abort_reason)
         self.assertIn("tight", s.abort_reason)
-        self.assertIn("--capture-unsafe-auth", s.abort_reason)
+        self.assertIn("--capture-raw-unsafe-auth", s.abort_reason)
         self.assertIn("tight", s.unscrubbed_auth)
         self.assertIn("16", s.unscrubbed_auth)
 
@@ -212,7 +205,6 @@ class TestHandshakeScrubber(TestCase):
         second = s.feed("s2c", CHALLENGE[6:])
         self.assertEqual(first, b"")
         self.assertEqual(second, MARKER)
-        self.assertEqual(s.scrubbed, ["vnc-auth-challenge"])
 
     def test_flush_drops_partial_secret(self) -> None:
         s = HandshakeScrubber()
@@ -237,23 +229,6 @@ class TestHandshakeScrubber(TestCase):
         pending = s.flush()
         self.assertEqual(pending["s2c"], SECURITY_RESULT_OK[:2])
         self.assertEqual(pending["c2s"], b"")
-
-
-class TestScrubPassword(TestCase):
-    def test_redacts_password_bytes(self) -> None:
-        out, hit = scrub_password(b"xxsecretxx", b"secret")
-        self.assertTrue(hit)
-        self.assertEqual(out, b"xx" + b"\x00" * 6 + b"xx")
-
-    def test_no_password_configured(self) -> None:
-        out, hit = scrub_password(b"whatever", None)
-        self.assertFalse(hit)
-        self.assertEqual(out, b"whatever")
-
-    def test_password_not_present(self) -> None:
-        out, hit = scrub_password(b"whatever", b"missing")
-        self.assertFalse(hit)
-        self.assertEqual(out, b"whatever")
 
 
 class TestCheckCaptureTarget(TestCase):
@@ -297,7 +272,7 @@ class TestCaptureWriter(TestCase):
         return json.loads(self.read_archive("meta.json"))
 
     def test_meta_and_write_vnc_auth(self) -> None:
-        cw = CaptureWriter(server="host::5900", password=None)
+        cw = CaptureWriter(server="host::5900")
         cw.feed_s2c(VERSION_33)
         cw.feed_c2s(VERSION_33)
         cw.feed_s2c(b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION]))
@@ -316,7 +291,6 @@ class TestCaptureWriter(TestCase):
         )
         self.assertEqual(bytes(cw.s2c), expected_s2c)
         self.assertEqual(bytes(cw.c2s), VERSION_33 + MARKER + b"\x01")
-        self.assertEqual(cw.scrubbed_list(), ["vnc-auth-challenge", "vnc-auth-response"])
 
         cw.write_archive(self.archive, cw.meta("9.9.9"), session_vdo=b"pause 0.1 key a\n")
 
@@ -333,13 +307,12 @@ class TestCaptureWriter(TestCase):
         self.assertEqual(meta["vncdotool_version"], "9.9.9")
         self.assertEqual(meta["protocol_version"], "RFB 003.003")
         self.assertEqual(meta["security_types"], [AuthTypes.VNC_AUTHENTICATION])
-        self.assertEqual(meta["scrubbed"], ["vnc-auth-challenge", "vnc-auth-response"])
         self.assertIsNone(meta["unscrubbed_auth"])
         self.assertEqual(meta["geometry"], {"width": 640, "height": 480})
         self.assertIn("capture_timestamp", meta)
 
     def test_auth_none_session_untouched_and_unscrubbed(self) -> None:
-        cw = CaptureWriter(server="host::5900", password=None)
+        cw = CaptureWriter(server="host::5900")
         cw.feed_s2c(VERSION_38)
         cw.feed_c2s(VERSION_38)
         cw.feed_s2c(bytes([1, AuthTypes.NONE]))
@@ -353,11 +326,9 @@ class TestCaptureWriter(TestCase):
             VERSION_38 + bytes([1, AuthTypes.NONE]) + SECURITY_RESULT_OK + SERVER_INIT_640x480,
         )
         self.assertEqual(bytes(cw.c2s), VERSION_38 + bytes([AuthTypes.NONE]) + b"\x01")
-        self.assertEqual(cw.scrubbed_list(), [])
 
         cw.write_archive(self.archive, cw.meta("9.9.9"))
         meta = self.read_meta()
-        self.assertEqual(meta["scrubbed"], [])
         self.assertEqual(meta["security_types"], [AuthTypes.NONE])
         self.assertIsNone(meta["unscrubbed_auth"])
         self.assertEqual(meta["geometry"], {"width": 640, "height": 480})
@@ -365,7 +336,6 @@ class TestCaptureWriter(TestCase):
     def test_unscrubbed_auth_recorded_in_meta_when_opted_in(self) -> None:
         cw = CaptureWriter(
             server="host::5900",
-            password=None,
             scrubber=HandshakeScrubber(allow_unsafe_auth=True),
         )
         cw.feed_s2c(VERSION_38)
@@ -374,14 +344,13 @@ class TestCaptureWriter(TestCase):
         cw.feed_c2s(bytes([AuthTypes.TIGHT]))
 
         meta = cw.meta("9.9.9")
-        self.assertEqual(meta["scrubbed"], [])
         self.assertIsNotNone(meta["unscrubbed_auth"])
         self.assertIn("tight", meta["unscrubbed_auth"])
         self.assertIsNone(cw.abort_reason)
 
     def test_encodings_seen_recorded_in_meta(self) -> None:
         """What the server actually sent, named where we know the name."""
-        cw = CaptureWriter(server="host::5900", password=None)
+        cw = CaptureWriter(server="host::5900")
         cw.note_encoding(Encoding.RAW)
         cw.note_encoding(Encoding.RAW)
         cw.note_encoding(Encoding.ZRLE)
@@ -397,7 +366,7 @@ class TestCaptureWriter(TestCase):
         )
 
     def test_no_partial_archive_left_when_write_fails(self) -> None:
-        cw = CaptureWriter(server="host::5900", password=None)
+        cw = CaptureWriter(server="host::5900")
         cw.feed_s2c(VERSION_33)
         with mock.patch("vncdotool.capture.json.dumps", side_effect=RuntimeError("boom")):
             with self.assertRaises(RuntimeError):
@@ -406,14 +375,8 @@ class TestCaptureWriter(TestCase):
         self.assertFalse(os.path.exists(self.archive))
         self.assertFalse(os.path.exists(self.archive + ".part"))
 
-    def test_password_bytes_scrubbed_when_present(self) -> None:
-        cw = CaptureWriter(server="host::5900", password=b"hunter2")
-        cw.feed_c2s(b"clientcuttext-hunter2-trailing")
-        self.assertEqual(bytes(cw.c2s), b"clientcuttext-" + b"\x00" * 7 + b"-trailing")
-        self.assertEqual(cw.scrubbed_list(), ["password"])
-
     def test_write_flushes_pending_non_secret_but_drops_partial_secret(self) -> None:
-        cw = CaptureWriter(server="host::5900", password=None)
+        cw = CaptureWriter(server="host::5900")
         cw.feed_s2c(VERSION_33)
         cw.feed_c2s(VERSION_33)
         cw.feed_s2c(b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION]))
@@ -453,7 +416,7 @@ class TestProxyCaptureWiring(TestCase):
         factory.password_required = True  # matches the RFB 3.3 script below
         self.server_proxy.factory = factory
 
-        self.server_proxy.capture = CaptureWriter(server="testhost::5900", password=None)
+        self.server_proxy.capture = CaptureWriter(server="testhost::5900")
 
     def test_vnc_auth_challenge_and_response_scrubbed_both_directions(self) -> None:
         sp, cp = self.server_proxy, self.client_proxy
@@ -470,7 +433,6 @@ class TestProxyCaptureWiring(TestCase):
         expected_c2s = VERSION_33 + MARKER + b"\x01"
         self.assertEqual(bytes(sp.capture.s2c), expected_s2c)
         self.assertEqual(bytes(sp.capture.c2s), expected_c2s)
-        self.assertEqual(sp.capture.scrubbed_list(), ["vnc-auth-challenge", "vnc-auth-response"])
 
         # Unscrubbed bytes still reach the peer transports: capture must
         # never mutate what the proxy forwards.
@@ -510,7 +472,6 @@ class TestProxyCaptureWiring(TestCase):
         self.assertEqual(bytes(sp.capture.c2s), expected_c2s)
         expected_s2c = VERSION_38 + bytes([1, AuthTypes.VNC_AUTHENTICATION]) + MARKER + b"\x00\x00\x00\x00"
         self.assertEqual(bytes(sp.capture.s2c), expected_s2c)
-        self.assertEqual(sp.capture.scrubbed_list(), ["vnc-auth-challenge", "vnc-auth-response"])
 
         # ClientInit was reached (not desynced into _handle_protocol on the
         # response bytes), so the client-init handoff fired normally.
@@ -548,7 +509,7 @@ class TestProxyCaptureWiring(TestCase):
         """Not from SetEncodings: a server may answer in anything it likes."""
         from vncdotool.loggingproxy import VNCLoggingClient
 
-        capture = CaptureWriter(server="testhost::5900", password=None)
+        capture = CaptureWriter(server="testhost::5900")
         vnclog = VNCLoggingClient()
         vnclog.capture = capture
         # Stop after the tally; the decode path itself is test_client.py's job.
@@ -615,7 +576,7 @@ class TestProxyCaptureWiring(TestCase):
 
         probe = VNCLoggingServerProxy()
         probe.factory = factory
-        probe.capture = CaptureWriter(server="testhost::5900", password=None)  # never fed any bytes
+        probe.capture = CaptureWriter(server="testhost::5900")  # never fed any bytes
 
         probe.connectionLost(mock.Mock())
 
@@ -637,7 +598,7 @@ class TestProxyCaptureWiring(TestCase):
 
         session = VNCLoggingServerProxy()
         session.factory = factory
-        session.capture = CaptureWriter(server="testhost::5900", password=None)
+        session.capture = CaptureWriter(server="testhost::5900")
         session.capture.feed_s2c(b"RFB 003.003\n")  # greeting arrived; client never got a byte through
 
         session.connectionLost(mock.Mock())

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -43,12 +43,12 @@ SERVER_INIT_640x480 = (
 class TestHandshakeScrubber(TestCase):
     def test_vnc_auth_scrubbed_pre37(self) -> None:
         s = HandshakeScrubber()
-        self.assertEqual(s.feed("s2c", VERSION_33), VERSION_33)
-        self.assertEqual(s.feed("c2s", VERSION_33), VERSION_33)
+        self.assertEqual(s.s2c.feed(VERSION_33), VERSION_33)
+        self.assertEqual(s.c2s.feed(VERSION_33), VERSION_33)
         auth_announce = b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION])
-        self.assertEqual(s.feed("s2c", auth_announce), auth_announce)
-        self.assertEqual(s.feed("s2c", CHALLENGE), MARKER)
-        self.assertEqual(s.feed("c2s", RESPONSE), MARKER)
+        self.assertEqual(s.s2c.feed(auth_announce), auth_announce)
+        self.assertEqual(s.s2c.feed(CHALLENGE), MARKER)
+        self.assertEqual(s.c2s.feed(RESPONSE), MARKER)
 
         self.assertEqual(s.security_type, AuthTypes.VNC_AUTHENTICATION)
         self.assertEqual(s.protocol_version, "RFB 003.003")
@@ -56,20 +56,20 @@ class TestHandshakeScrubber(TestCase):
         self.assertIsNone(s.unscrubbable_auth)
 
         # the security-result that follows is still passed through untouched
-        self.assertEqual(s.feed("s2c", SECURITY_RESULT_OK), SECURITY_RESULT_OK)
+        self.assertEqual(s.s2c.feed(SECURITY_RESULT_OK), SECURITY_RESULT_OK)
 
     def test_vnc_auth_scrubbed_negotiated(self) -> None:
         s = HandshakeScrubber()
-        s.feed("s2c", VERSION_38)
-        s.feed("c2s", VERSION_38)
+        s.s2c.feed(VERSION_38)
+        s.c2s.feed(VERSION_38)
         # server offers None + VNC auth, client picks VNC auth
         self.assertEqual(
-            s.feed("s2c", bytes([2, AuthTypes.NONE, AuthTypes.VNC_AUTHENTICATION])),
+            s.s2c.feed(bytes([2, AuthTypes.NONE, AuthTypes.VNC_AUTHENTICATION])),
             bytes([2, AuthTypes.NONE, AuthTypes.VNC_AUTHENTICATION]),
         )
-        self.assertEqual(s.feed("c2s", bytes([AuthTypes.VNC_AUTHENTICATION])), bytes([AuthTypes.VNC_AUTHENTICATION]))
-        self.assertEqual(s.feed("s2c", CHALLENGE), MARKER)
-        self.assertEqual(s.feed("c2s", RESPONSE), MARKER)
+        self.assertEqual(s.c2s.feed(bytes([AuthTypes.VNC_AUTHENTICATION])), bytes([AuthTypes.VNC_AUTHENTICATION]))
+        self.assertEqual(s.s2c.feed(CHALLENGE), MARKER)
+        self.assertEqual(s.c2s.feed(RESPONSE), MARKER)
         self.assertEqual(s.security_types, [AuthTypes.NONE, AuthTypes.VNC_AUTHENTICATION])
 
     def test_version_downgrade_still_finds_vnc_auth(self) -> None:
@@ -78,16 +78,16 @@ class TestHandshakeScrubber(TestCase):
         watches the wrong 16 bytes and lets the real ones through.
         """
         s = HandshakeScrubber()
-        s.feed("s2c", VERSION_38)  # server greets 3.8
-        s.feed("c2s", VERSION_33)  # client downgrades to 3.3
+        s.s2c.feed(VERSION_38)  # server greets 3.8
+        s.c2s.feed(VERSION_33)  # client downgrades to 3.3
         self.assertEqual(s.negotiated_version, (3, 3))
 
         # pre-3.7 path: a direct 4-byte auth type announcement, no
         # client-side security-type selection byte.
         auth_announce = b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION])
-        self.assertEqual(s.feed("s2c", auth_announce), auth_announce)
-        self.assertEqual(s.feed("s2c", CHALLENGE), MARKER)
-        self.assertEqual(s.feed("c2s", RESPONSE), MARKER)
+        self.assertEqual(s.s2c.feed(auth_announce), auth_announce)
+        self.assertEqual(s.s2c.feed(CHALLENGE), MARKER)
+        self.assertEqual(s.c2s.feed(RESPONSE), MARKER)
 
         self.assertEqual(s.security_type, AuthTypes.VNC_AUTHENTICATION)
 
@@ -96,41 +96,41 @@ class TestHandshakeScrubber(TestCase):
         what is on the wire rather than assume either side behaves.
         """
         s = HandshakeScrubber()
-        s.feed("s2c", VERSION_33)
-        s.feed("c2s", VERSION_38)
+        s.s2c.feed(VERSION_33)
+        s.c2s.feed(VERSION_38)
         self.assertEqual(s.negotiated_version, (3, 8))
 
-        self.assertEqual(s.feed("s2c", bytes([1, AuthTypes.VNC_AUTHENTICATION])), bytes([1, AuthTypes.VNC_AUTHENTICATION]))
-        self.assertEqual(s.feed("c2s", bytes([AuthTypes.VNC_AUTHENTICATION])), bytes([AuthTypes.VNC_AUTHENTICATION]))
-        self.assertEqual(s.feed("s2c", CHALLENGE), MARKER)
-        self.assertEqual(s.feed("c2s", RESPONSE), MARKER)
+        self.assertEqual(s.s2c.feed(bytes([1, AuthTypes.VNC_AUTHENTICATION])), bytes([1, AuthTypes.VNC_AUTHENTICATION]))
+        self.assertEqual(s.c2s.feed(bytes([AuthTypes.VNC_AUTHENTICATION])), bytes([AuthTypes.VNC_AUTHENTICATION]))
+        self.assertEqual(s.s2c.feed(CHALLENGE), MARKER)
+        self.assertEqual(s.c2s.feed(RESPONSE), MARKER)
 
     def test_auth_none_untouched(self) -> None:
         s = HandshakeScrubber()
-        s.feed("s2c", VERSION_38)
-        s.feed("c2s", VERSION_38)
-        s.feed("s2c", bytes([1, AuthTypes.NONE]))
-        out = s.feed("c2s", bytes([AuthTypes.NONE]))
+        s.s2c.feed(VERSION_38)
+        s.c2s.feed(VERSION_38)
+        s.s2c.feed(bytes([1, AuthTypes.NONE]))
+        out = s.c2s.feed(bytes([AuthTypes.NONE]))
         self.assertEqual(out, bytes([AuthTypes.NONE]))
         self.assertEqual(s.security_type, AuthTypes.NONE)
         self.assertIsNone(s.unscrubbable_auth)
 
         # security-result(4) + ClientInit(1) + ServerInit(24), still passthrough
-        self.assertEqual(s.feed("s2c", SECURITY_RESULT_OK), SECURITY_RESULT_OK)
-        self.assertEqual(s.feed("c2s", b"\x01"), b"\x01")
-        self.assertEqual(s.feed("s2c", SERVER_INIT_640x480), SERVER_INIT_640x480)
+        self.assertEqual(s.s2c.feed(SECURITY_RESULT_OK), SECURITY_RESULT_OK)
+        self.assertEqual(s.c2s.feed(b"\x01"), b"\x01")
+        self.assertEqual(s.s2c.feed(SERVER_INIT_640x480), SERVER_INIT_640x480)
         self.assertEqual(s.width, 640)
         self.assertEqual(s.height, 480)
 
         rest = b"some-server-name-bytes"
-        self.assertEqual(s.feed("s2c", rest), rest)
+        self.assertEqual(s.s2c.feed(rest), rest)
 
     def _ard_to_credentials(self, s: HandshakeScrubber, key_len: int = 8) -> None:
         """Drive an ARD handshake up to the client's credential block."""
-        s.feed("s2c", VERSION_38)
-        s.feed("c2s", VERSION_38)
-        s.feed("s2c", bytes([1, AuthTypes.DIFFIE_HELLMAN]))
-        s.feed("c2s", bytes([AuthTypes.DIFFIE_HELLMAN]))
+        s.s2c.feed(VERSION_38)
+        s.c2s.feed(VERSION_38)
+        s.s2c.feed(bytes([1, AuthTypes.DIFFIE_HELLMAN]))
+        s.c2s.feed(bytes([AuthTypes.DIFFIE_HELLMAN]))
         self.dh_params = b"\x00\x02" + key_len.to_bytes(2, "big")
         self.modulus = b"P" * key_len
         self.server_key = b"G" * key_len
@@ -144,35 +144,35 @@ class TestHandshakeScrubber(TestCase):
         s = HandshakeScrubber()
         self._ard_to_credentials(s)
 
-        self.assertEqual(s.feed("s2c", self.dh_params), self.dh_params)
-        self.assertEqual(s.feed("s2c", self.modulus), self.modulus)
-        self.assertEqual(s.feed("s2c", self.server_key), self.server_key)
+        self.assertEqual(s.s2c.feed(self.dh_params), self.dh_params)
+        self.assertEqual(s.s2c.feed(self.modulus), self.modulus)
+        self.assertEqual(s.s2c.feed(self.server_key), self.server_key)
 
         credentials = bytes(range(256))[:ARD_CREDENTIALS_LEN]
         client_key = b"Y" * 8
-        self.assertEqual(s.feed("c2s", credentials + client_key), bytes(ARD_CREDENTIALS_LEN) + client_key)
+        self.assertEqual(s.c2s.feed(credentials + client_key), bytes(ARD_CREDENTIALS_LEN) + client_key)
 
         self.assertIsNone(s.unscrubbable_auth)
         self.assertIsNone(s.abort_reason)
-        self.assertEqual(s.feed("s2c", SECURITY_RESULT_OK), SECURITY_RESULT_OK)
+        self.assertEqual(s.s2c.feed(SECURITY_RESULT_OK), SECURITY_RESULT_OK)
 
     def test_scrubbing_preserves_byte_offsets(self) -> None:
         """A redaction that changed length would break replay of the capture."""
         s = HandshakeScrubber()
         self._ard_to_credentials(s)
-        s.feed("s2c", self.dh_params + self.modulus + self.server_key)
+        s.s2c.feed(self.dh_params + self.modulus + self.server_key)
 
         credentials = b"\xab" * ARD_CREDENTIALS_LEN
-        out = s.feed("c2s", credentials)
+        out = s.c2s.feed(credentials)
         self.assertEqual(len(out), ARD_CREDENTIALS_LEN)
         self.assertNotIn(b"\xab", out)
 
     def test_unscrubbable_auth_aborts_by_default(self) -> None:
         s = HandshakeScrubber()
-        s.feed("s2c", VERSION_38)
-        s.feed("c2s", VERSION_38)
-        s.feed("s2c", bytes([1, AuthTypes.TIGHT]))
-        s.feed("c2s", bytes([AuthTypes.TIGHT]))
+        s.s2c.feed(VERSION_38)
+        s.c2s.feed(VERSION_38)
+        s.s2c.feed(bytes([1, AuthTypes.TIGHT]))
+        s.c2s.feed(bytes([AuthTypes.TIGHT]))
 
         self.assertIsNotNone(s.abort_reason)
         self.assertIn("tight", s.abort_reason)
@@ -182,55 +182,53 @@ class TestHandshakeScrubber(TestCase):
 
     def test_unscrubbable_auth_allowed_when_opted_in(self) -> None:
         s = HandshakeScrubber(allow_unsafe_auth=True)
-        s.feed("s2c", VERSION_38)
-        s.feed("c2s", VERSION_38)
-        s.feed("s2c", bytes([1, AuthTypes.TIGHT]))
-        s.feed("c2s", bytes([AuthTypes.TIGHT]))
+        s.s2c.feed(VERSION_38)
+        s.c2s.feed(VERSION_38)
+        s.s2c.feed(bytes([1, AuthTypes.TIGHT]))
+        s.c2s.feed(bytes([AuthTypes.TIGHT]))
 
         self.assertIsNone(s.abort_reason)
         self.assertIn("tight", s.unscrubbable_auth)
         # key exchange passes through verbatim -- that is what was opted into
         exchange = b"\x01\x02\x03\x04"
-        self.assertEqual(s.feed("s2c", exchange), exchange)
+        self.assertEqual(s.s2c.feed(exchange), exchange)
 
     def test_split_across_chunks(self) -> None:
         s = HandshakeScrubber()
-        self.assertEqual(s.feed("s2c", b"RFB 003."), b"")
-        self.assertEqual(s.feed("s2c", b"003\n"), VERSION_33)
+        self.assertEqual(s.s2c.feed(b"RFB 003."), b"")
+        self.assertEqual(s.s2c.feed(b"003\n"), VERSION_33)
 
     def test_split_challenge_across_chunks(self) -> None:
         s = HandshakeScrubber()
-        s.feed("s2c", VERSION_33)
-        s.feed("c2s", VERSION_33)
-        s.feed("s2c", b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION]))
-        first = s.feed("s2c", CHALLENGE[:6])
-        second = s.feed("s2c", CHALLENGE[6:])
+        s.s2c.feed(VERSION_33)
+        s.c2s.feed(VERSION_33)
+        s.s2c.feed(b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION]))
+        first = s.s2c.feed(CHALLENGE[:6])
+        second = s.s2c.feed(CHALLENGE[6:])
         self.assertEqual(first, b"")
         self.assertEqual(second, MARKER)
 
     def test_flush_drops_partial_secret(self) -> None:
         s = HandshakeScrubber()
-        s.feed("s2c", VERSION_33)
-        s.feed("c2s", VERSION_33)
-        s.feed("s2c", b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION]))
-        s.feed("s2c", CHALLENGE[:6])  # connection drops mid-challenge
+        s.s2c.feed(VERSION_33)
+        s.c2s.feed(VERSION_33)
+        s.s2c.feed(b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION]))
+        s.s2c.feed(CHALLENGE[:6])  # connection drops mid-challenge
 
-        pending = s.flush()
-        self.assertEqual(pending["s2c"], b"", "a half-collected secret must never be flushed in the clear")
-        self.assertEqual(pending["c2s"], b"")
+        self.assertEqual(s.s2c.flush(), b"", "a half-collected secret must never be flushed in the clear")
+        self.assertEqual(s.c2s.flush(), b"")
 
     def test_flush_emits_pending_non_secret(self) -> None:
         s = HandshakeScrubber()
-        s.feed("s2c", VERSION_33)
-        s.feed("c2s", VERSION_33)
-        s.feed("s2c", b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION]))
-        s.feed("s2c", CHALLENGE)
-        s.feed("c2s", RESPONSE)
-        s.feed("s2c", SECURITY_RESULT_OK[:2])  # connection drops mid-result, not a secret
+        s.s2c.feed(VERSION_33)
+        s.c2s.feed(VERSION_33)
+        s.s2c.feed(b"\x00\x00\x00" + bytes([AuthTypes.VNC_AUTHENTICATION]))
+        s.s2c.feed(CHALLENGE)
+        s.c2s.feed(RESPONSE)
+        s.s2c.feed(SECURITY_RESULT_OK[:2])  # connection drops mid-result, not a secret
 
-        pending = s.flush()
-        self.assertEqual(pending["s2c"], SECURITY_RESULT_OK[:2])
-        self.assertEqual(pending["c2s"], b"")
+        self.assertEqual(s.s2c.flush(), SECURITY_RESULT_OK[:2])
+        self.assertEqual(s.c2s.flush(), b"")
 
 
 class TestCheckCaptureTarget(TestCase):

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -25,7 +25,11 @@ from vncdotool.capture import (
     check_capture_target,
 )
 from vncdotool.const import AuthTypes, Encoding
-from vncdotool.loggingproxy import VNCLoggingClientProxy, VNCLoggingServerProxy
+from vncdotool.loggingproxy import (
+    VNCLoggingClientProxy,
+    VNCLoggingServerFactory,
+    VNCLoggingServerProxy,
+)
 
 VERSION_33 = b"RFB 003.003\n"
 VERSION_38 = b"RFB 003.008\n"
@@ -155,6 +159,27 @@ class TestHandshakeScrubber(TestCase):
         self.assertIsNone(s.unscrubbable_auth)
         self.assertIsNone(s.abort_reason)
         self.assertEqual(s.s2c.feed(SECURITY_RESULT_OK), SECURITY_RESULT_OK)
+
+    def test_unparseable_version_reply_aborts(self) -> None:
+        """Losing the handshake must fail closed.
+
+        Giving up quietly would put both directions into passthrough, so a
+        server that carried on regardless would have its challenge and
+        response recorded in the clear.
+        """
+        s = HandshakeScrubber()
+        s.s2c.feed(VERSION_38)
+        s.c2s.feed(b"NOT-A-VERSION\n"[:12])
+
+        self.assertIsNotNone(s.abort_reason)
+        self.assertIn("--capture-raw-unsafe-auth", s.abort_reason)
+
+    def test_unparseable_version_reply_allowed_when_opted_in(self) -> None:
+        s = HandshakeScrubber(allow_unsafe_auth=True)
+        s.s2c.feed(VERSION_38)
+        s.c2s.feed(b"NOT-A-VERSION\n"[:12])
+
+        self.assertIsNone(s.abort_reason)
 
     def test_scrubbing_preserves_byte_offsets(self) -> None:
         """A redaction that changed length would break replay of the capture."""
@@ -391,6 +416,11 @@ class TestProxyCaptureWiring(TestCase):
     for the peer connections portforward would otherwise wire up.
     """
 
+    def tmpdir(self) -> str:
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        return tmp
+
     def setUp(self) -> None:
         self.server_proxy = VNCLoggingServerProxy()
         self.server_proxy.transport = mock.Mock()
@@ -476,7 +506,7 @@ class TestProxyCaptureWiring(TestCase):
     def test_unscrubbable_auth_aborts_and_writes_nothing(self) -> None:
         """Chosen on the client side (3.7+), so it surfaces in the c2s tap."""
         sp, cp = self.server_proxy, self.client_proxy
-        sp.factory.capture_path = os.path.join(tempfile.mkdtemp(), "capture.zip")
+        sp.factory.capture_path = os.path.join(self.tmpdir(), "capture.zip")
         sp.factory.session_taken = True
 
         cp.dataReceived(VERSION_38)
@@ -491,7 +521,7 @@ class TestProxyCaptureWiring(TestCase):
     def test_unscrubbable_auth_chosen_by_a_pre37_server_also_aborts(self) -> None:
         """Pre-3.7 the server dictates the type, so the s2c tap has to catch it."""
         sp, cp = self.server_proxy, self.client_proxy
-        sp.factory.capture_path = os.path.join(tempfile.mkdtemp(), "capture.zip")
+        sp.factory.capture_path = os.path.join(self.tmpdir(), "capture.zip")
 
         cp.dataReceived(VERSION_33)
         sp.dataReceived(VERSION_33)
@@ -573,6 +603,41 @@ class TestProxyCaptureWiring(TestCase):
         self.assertIsNone(sp.capture)
         factory.getRecorder.assert_not_called()
 
+    def test_a_refused_connection_touches_nothing(self) -> None:
+        """A probe refused mid-session must not disturb the live one.
+
+        The refuse path returns before ProxyServer.connectionMade, so it has
+        no peer and never got pauseProducing(): bytes can still arrive, and
+        connectionLost still fires. A real factory is used deliberately --
+        against a Mock every one of these side effects is invisible.
+        """
+        factory = VNCLoggingServerFactory("localhost", 5900)
+        factory.one_shot = True
+        factory.session_taken = True  # a live session holds it
+        factory.capture_path = "/tmp/some-capture.zip"
+        live_recorder = factory.getRecorder()  # the live session's session.vdo
+        live_recorder("pause 0.1\n")
+
+        refused = VNCLoggingServerProxy()
+        refused.factory = factory
+        refused.transport = mock.Mock()
+        refused.transport.getPeer.return_value = mock.Mock(host="10.0.0.9")
+
+        refused.connectionMade()
+        refused.transport.loseConnection.assert_called_once()
+
+        # Bytes arriving after loseConnection() must not make this a session.
+        refused.dataReceived(b"RFB 003.008\n")
+        self.assertFalse(refused.saw_bytes)
+
+        refused.connectionLost(mock.Mock())
+
+        self.assertTrue(factory.session_taken, "the live session's claim must survive")
+        self.assertEqual(
+            factory.getRecordedSession(), b"pause 0.1\n",
+            "the live session's recorder must survive a refused connection",
+        )
+
     def test_empty_connection_does_not_use_up_the_one_shot(self) -> None:
         """A bare TCP probe must not lock out the real connection behind it.
         Found live: the functional suite's own port-polling startup wait was
@@ -585,6 +650,7 @@ class TestProxyCaptureWiring(TestCase):
 
         probe = VNCLoggingServerProxy()
         probe.factory = factory
+        probe.took_session = True  # it was accepted, so connectionMade set both
         probe.capture = CaptureWriter(server="testhost::5900")  # never fed any bytes
 
         probe.connectionLost(mock.Mock())

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -15,6 +15,8 @@ import zipfile
 from struct import pack
 from unittest import TestCase, mock
 
+from twisted.protocols import portforward
+
 from vncdotool.client import VNCDoToolClient
 from vncdotool.capture import (
     ARD_CREDENTIALS_LEN,
@@ -51,7 +53,7 @@ class TestHandshakeScrubber(TestCase):
         self.assertEqual(s.security_type, AuthTypes.VNC_AUTHENTICATION)
         self.assertEqual(s.protocol_version, "RFB 003.003")
         self.assertEqual(s.security_types, [AuthTypes.VNC_AUTHENTICATION])
-        self.assertIsNone(s.unscrubbed_auth)
+        self.assertIsNone(s.unscrubbable_auth)
 
         # the security-result that follows is still passed through untouched
         self.assertEqual(s.feed("s2c", SECURITY_RESULT_OK), SECURITY_RESULT_OK)
@@ -111,7 +113,7 @@ class TestHandshakeScrubber(TestCase):
         out = s.feed("c2s", bytes([AuthTypes.NONE]))
         self.assertEqual(out, bytes([AuthTypes.NONE]))
         self.assertEqual(s.security_type, AuthTypes.NONE)
-        self.assertIsNone(s.unscrubbed_auth)
+        self.assertIsNone(s.unscrubbable_auth)
 
         # security-result(4) + ClientInit(1) + ServerInit(24), still passthrough
         self.assertEqual(s.feed("s2c", SECURITY_RESULT_OK), SECURITY_RESULT_OK)
@@ -150,7 +152,7 @@ class TestHandshakeScrubber(TestCase):
         client_key = b"Y" * 8
         self.assertEqual(s.feed("c2s", credentials + client_key), bytes(ARD_CREDENTIALS_LEN) + client_key)
 
-        self.assertIsNone(s.unscrubbed_auth)
+        self.assertIsNone(s.unscrubbable_auth)
         self.assertIsNone(s.abort_reason)
         self.assertEqual(s.feed("s2c", SECURITY_RESULT_OK), SECURITY_RESULT_OK)
 
@@ -175,8 +177,8 @@ class TestHandshakeScrubber(TestCase):
         self.assertIsNotNone(s.abort_reason)
         self.assertIn("tight", s.abort_reason)
         self.assertIn("--capture-raw-unsafe-auth", s.abort_reason)
-        self.assertIn("tight", s.unscrubbed_auth)
-        self.assertIn("16", s.unscrubbed_auth)
+        self.assertIn("tight", s.unscrubbable_auth)
+        self.assertIn("16", s.unscrubbable_auth)
 
     def test_unscrubbable_auth_allowed_when_opted_in(self) -> None:
         s = HandshakeScrubber(allow_unsafe_auth=True)
@@ -186,7 +188,7 @@ class TestHandshakeScrubber(TestCase):
         s.feed("c2s", bytes([AuthTypes.TIGHT]))
 
         self.assertIsNone(s.abort_reason)
-        self.assertIn("tight", s.unscrubbed_auth)
+        self.assertIn("tight", s.unscrubbable_auth)
         # key exchange passes through verbatim -- that is what was opted into
         exchange = b"\x01\x02\x03\x04"
         self.assertEqual(s.feed("s2c", exchange), exchange)
@@ -307,7 +309,6 @@ class TestCaptureWriter(TestCase):
         self.assertEqual(meta["vncdotool_version"], "9.9.9")
         self.assertEqual(meta["protocol_version"], "RFB 003.003")
         self.assertEqual(meta["security_types"], [AuthTypes.VNC_AUTHENTICATION])
-        self.assertIsNone(meta["unscrubbed_auth"])
         self.assertEqual(meta["geometry"], {"width": 640, "height": 480})
         self.assertIn("capture_timestamp", meta)
 
@@ -330,10 +331,9 @@ class TestCaptureWriter(TestCase):
         cw.write_archive(self.archive, cw.meta("9.9.9"))
         meta = self.read_meta()
         self.assertEqual(meta["security_types"], [AuthTypes.NONE])
-        self.assertIsNone(meta["unscrubbed_auth"])
         self.assertEqual(meta["geometry"], {"width": 640, "height": 480})
 
-    def test_unscrubbed_auth_recorded_in_meta_when_opted_in(self) -> None:
+    def test_unscrubbable_auth_captured_when_opted_in(self) -> None:
         cw = CaptureWriter(
             server="host::5900",
             scrubber=HandshakeScrubber(allow_unsafe_auth=True),
@@ -343,10 +343,8 @@ class TestCaptureWriter(TestCase):
         cw.feed_s2c(bytes([1, AuthTypes.TIGHT]))
         cw.feed_c2s(bytes([AuthTypes.TIGHT]))
 
-        meta = cw.meta("9.9.9")
-        self.assertIsNotNone(meta["unscrubbed_auth"])
-        self.assertIn("tight", meta["unscrubbed_auth"])
-        self.assertIsNone(cw.abort_reason)
+        self.assertIsNone(cw.abort_reason, "the opt-in must not abort")
+        self.assertIn("tight", cw.scrubber.unscrubbable_auth)
 
     def test_encodings_seen_recorded_in_meta(self) -> None:
         """What the server actually sent, named where we know the name."""
@@ -481,7 +479,7 @@ class TestProxyCaptureWiring(TestCase):
         """Chosen on the client side (3.7+), so it surfaces in the c2s tap."""
         sp, cp = self.server_proxy, self.client_proxy
         sp.factory.capture_path = os.path.join(tempfile.mkdtemp(), "capture.zip")
-        sp.factory.capture_claimed = True
+        sp.factory.session_taken = True
 
         cp.dataReceived(VERSION_38)
         sp.dataReceived(VERSION_38)
@@ -522,6 +520,18 @@ class TestProxyCaptureWiring(TestCase):
             {int(Encoding.ZRLE): 2, int(Encoding.HEXTILE): 1},
         )
 
+    def test_forwarding_failures_are_not_swallowed(self) -> None:
+        """Only the observers are wrapped.
+
+        Suppressing a forwarding failure would leave the client waiting on
+        bytes that never arrive, so the session has to fail as it always did.
+        """
+        sp = self.server_proxy
+        sp.factory.password_required = False
+        with mock.patch.object(portforward.ProxyServer, "dataReceived", side_effect=RuntimeError("boom")):
+            with self.assertRaises(RuntimeError):
+                sp.dataReceived(VERSION_38)
+
     def test_capture_survives_a_parser_that_raises(self) -> None:
         """The tap must not depend on RFBServer's semantic parser: an
         unknown ptype raises ProtocolError, and capture and forwarding both
@@ -552,7 +562,7 @@ class TestProxyCaptureWiring(TestCase):
         """
         factory = mock.Mock()
         factory.capture_path = "/tmp/some-capture.zip"
-        factory.capture_claimed = True
+        factory.session_taken = True
 
         sp = VNCLoggingServerProxy()
         sp.factory = factory
@@ -565,14 +575,15 @@ class TestProxyCaptureWiring(TestCase):
         self.assertIsNone(sp.capture)
         factory.getRecorder.assert_not_called()
 
-    def test_empty_connection_does_not_permanently_claim_capture(self) -> None:
+    def test_empty_connection_does_not_use_up_the_one_shot(self) -> None:
         """A bare TCP probe must not lock out the real connection behind it.
         Found live: the functional suite's own port-polling startup wait was
-        claiming the capture before vncdo ever connected.
+        taking the session before vncdo ever connected.
         """
         factory = mock.Mock()
+        factory.one_shot = True
         factory.capture_path = "/tmp/some-capture.zip"
-        factory.capture_claimed = True  # what connectionMade would have set
+        factory.session_taken = True  # what connectionMade would have set
 
         probe = VNCLoggingServerProxy()
         probe.factory = factory
@@ -580,8 +591,9 @@ class TestProxyCaptureWiring(TestCase):
 
         probe.connectionLost(mock.Mock())
 
-        self.assertFalse(factory.capture_claimed)
+        self.assertFalse(factory.session_taken)
         self.assertIsNone(probe.capture)
+        factory.sessionFinished.assert_not_called()
 
     def test_greeting_only_session_is_still_written(self) -> None:
         """A server rejecting the client before it speaks (TigerVNC's "Too
@@ -592,18 +604,21 @@ class TestProxyCaptureWiring(TestCase):
         self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
         archive = os.path.join(tmp, "capture.zip")
         factory = mock.Mock()
+        factory.one_shot = True
         factory.capture_path = archive
-        factory.capture_claimed = True
+        factory.session_taken = True
         factory.getRecordedSession.return_value = b""
 
         session = VNCLoggingServerProxy()
         session.factory = factory
         session.capture = CaptureWriter(server="testhost::5900")
-        session.capture.feed_s2c(b"RFB 003.003\n")  # greeting arrived; client never got a byte through
+        session.saw_bytes = True  # the greeting arrived
+        session.capture.feed_s2c(b"RFB 003.003\n")  # client never got a byte through
 
         session.connectionLost(mock.Mock())
 
-        self.assertTrue(factory.capture_claimed, "a real (if one-sided) session keeps the claim")
+        self.assertTrue(factory.session_taken, "a real (if one-sided) session is still a session")
+        factory.sessionFinished.assert_called_once()
         with zipfile.ZipFile(archive) as zf:
             self.assertEqual(zf.read("s2c.bin"), b"RFB 003.003\n")
             self.assertEqual(zf.read("c2s.bin"), b"")

--- a/vncdotool/capture.py
+++ b/vncdotool/capture.py
@@ -1,20 +1,31 @@
 """Raw wire capture for the ``vnclog --capture`` discovery kit.
 
 Scrubbing happens *before* bytes touch disk, and is kept here, socket-free,
-so it can be unit tested. Two independent redactions:
+so it can be unit tested. Secrets are located by walking the handshake state
+machine, never by pattern matching -- every one of them is high-entropy and
+indistinguishable from any other span of the same length by content alone:
 
-* The VNC-auth challenge and response are located by walking the handshake
-  state machine, not by pattern matching -- both are high-entropy and
-  indistinguishable from any other 16-byte span by content alone.
-* Literal occurrences of the proxy's own password are replaced wherever
-  they appear. Best-effort defence only: VNC auth never puts the password
-  on the wire in the clear, and a span crossing a ``feed()`` boundary is
-  missed.
+* VNC auth (:attr:`AuthTypes.VNC_AUTHENTICATION`): the 16-byte challenge and
+  the 16-byte response.
+* ARD / Apple Screen Sharing (:attr:`AuthTypes.DIFFIE_HELLMAN`): the
+  128-byte AES-ECB block carrying username and password. The surrounding
+  Diffie-Hellman values (generator, modulus, both public keys) are public by
+  construction and pass through, so the capture still shows the key exchange
+  a compatibility bug would live in.
 
-Auth types with no scrubber (Diffie-Hellman/ARD, used by macOS Screen
-Sharing) are named in ``unscrubbed_auth`` rather than passing their key
-exchange through with an empty ``scrubbed`` list implying it was safe.
-See ``docs/capture.rst``.
+Redacted spans are replaced by an equal number of zero bytes, never by a
+shorter or longer marker: a capture whose byte offsets shifted under
+scrubbing would no longer replay.
+
+An auth type with no scrubber aborts the capture and names itself, unless
+the contributor passes ``--capture-unsafe-auth``. Writing an unscrubbed key
+exchange to a file destined for a public issue tracker is a decision for a
+human with a disposable password, not a default. See ``docs/capture.rst``.
+
+Scrubbing stops at the end of the handshake. Everything the session itself
+carries -- keystrokes, clipboard -- is recorded verbatim; that risk is
+documented rather than filtered, because a capture with its input stream
+rewritten is no longer evidence of what the server did.
 """
 
 from __future__ import annotations
@@ -22,13 +33,18 @@ from __future__ import annotations
 import json
 import os
 import time
+import zipfile
 from dataclasses import dataclass, field
 from struct import unpack
 from typing import Any, Generator
 
-from .const import AuthTypes
+from .const import AuthTypes, Encoding
 
 MARKER = b"\x00" * 16
+
+# AES-ECB over a fixed 64-byte username + 64-byte password struct; see
+# RFBClient._encryptArd().
+ARD_CREDENTIALS_LEN = 128
 
 Direction = str  # "s2c" or "c2s"
 
@@ -44,13 +60,17 @@ class HandshakeScrubber:
     Once the handshake is done it passes bytes straight through.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, allow_unsafe_auth: bool = False) -> None:
+        self.allow_unsafe_auth = allow_unsafe_auth
         self.protocol_version: str | None = None
         self.negotiated_version: tuple[int, int] | None = None
         self.security_types: list[int] = []
         self.security_type: int | None = None
         self.scrubbed: list[str] = []
         self.unscrubbed_auth: str | None = None
+        # Set when an auth type we cannot scrub is selected and the
+        # contributor has not opted in; the caller drops the capture.
+        self.abort_reason: str | None = None
         self.width: int | None = None
         self.height: int | None = None
 
@@ -96,7 +116,9 @@ class HandshakeScrubber:
                 break
             chunk = bytes(buf[:nbytes])
             del buf[:nbytes]
-            out += MARKER if mode == "scrub" else chunk
+            # Equal-length redaction: byte offsets after a scrubbed span
+            # have to match the live stream or the capture stops replaying.
+            out += bytes(nbytes) if mode == "scrub" else chunk
             self._advance(chunk)
 
         # No longer tracked, so flush rather than hold these back forever.
@@ -165,12 +187,34 @@ class HandshakeScrubber:
             self.scrubbed.append("vnc-auth-challenge")
             yield ("c2s", 16, "scrub")
             self.scrubbed.append("vnc-auth-response")
+        elif sectype == AuthTypes.DIFFIE_HELLMAN:
+            # ARD / Apple Screen Sharing, laid out as RFBClient._handleDHAuth
+            # reads it: generator(2) keyLen(2), modulus(keyLen),
+            # serverKey(keyLen), then the client's reply. Only the client's
+            # AES block is secret -- the DH values are public by design, and
+            # keeping them is what makes the capture useful for the ARD
+            # compatibility bugs this kit exists to chase.
+            head = yield ("s2c", 4, "pass")
+            _generator, key_len = unpack("!HH", head)
+            yield ("s2c", key_len, "pass")  # modulus
+            yield ("s2c", key_len, "pass")  # server public key
+            yield ("c2s", ARD_CREDENTIALS_LEN, "scrub")
+            self.scrubbed.append("ard-credentials")
+            yield ("c2s", key_len, "pass")  # client public key
         elif sectype not in (AuthTypes.NONE, AuthTypes.INVALID):
-            # Key-exchange bytes pass through unredacted, so name the type
-            # rather than let an empty `scrubbed` list imply it was safe.
+            # No scrubber for this type: its key exchange would reach disk
+            # whole. Name it, and stop unless a human opted in.
             looked_up = AuthTypes.lookup(sectype)
             name = getattr(looked_up, "name", None) or str(looked_up)
             self.unscrubbed_auth = f"{name.lower().replace('_', '-')}({int(sectype)})"
+            if not self.allow_unsafe_auth:
+                self.abort_reason = (
+                    f"the session negotiated {self.unscrubbed_auth}, which vncdotool cannot scrub; "
+                    "the capture would contain the credential exchange verbatim. "
+                    "Re-run with --capture-unsafe-auth, using a disposable password you "
+                    "rotate afterwards, if you need this exchange captured."
+                )
+                return
 
         # SecurityResult follows in every case but one: pre-3.8 with
         # AuthTypes.NONE jumps straight to ClientInit.
@@ -213,8 +257,20 @@ class CaptureWriter:
     scrubber: HandshakeScrubber = field(default_factory=HandshakeScrubber)
     s2c: bytearray = field(default_factory=bytearray)
     c2s: bytearray = field(default_factory=bytearray)
+    # encoding number -> rectangles seen. Recorded from the decoded stream,
+    # never from the client's SetEncodings request: a server may answer in
+    # any encoding it likes, and which one it actually chose is the whole
+    # question a capture from an unhostable server is meant to answer.
+    encodings_seen: dict[int, int] = field(default_factory=dict)
     _password_scrubbed: bool = False
     capture_timestamp: str = field(default_factory=lambda: time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()))
+
+    @property
+    def abort_reason(self) -> str | None:
+        return self.scrubber.abort_reason
+
+    def note_encoding(self, encoding: int) -> None:
+        self.encodings_seen[encoding] = self.encodings_seen.get(encoding, 0) + 1
 
     def feed_s2c(self, data: bytes) -> None:
         self._feed("s2c", data)
@@ -247,6 +303,21 @@ class CaptureWriter:
             names.append("password")
         return names
 
+    def encodings_list(self) -> list[dict[str, Any]]:
+        """`encodings_seen` as JSON, ordered and named where we know the name."""
+        out = []
+        for encoding in sorted(self.encodings_seen):
+            looked_up = Encoding.lookup(encoding)
+            name = getattr(looked_up, "name", None)
+            out.append(
+                {
+                    "encoding": encoding,
+                    "name": name.lower().replace("_", "-") if name else None,
+                    "rectangles": self.encodings_seen[encoding],
+                }
+            )
+        return out
+
     def meta(self, vncdotool_version: str) -> dict[str, Any]:
         return {
             "server": self.server,
@@ -256,6 +327,7 @@ class CaptureWriter:
             "security_types": self.scrubber.security_types,
             "scrubbed": self.scrubbed_list(),
             "unscrubbed_auth": self.scrubber.unscrubbed_auth,
+            "encodings_seen": self.encodings_list(),
             "geometry": (
                 {"width": self.scrubber.width, "height": self.scrubber.height}
                 if self.scrubber.width is not None and self.scrubber.height is not None
@@ -263,28 +335,37 @@ class CaptureWriter:
             ),
         }
 
-    def write(self, directory: str) -> None:
+    def write_archive(self, path: str, meta: dict[str, Any], session_vdo: bytes = b"") -> None:
+        """Write the whole capture as one zip, ready to attach to an issue.
+
+        Built at a temporary path and renamed into place, so an interrupted
+        write cannot leave a half archive looking like a complete capture.
+        """
         self.flush()
-        with open(os.path.join(directory, "s2c.bin"), "wb") as fh:
-            fh.write(self.s2c)
-        with open(os.path.join(directory, "c2s.bin"), "wb") as fh:
-            fh.write(self.c2s)
+        partial = path + ".part"
+        try:
+            with zipfile.ZipFile(partial, "w", zipfile.ZIP_DEFLATED) as archive:
+                archive.writestr("s2c.bin", bytes(self.s2c))
+                archive.writestr("c2s.bin", bytes(self.c2s))
+                archive.writestr("session.vdo", session_vdo)
+                archive.writestr("meta.json", json.dumps(meta, indent=2, sort_keys=True) + "\n")
+            os.replace(partial, path)
+        except BaseException:
+            if os.path.exists(partial):
+                os.unlink(partial)
+            raise
 
 
-def check_capture_dir(path: str) -> None:
+def check_capture_target(path: str) -> None:
     """Validate `path` is usable as a --capture target.
 
-    Creates nothing: callers create the directory only once every other
-    argument has validated, so a later `op.error()` leaves nothing behind.
+    Creates nothing: the archive is written when the session ends, so a
+    later `op.error()` leaves nothing behind.
     """
+    if not path.endswith(".zip"):
+        raise ValueError(f"--capture target {path!r} must end in .zip -- captures are written as one archive")
     if os.path.exists(path):
-        if not os.path.isdir(path):
-            raise ValueError(f"--capture target {path!r} exists and is not a directory")
-        if os.listdir(path):
-            raise ValueError(f"--capture target {path!r} exists and is not empty -- refusing to mix captures")
-
-
-def write_meta(path: str, meta: dict[str, Any]) -> None:
-    with open(path, "w") as fh:
-        json.dump(meta, fh, indent=2, sort_keys=True)
-        fh.write("\n")
+        raise ValueError(f"--capture target {path!r} already exists -- refusing to overwrite a capture")
+    parent = os.path.dirname(os.path.abspath(path))
+    if not os.path.isdir(parent):
+        raise ValueError(f"--capture target directory {parent!r} does not exist")

--- a/vncdotool/capture.py
+++ b/vncdotool/capture.py
@@ -100,6 +100,21 @@ class HandshakeScrubber:
             self._gen = None
             self._want = None
 
+    def _give_up(self, why: str) -> None:
+        """Stop the capture when we can no longer follow the handshake.
+
+        Losing track means we no longer know where the credentials are, so
+        the same rule as an unscrubbable auth type applies: nothing is
+        written unless a human asked for it.
+        """
+        if self.allow_unsafe_auth:
+            return
+        self.abort_reason = (
+            f"{why}; vncdotool can no longer tell where this handshake's credentials are. "
+            "Re-run with --capture-raw-unsafe-auth, using a disposable password you rotate "
+            "afterwards, if you need this session captured."
+        )
+
     def _waiting_on(self, tap: Tap) -> _Want | None:
         """What the handshake wants from `tap`, if it is watching it at all."""
         if self._gen is None or self._want is None or self._want.tap is not tap:
@@ -165,6 +180,10 @@ class HandshakeScrubber:
         try:
             negotiated = (int(client_head[4:7]), int(client_head[8:11]))
         except (ValueError, IndexError):
+            # Fail closed. Giving up here would put both directions into
+            # passthrough, so a server that carried on regardless would have
+            # its challenge and response recorded in the clear.
+            self._give_up(f"could not parse the client's version reply {bytes(client_head)!r}")
             return
         self.negotiated_version = negotiated
 

--- a/vncdotool/capture.py
+++ b/vncdotool/capture.py
@@ -1,0 +1,290 @@
+"""Raw wire capture for the ``vnclog --capture`` discovery kit.
+
+Scrubbing happens *before* bytes touch disk, and is kept here, socket-free,
+so it can be unit tested. Two independent redactions:
+
+* The VNC-auth challenge and response are located by walking the handshake
+  state machine, not by pattern matching -- both are high-entropy and
+  indistinguishable from any other 16-byte span by content alone.
+* Literal occurrences of the proxy's own password are replaced wherever
+  they appear. Best-effort defence only: VNC auth never puts the password
+  on the wire in the clear, and a span crossing a ``feed()`` boundary is
+  missed.
+
+Auth types with no scrubber (Diffie-Hellman/ARD, used by macOS Screen
+Sharing) are named in ``unscrubbed_auth`` rather than passing their key
+exchange through with an empty ``scrubbed`` list implying it was safe.
+See ``docs/capture.rst``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from struct import unpack
+from typing import Any, Generator
+
+from .const import AuthTypes
+
+MARKER = b"\x00" * 16
+
+Direction = str  # "s2c" or "c2s"
+
+# What _run() is currently waiting for: (direction, nbytes, "pass"|"scrub").
+_Want = tuple[Direction, int, str]
+
+
+class HandshakeScrubber:
+    """Tracks an RFB handshake across both directions of a proxied stream.
+
+    :meth:`feed` takes raw bytes in arrival order and returns what should
+    reach disk, with the VNC-auth challenge/response replaced by ``MARKER``.
+    Once the handshake is done it passes bytes straight through.
+    """
+
+    def __init__(self) -> None:
+        self.protocol_version: str | None = None
+        self.negotiated_version: tuple[int, int] | None = None
+        self.security_types: list[int] = []
+        self.security_type: int | None = None
+        self.scrubbed: list[str] = []
+        self.unscrubbed_auth: str | None = None
+        self.width: int | None = None
+        self.height: int | None = None
+
+        self._bufs: dict[Direction, bytearray] = {"s2c": bytearray(), "c2s": bytearray()}
+        self._gen: Generator[_Want, bytes, None] | None = self._run()
+        self._want: _Want | None = None
+        self._advance(None)
+
+    # -- driving the handshake state machine --------------------------------
+
+    def _advance(self, sent: bytes | None) -> None:
+        if self._gen is None:
+            return
+        try:
+            if sent is None:
+                self._want = next(self._gen)
+            else:
+                self._want = self._gen.send(sent)
+        except StopIteration:
+            self._gen = None
+            self._want = None
+
+    def feed(self, direction: Direction, data: bytes) -> bytes:
+        if not data:
+            return b""
+
+        buf = self._bufs[direction]
+
+        if self._gen is None or self._want is None or self._want[0] != direction:
+            # Not tracking this direction, so nothing pending here is a
+            # secret: flush it with the new data, unmodified.
+            buf += data
+            out = bytes(buf)
+            del buf[:]
+            return out
+
+        buf += data
+        out = bytearray()
+
+        while self._gen is not None and self._want is not None and self._want[0] == direction:
+            _, nbytes, mode = self._want
+            if len(buf) < nbytes:
+                break
+            chunk = bytes(buf[:nbytes])
+            del buf[:nbytes]
+            out += MARKER if mode == "scrub" else chunk
+            self._advance(chunk)
+
+        # No longer tracked, so flush rather than hold these back forever.
+        if buf and (self._gen is None or self._want is None or self._want[0] != direction):
+            out += buf
+            del buf[:]
+
+        return bytes(out)
+
+    def flush(self) -> dict[Direction, bytes]:
+        """Bytes left buffered per direction when the connection ends.
+
+        Bytes buffered mid-secret are dropped instead of returned: half a
+        challenge is still a fragment of a secret.
+        """
+        out: dict[Direction, bytes] = {"s2c": b"", "c2s": b""}
+        for direction in ("s2c", "c2s"):
+            buf = self._bufs[direction]
+            if not buf:
+                continue
+            pending_is_secret = (
+                self._want is not None and self._want[0] == direction and self._want[2] == "scrub"
+            )
+            if not pending_is_secret:
+                out[direction] = bytes(buf)
+            del buf[:]
+        return out
+
+    # -- the handshake description -------------------------------------------
+
+    def _run(self) -> Generator[_Want, bytes, None]:
+        server_head = yield ("s2c", 12, "pass")
+        self.protocol_version = server_head.decode("ascii", "replace").rstrip("\n")
+
+        # Branch on the client's reply, not the server's greeting: per RFC
+        # 6143 7.1.1 that reply governs the rest of the exchange, so a client
+        # downgrading below 3.7 would otherwise take this down the wrong path
+        # and miss the challenge/response entirely.
+        client_head = yield ("c2s", 12, "pass")
+        try:
+            negotiated = (int(client_head[4:7]), int(client_head[8:11]))
+        except (ValueError, IndexError):
+            return
+        self.negotiated_version = negotiated
+
+        if negotiated >= (3, 7):
+            num_types_b = yield ("s2c", 1, "pass")
+            num_types = num_types_b[0]
+            if num_types == 0:
+                return  # connection-failed reason string follows; not tracked
+            types_b = yield ("s2c", num_types, "pass")
+            self.security_types = list(types_b)
+            sectype_b = yield ("c2s", 1, "pass")
+            sectype = sectype_b[0]
+        else:
+            auth_b = yield ("s2c", 4, "pass")
+            sectype = int.from_bytes(auth_b, "big")
+            if sectype == AuthTypes.INVALID:
+                return
+            self.security_types = [sectype]
+
+        self.security_type = sectype
+
+        if sectype == AuthTypes.VNC_AUTHENTICATION:
+            yield ("s2c", 16, "scrub")
+            self.scrubbed.append("vnc-auth-challenge")
+            yield ("c2s", 16, "scrub")
+            self.scrubbed.append("vnc-auth-response")
+        elif sectype not in (AuthTypes.NONE, AuthTypes.INVALID):
+            # Key-exchange bytes pass through unredacted, so name the type
+            # rather than let an empty `scrubbed` list imply it was safe.
+            looked_up = AuthTypes.lookup(sectype)
+            name = getattr(looked_up, "name", None) or str(looked_up)
+            self.unscrubbed_auth = f"{name.lower().replace('_', '-')}({int(sectype)})"
+
+        # SecurityResult follows in every case but one: pre-3.8 with
+        # AuthTypes.NONE jumps straight to ClientInit.
+        if not (negotiated < (3, 8) and sectype == AuthTypes.NONE):
+            result_b = yield ("s2c", 4, "pass")
+            (result,) = unpack("!I", result_b)
+            if result != 0:
+                return  # auth failed/too-many-tries; reason string not tracked
+
+        yield ("c2s", 1, "pass")  # ClientInit: shared flag
+
+        # ServerInit: width(2) height(2) pixel-format(16) name-len(4).
+        server_init = yield ("s2c", 24, "pass")
+        self.width, self.height = unpack("!HH", server_init[:4])
+
+        # Server name follows; nothing past it carries a tracked secret.
+        return
+
+
+def scrub_password(data: bytes, password: bytes | None) -> tuple[bytes, bool]:
+    """Redact literal occurrences of `password` in `data`.
+
+    Best-effort: only catches a password landing entirely within one chunk.
+    """
+    if not password or password not in data:
+        return data, False
+    marker = b"\x00" * len(password)
+    return data.replace(password, marker), True
+
+
+@dataclass
+class CaptureWriter:
+    """Scrubbed s2c/c2s streams and meta.json fields for one connection.
+
+    Owns no file handles: the caller decides when to flush to disk.
+    """
+
+    server: str
+    password: bytes | None = None
+    scrubber: HandshakeScrubber = field(default_factory=HandshakeScrubber)
+    s2c: bytearray = field(default_factory=bytearray)
+    c2s: bytearray = field(default_factory=bytearray)
+    _password_scrubbed: bool = False
+    capture_timestamp: str = field(default_factory=lambda: time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()))
+
+    def feed_s2c(self, data: bytes) -> None:
+        self._feed("s2c", data)
+
+    def feed_c2s(self, data: bytes) -> None:
+        self._feed("c2s", data)
+
+    def _feed(self, direction: Direction, data: bytes) -> None:
+        scrubbed = self.scrubber.feed(direction, data)
+        self._append(direction, scrubbed)
+
+    def _append(self, direction: Direction, data: bytes) -> None:
+        if not data:
+            return
+        scrubbed, hit = scrub_password(data, self.password)
+        if hit:
+            self._password_scrubbed = True
+        buf = self.s2c if direction == "s2c" else self.c2s
+        buf += scrubbed
+
+    def flush(self) -> None:
+        """Emit whatever the scrubber was still holding back, at disconnect."""
+        pending = self.scrubber.flush()
+        for direction, data in pending.items():
+            self._append(direction, data)
+
+    def scrubbed_list(self) -> list[str]:
+        names = list(self.scrubber.scrubbed)
+        if self._password_scrubbed:
+            names.append("password")
+        return names
+
+    def meta(self, vncdotool_version: str) -> dict[str, Any]:
+        return {
+            "server": self.server,
+            "vncdotool_version": vncdotool_version,
+            "capture_timestamp": self.capture_timestamp,
+            "protocol_version": self.scrubber.protocol_version,
+            "security_types": self.scrubber.security_types,
+            "scrubbed": self.scrubbed_list(),
+            "unscrubbed_auth": self.scrubber.unscrubbed_auth,
+            "geometry": (
+                {"width": self.scrubber.width, "height": self.scrubber.height}
+                if self.scrubber.width is not None and self.scrubber.height is not None
+                else None
+            ),
+        }
+
+    def write(self, directory: str) -> None:
+        self.flush()
+        with open(os.path.join(directory, "s2c.bin"), "wb") as fh:
+            fh.write(self.s2c)
+        with open(os.path.join(directory, "c2s.bin"), "wb") as fh:
+            fh.write(self.c2s)
+
+
+def check_capture_dir(path: str) -> None:
+    """Validate `path` is usable as a --capture target.
+
+    Creates nothing: callers create the directory only once every other
+    argument has validated, so a later `op.error()` leaves nothing behind.
+    """
+    if os.path.exists(path):
+        if not os.path.isdir(path):
+            raise ValueError(f"--capture target {path!r} exists and is not a directory")
+        if os.listdir(path):
+            raise ValueError(f"--capture target {path!r} exists and is not empty -- refusing to mix captures")
+
+
+def write_meta(path: str, meta: dict[str, Any]) -> None:
+    with open(path, "w") as fh:
+        json.dump(meta, fh, indent=2, sort_keys=True)
+        fh.write("\n")

--- a/vncdotool/capture.py
+++ b/vncdotool/capture.py
@@ -23,8 +23,6 @@ from typing import Any, Generator
 
 from .const import AuthTypes, Encoding
 
-MARKER = b"\x00" * 16
-
 # AES-ECB over a fixed 64-byte username + 64-byte password struct; see
 # RFBClient._encryptArd().
 ARD_CREDENTIALS_LEN = 128
@@ -39,8 +37,8 @@ class HandshakeScrubber:
     """Tracks an RFB handshake across both directions of a proxied stream.
 
     :meth:`feed` takes raw bytes in arrival order and returns what should
-    reach disk, with the VNC-auth challenge/response replaced by ``MARKER``.
-    Once the handshake is done it passes bytes straight through.
+    reach disk, credentials replaced by zeros. Once the handshake is done it
+    passes bytes straight through.
     """
 
     def __init__(self, allow_unsafe_auth: bool = False) -> None:
@@ -49,7 +47,7 @@ class HandshakeScrubber:
         self.negotiated_version: tuple[int, int] | None = None
         self.security_types: list[int] = []
         self.security_type: int | None = None
-        self.unscrubbed_auth: str | None = None
+        self.unscrubbable_auth: str | None = None
         # Set when an unscrubbable auth type is selected without an opt-in;
         # the caller drops the capture.
         self.abort_reason: str | None = None
@@ -183,10 +181,10 @@ class HandshakeScrubber:
             # whole. Name it, and stop unless a human opted in.
             looked_up = AuthTypes.lookup(sectype)
             name = getattr(looked_up, "name", None) or str(looked_up)
-            self.unscrubbed_auth = f"{name.lower().replace('_', '-')}({int(sectype)})"
+            self.unscrubbable_auth = f"{name.lower().replace('_', '-')}({int(sectype)})"
             if not self.allow_unsafe_auth:
                 self.abort_reason = (
-                    f"the session negotiated {self.unscrubbed_auth}, which vncdotool cannot scrub; "
+                    f"the session negotiated {self.unscrubbable_auth}, which vncdotool cannot scrub; "
                     "the capture would contain the credential exchange verbatim. "
                     "Re-run with --capture-raw-unsafe-auth, using a disposable password "
                     "you rotate afterwards, if you need this exchange captured."
@@ -278,7 +276,6 @@ class CaptureWriter:
             "capture_timestamp": self.capture_timestamp,
             "protocol_version": self.scrubber.protocol_version,
             "security_types": self.scrubber.security_types,
-            "unscrubbed_auth": self.scrubber.unscrubbed_auth,
             "encodings_seen": self.encodings_list(),
             "geometry": (
                 {"width": self.scrubber.width, "height": self.scrubber.height}

--- a/vncdotool/capture.py
+++ b/vncdotool/capture.py
@@ -19,7 +19,7 @@ import time
 import zipfile
 from dataclasses import dataclass, field
 from struct import unpack
-from typing import Any, Generator
+from typing import Any, Generator, NamedTuple
 
 from .const import AuthTypes, Encoding
 
@@ -27,21 +27,49 @@ from .const import AuthTypes, Encoding
 # RFBClient._encryptArd().
 ARD_CREDENTIALS_LEN = 128
 
-Direction = str  # "s2c" or "c2s"
 
-# What _run() is currently waiting for: (direction, nbytes, "pass"|"scrub").
-_Want = tuple[Direction, int, str]
+class Tap:
+    """One direction of the proxied connection.
+
+    Callers hold the tap for the direction they are feeding, so no direction
+    argument travels through the code: ``scrubber.s2c.feed(data)`` returns
+    what that direction should record.
+    """
+
+    def __init__(self, scrubber: HandshakeScrubber, name: str) -> None:
+        self.name = name  # "s2c" / "c2s", for messages only
+        self.pending = bytearray()
+        self._scrubber = scrubber
+
+    def __repr__(self) -> str:
+        return f"<Tap {self.name}>"
+
+    def feed(self, data: bytes) -> bytes:
+        return self._scrubber._feed(self, data)
+
+    def flush(self) -> bytes:
+        return self._scrubber._flush(self)
+
+
+class _Want(NamedTuple):
+    """What the handshake is waiting for next."""
+
+    tap: Tap
+    nbytes: int
+    scrub: bool
 
 
 class HandshakeScrubber:
     """Tracks an RFB handshake across both directions of a proxied stream.
 
-    :meth:`feed` takes raw bytes in arrival order and returns what should
-    reach disk, credentials replaced by zeros. Once the handshake is done it
-    passes bytes straight through.
+    Feed arriving bytes to :attr:`s2c` or :attr:`c2s`; each returns what that
+    direction should record, credentials replaced by zeros. Once the
+    handshake is done both pass bytes straight through.
     """
 
     def __init__(self, allow_unsafe_auth: bool = False) -> None:
+        self.s2c = Tap(self, "s2c")
+        self.c2s = Tap(self, "c2s")
         self.allow_unsafe_auth = allow_unsafe_auth
         self.protocol_version: str | None = None
         self.negotiated_version: tuple[int, int] | None = None
@@ -54,7 +82,6 @@ class HandshakeScrubber:
         self.width: int | None = None
         self.height: int | None = None
 
-        self._bufs: dict[Direction, bytearray] = {"s2c": bytearray(), "c2s": bytearray()}
         self._gen: Generator[_Want, bytes, None] | None = self._run()
         self._want: _Want | None = None
         self._advance(None)
@@ -73,14 +100,20 @@ class HandshakeScrubber:
             self._gen = None
             self._want = None
 
-    def feed(self, direction: Direction, data: bytes) -> bytes:
+    def _waiting_on(self, tap: Tap) -> _Want | None:
+        """What the handshake wants from `tap`, if it is watching it at all."""
+        if self._gen is None or self._want is None or self._want.tap is not tap:
+            return None
+        return self._want
+
+    def _feed(self, tap: Tap, data: bytes) -> bytes:
         if not data:
             return b""
 
-        buf = self._bufs[direction]
+        buf = tap.pending
 
-        if self._gen is None or self._want is None or self._want[0] != direction:
-            # Not tracking this direction, so nothing pending here is a
+        if self._waiting_on(tap) is None:
+            # Not watching this direction, so nothing pending here is a
             # secret: flush it with the new data, unmodified.
             buf += data
             out = bytes(buf)
@@ -90,54 +123,45 @@ class HandshakeScrubber:
         buf += data
         out = bytearray()
 
-        while self._gen is not None and self._want is not None and self._want[0] == direction:
-            _, nbytes, mode = self._want
-            if len(buf) < nbytes:
+        while (want := self._waiting_on(tap)) is not None:
+            if len(buf) < want.nbytes:
                 break
-            chunk = bytes(buf[:nbytes])
-            del buf[:nbytes]
+            chunk = bytes(buf[:want.nbytes])
+            del buf[:want.nbytes]
             # Equal-length redaction: byte offsets after a scrubbed span
             # have to match the live stream or the capture stops replaying.
-            out += bytes(nbytes) if mode == "scrub" else chunk
+            out += bytes(want.nbytes) if want.scrub else chunk
             self._advance(chunk)
 
-        # No longer tracked, so flush rather than hold these back forever.
-        if buf and (self._gen is None or self._want is None or self._want[0] != direction):
+        # No longer watched, so flush rather than hold these back forever.
+        if buf and self._waiting_on(tap) is None:
             out += buf
             del buf[:]
 
         return bytes(out)
 
-    def flush(self) -> dict[Direction, bytes]:
-        """Bytes left buffered per direction when the connection ends.
+    def _flush(self, tap: Tap) -> bytes:
+        """Bytes left buffered on `tap` when the connection ends.
 
         Bytes buffered mid-secret are dropped instead of returned: half a
         challenge is still a fragment of a secret.
         """
-        out: dict[Direction, bytes] = {"s2c": b"", "c2s": b""}
-        for direction in ("s2c", "c2s"):
-            buf = self._bufs[direction]
-            if not buf:
-                continue
-            pending_is_secret = (
-                self._want is not None and self._want[0] == direction and self._want[2] == "scrub"
-            )
-            if not pending_is_secret:
-                out[direction] = bytes(buf)
-            del buf[:]
+        want = self._waiting_on(tap)
+        out = b"" if want is not None and want.scrub else bytes(tap.pending)
+        del tap.pending[:]
         return out
 
     # -- the handshake description -------------------------------------------
 
     def _run(self) -> Generator[_Want, bytes, None]:
-        server_head = yield ("s2c", 12, "pass")
+        server_head = yield _Want(self.s2c, 12, scrub=False)
         self.protocol_version = server_head.decode("ascii", "replace").rstrip("\n")
 
         # Branch on the client's reply, not the server's greeting: per RFC
         # 6143 7.1.1 that reply governs the rest of the exchange, so a client
         # downgrading below 3.7 would otherwise take this down the wrong path
         # and miss the challenge/response entirely.
-        client_head = yield ("c2s", 12, "pass")
+        client_head = yield _Want(self.c2s, 12, scrub=False)
         try:
             negotiated = (int(client_head[4:7]), int(client_head[8:11]))
         except (ValueError, IndexError):
@@ -145,16 +169,16 @@ class HandshakeScrubber:
         self.negotiated_version = negotiated
 
         if negotiated >= (3, 7):
-            num_types_b = yield ("s2c", 1, "pass")
+            num_types_b = yield _Want(self.s2c, 1, scrub=False)
             num_types = num_types_b[0]
             if num_types == 0:
                 return  # connection-failed reason string follows; not tracked
-            types_b = yield ("s2c", num_types, "pass")
+            types_b = yield _Want(self.s2c, num_types, scrub=False)
             self.security_types = list(types_b)
-            sectype_b = yield ("c2s", 1, "pass")
+            sectype_b = yield _Want(self.c2s, 1, scrub=False)
             sectype = sectype_b[0]
         else:
-            auth_b = yield ("s2c", 4, "pass")
+            auth_b = yield _Want(self.s2c, 4, scrub=False)
             sectype = int.from_bytes(auth_b, "big")
             if sectype == AuthTypes.INVALID:
                 return
@@ -163,19 +187,19 @@ class HandshakeScrubber:
         self.security_type = sectype
 
         if sectype == AuthTypes.VNC_AUTHENTICATION:
-            yield ("s2c", 16, "scrub")  # challenge
-            yield ("c2s", 16, "scrub")  # response
+            yield _Want(self.s2c, 16, scrub=True)  # challenge
+            yield _Want(self.c2s, 16, scrub=True)  # response
         elif sectype == AuthTypes.DIFFIE_HELLMAN:
             # ARD / Apple Screen Sharing, laid out as RFBClient._handleDHAuth
             # reads it. Only the client's AES block is secret; the DH values
             # are public by design, and keeping them is what makes the
             # capture useful for the ARD bugs this kit exists to chase.
-            head = yield ("s2c", 4, "pass")
+            head = yield _Want(self.s2c, 4, scrub=False)
             _generator, key_len = unpack("!HH", head)
-            yield ("s2c", key_len, "pass")  # modulus
-            yield ("s2c", key_len, "pass")  # server public key
-            yield ("c2s", ARD_CREDENTIALS_LEN, "scrub")  # username + password
-            yield ("c2s", key_len, "pass")  # client public key
+            yield _Want(self.s2c, key_len, scrub=False)  # modulus
+            yield _Want(self.s2c, key_len, scrub=False)  # server public key
+            yield _Want(self.c2s, ARD_CREDENTIALS_LEN, scrub=True)  # username + password
+            yield _Want(self.c2s, key_len, scrub=False)  # client public key
         elif sectype not in (AuthTypes.NONE, AuthTypes.INVALID):
             # No scrubber for this type: its key exchange would reach disk
             # whole. Name it, and stop unless a human opted in.
@@ -194,15 +218,15 @@ class HandshakeScrubber:
         # SecurityResult follows in every case but one: pre-3.8 with
         # AuthTypes.NONE jumps straight to ClientInit.
         if not (negotiated < (3, 8) and sectype == AuthTypes.NONE):
-            result_b = yield ("s2c", 4, "pass")
+            result_b = yield _Want(self.s2c, 4, scrub=False)
             (result,) = unpack("!I", result_b)
             if result != 0:
                 return  # auth failed/too-many-tries; reason string not tracked
 
-        yield ("c2s", 1, "pass")  # ClientInit: shared flag
+        yield _Want(self.c2s, 1, scrub=False)  # ClientInit: shared flag
 
         # ServerInit: width(2) height(2) pixel-format(16) name-len(4).
-        server_init = yield ("s2c", 24, "pass")
+        server_init = yield _Want(self.s2c, 24, scrub=False)
         self.width, self.height = unpack("!HH", server_init[:4])
 
         # Server name follows; nothing past it carries a tracked secret.
@@ -234,25 +258,15 @@ class CaptureWriter:
         self.encodings_seen[encoding] = self.encodings_seen.get(encoding, 0) + 1
 
     def feed_s2c(self, data: bytes) -> None:
-        self._feed("s2c", data)
+        self.s2c += self.scrubber.s2c.feed(data)
 
     def feed_c2s(self, data: bytes) -> None:
-        self._feed("c2s", data)
-
-    def _feed(self, direction: Direction, data: bytes) -> None:
-        self._append(direction, self.scrubber.feed(direction, data))
-
-    def _append(self, direction: Direction, data: bytes) -> None:
-        if not data:
-            return
-        buf = self.s2c if direction == "s2c" else self.c2s
-        buf += data
+        self.c2s += self.scrubber.c2s.feed(data)
 
     def flush(self) -> None:
         """Emit whatever the scrubber was still holding back, at disconnect."""
-        pending = self.scrubber.flush()
-        for direction, data in pending.items():
-            self._append(direction, data)
+        self.s2c += self.scrubber.s2c.flush()
+        self.c2s += self.scrubber.c2s.flush()
 
     def encodings_list(self) -> list[dict[str, Any]]:
         """`encodings_seen` as JSON, ordered and named where we know the name."""

--- a/vncdotool/capture.py
+++ b/vncdotool/capture.py
@@ -1,31 +1,14 @@
-"""Raw wire capture for the ``vnclog --capture`` discovery kit.
+"""Raw wire capture for the ``vnclog --capture-raw`` discovery kit.
 
-Scrubbing happens *before* bytes touch disk, and is kept here, socket-free,
-so it can be unit tested. Secrets are located by walking the handshake state
-machine, never by pattern matching -- every one of them is high-entropy and
-indistinguishable from any other span of the same length by content alone:
+Credentials are located by walking the handshake state machine, never by
+pattern matching: they are high-entropy and indistinguishable from any other
+span of the same length by content alone. Redacted spans are replaced by an
+equal number of zero bytes, so byte offsets do not shift and the capture
+still replays.
 
-* VNC auth (:attr:`AuthTypes.VNC_AUTHENTICATION`): the 16-byte challenge and
-  the 16-byte response.
-* ARD / Apple Screen Sharing (:attr:`AuthTypes.DIFFIE_HELLMAN`): the
-  128-byte AES-ECB block carrying username and password. The surrounding
-  Diffie-Hellman values (generator, modulus, both public keys) are public by
-  construction and pass through, so the capture still shows the key exchange
-  a compatibility bug would live in.
-
-Redacted spans are replaced by an equal number of zero bytes, never by a
-shorter or longer marker: a capture whose byte offsets shifted under
-scrubbing would no longer replay.
-
-An auth type with no scrubber aborts the capture and names itself, unless
-the contributor passes ``--capture-unsafe-auth``. Writing an unscrubbed key
-exchange to a file destined for a public issue tracker is a decision for a
-human with a disposable password, not a default. See ``docs/capture.rst``.
-
-Scrubbing stops at the end of the handshake. Everything the session itself
-carries -- keystrokes, clipboard -- is recorded verbatim; that risk is
-documented rather than filtered, because a capture with its input stream
-rewritten is no longer evidence of what the server did.
+An auth type with no scrubber aborts the capture unless the contributor
+passes ``--capture-raw-unsafe-auth``. Scrubbing stops at the end of the
+handshake; see ``docs/capture.rst``.
 """
 
 from __future__ import annotations
@@ -66,10 +49,9 @@ class HandshakeScrubber:
         self.negotiated_version: tuple[int, int] | None = None
         self.security_types: list[int] = []
         self.security_type: int | None = None
-        self.scrubbed: list[str] = []
         self.unscrubbed_auth: str | None = None
-        # Set when an auth type we cannot scrub is selected and the
-        # contributor has not opted in; the caller drops the capture.
+        # Set when an unscrubbable auth type is selected without an opt-in;
+        # the caller drops the capture.
         self.abort_reason: str | None = None
         self.width: int | None = None
         self.height: int | None = None
@@ -183,23 +165,18 @@ class HandshakeScrubber:
         self.security_type = sectype
 
         if sectype == AuthTypes.VNC_AUTHENTICATION:
-            yield ("s2c", 16, "scrub")
-            self.scrubbed.append("vnc-auth-challenge")
-            yield ("c2s", 16, "scrub")
-            self.scrubbed.append("vnc-auth-response")
+            yield ("s2c", 16, "scrub")  # challenge
+            yield ("c2s", 16, "scrub")  # response
         elif sectype == AuthTypes.DIFFIE_HELLMAN:
             # ARD / Apple Screen Sharing, laid out as RFBClient._handleDHAuth
-            # reads it: generator(2) keyLen(2), modulus(keyLen),
-            # serverKey(keyLen), then the client's reply. Only the client's
-            # AES block is secret -- the DH values are public by design, and
-            # keeping them is what makes the capture useful for the ARD
-            # compatibility bugs this kit exists to chase.
+            # reads it. Only the client's AES block is secret; the DH values
+            # are public by design, and keeping them is what makes the
+            # capture useful for the ARD bugs this kit exists to chase.
             head = yield ("s2c", 4, "pass")
             _generator, key_len = unpack("!HH", head)
             yield ("s2c", key_len, "pass")  # modulus
             yield ("s2c", key_len, "pass")  # server public key
-            yield ("c2s", ARD_CREDENTIALS_LEN, "scrub")
-            self.scrubbed.append("ard-credentials")
+            yield ("c2s", ARD_CREDENTIALS_LEN, "scrub")  # username + password
             yield ("c2s", key_len, "pass")  # client public key
         elif sectype not in (AuthTypes.NONE, AuthTypes.INVALID):
             # No scrubber for this type: its key exchange would reach disk
@@ -211,8 +188,8 @@ class HandshakeScrubber:
                 self.abort_reason = (
                     f"the session negotiated {self.unscrubbed_auth}, which vncdotool cannot scrub; "
                     "the capture would contain the credential exchange verbatim. "
-                    "Re-run with --capture-unsafe-auth, using a disposable password you "
-                    "rotate afterwards, if you need this exchange captured."
+                    "Re-run with --capture-raw-unsafe-auth, using a disposable password "
+                    "you rotate afterwards, if you need this exchange captured."
                 )
                 return
 
@@ -234,17 +211,6 @@ class HandshakeScrubber:
         return
 
 
-def scrub_password(data: bytes, password: bytes | None) -> tuple[bytes, bool]:
-    """Redact literal occurrences of `password` in `data`.
-
-    Best-effort: only catches a password landing entirely within one chunk.
-    """
-    if not password or password not in data:
-        return data, False
-    marker = b"\x00" * len(password)
-    return data.replace(password, marker), True
-
-
 @dataclass
 class CaptureWriter:
     """Scrubbed s2c/c2s streams and meta.json fields for one connection.
@@ -253,16 +219,13 @@ class CaptureWriter:
     """
 
     server: str
-    password: bytes | None = None
     scrubber: HandshakeScrubber = field(default_factory=HandshakeScrubber)
     s2c: bytearray = field(default_factory=bytearray)
     c2s: bytearray = field(default_factory=bytearray)
-    # encoding number -> rectangles seen. Recorded from the decoded stream,
-    # never from the client's SetEncodings request: a server may answer in
-    # any encoding it likes, and which one it actually chose is the whole
-    # question a capture from an unhostable server is meant to answer.
+    # encoding number -> rectangles seen, from the decoded stream rather than
+    # the client's SetEncodings request: a server may answer in any encoding
+    # it likes, and which one it chose is what the capture is asked for.
     encodings_seen: dict[int, int] = field(default_factory=dict)
-    _password_scrubbed: bool = False
     capture_timestamp: str = field(default_factory=lambda: time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()))
 
     @property
@@ -279,29 +242,19 @@ class CaptureWriter:
         self._feed("c2s", data)
 
     def _feed(self, direction: Direction, data: bytes) -> None:
-        scrubbed = self.scrubber.feed(direction, data)
-        self._append(direction, scrubbed)
+        self._append(direction, self.scrubber.feed(direction, data))
 
     def _append(self, direction: Direction, data: bytes) -> None:
         if not data:
             return
-        scrubbed, hit = scrub_password(data, self.password)
-        if hit:
-            self._password_scrubbed = True
         buf = self.s2c if direction == "s2c" else self.c2s
-        buf += scrubbed
+        buf += data
 
     def flush(self) -> None:
         """Emit whatever the scrubber was still holding back, at disconnect."""
         pending = self.scrubber.flush()
         for direction, data in pending.items():
             self._append(direction, data)
-
-    def scrubbed_list(self) -> list[str]:
-        names = list(self.scrubber.scrubbed)
-        if self._password_scrubbed:
-            names.append("password")
-        return names
 
     def encodings_list(self) -> list[dict[str, Any]]:
         """`encodings_seen` as JSON, ordered and named where we know the name."""
@@ -325,7 +278,6 @@ class CaptureWriter:
             "capture_timestamp": self.capture_timestamp,
             "protocol_version": self.scrubber.protocol_version,
             "security_types": self.scrubber.security_types,
-            "scrubbed": self.scrubbed_list(),
             "unscrubbed_auth": self.scrubber.unscrubbed_auth,
             "encodings_seen": self.encodings_list(),
             "geometry": (
@@ -357,15 +309,18 @@ class CaptureWriter:
 
 
 def check_capture_target(path: str) -> None:
-    """Validate `path` is usable as a --capture target.
+    """Validate `path` is usable as a --capture-raw target.
 
     Creates nothing: the archive is written when the session ends, so a
     later `op.error()` leaves nothing behind.
     """
     if not path.endswith(".zip"):
-        raise ValueError(f"--capture target {path!r} must end in .zip -- captures are written as one archive")
+        raise ValueError(f"--capture-raw target {path!r} must end in .zip -- captures are written as one archive")
     if os.path.exists(path):
-        raise ValueError(f"--capture target {path!r} already exists -- refusing to overwrite a capture")
+        raise ValueError(
+            f"--capture-raw target {path!r} already exists -- "
+            "refusing to overwrite a capture; pick another filename"
+        )
     parent = os.path.dirname(os.path.abspath(path))
     if not os.path.isdir(parent):
-        raise ValueError(f"--capture target directory {parent!r} does not exist")
+        raise ValueError(f"--capture-raw target directory {parent!r} does not exist")

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -481,7 +481,8 @@ def vnclog() -> None:
     options.address_family, options.host, options.port = parse_server(options.server)
 
     output = None
-    if options.one_shot and options.file_per_client:
+    # --capture-raw implies --one-shot, so it inherits the same conflict.
+    if (options.one_shot or options.capture_raw) and options.file_per_client:
         op.error("--file-per-client records several clients, so it cannot be combined with --one-shot")
     if options.capture_raw:
         if args:
@@ -530,6 +531,10 @@ def vnclog() -> None:
             env=os.environ,
         )
     reactor.run()
+    if factory.capture_failed and not reactor.exit_status:
+        # Aborted or unwritable capture: the contributor has no archive, so
+        # exiting 0 would tell a script the capture succeeded.
+        sys.exit(ExitStatus.COMMAND_FAILED)
     sys.exit(reactor.exit_status)
 
 

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -480,7 +480,10 @@ def vnclog() -> None:
 
     output = None
     if options.one_shot and options.forever:
-        op.error("--one-shot and --forever are mutually exclusive")
+        # --forever names an output layout (a .vdo per client), not a
+        # lifetime -- vnclog has always served connections until killed. It
+        # is still incoherent to ask for a file per client and stop after one.
+        op.error("--forever writes a file per client, so it cannot be combined with --one-shot")
     if options.capture_raw:
         if args:
             op.error("OUTPUT is implied by --capture-raw (session.vdo in the archive); do not also pass OUTPUT")

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -26,6 +26,7 @@ from twisted.internet.interfaces import IConnector
 from twisted.python.failure import Failure
 from twisted.python.log import PythonLoggingObserver
 
+from .capture import check_capture_dir
 from .client import (
     AuthenticationError,
     ProtocolError,
@@ -320,6 +321,7 @@ def build_tool(options: optparse.Values, args: list[str]) -> VNCDoCLIFactory:
 def build_proxy(options: optparse.Values) -> VNCLoggingServerFactory:
     factory = VNCLoggingServerFactory(options.host, int(options.port))
     factory.password_required = options.password_required
+    factory.server_str = options.server
     port = reactor.listenTCP(options.listen, factory)
     reactor.exit_status = 0
     factory.listen_port = port.getHost().port
@@ -419,7 +421,7 @@ def parse_server(server: str) -> tuple[socket.AddressFamily, str, int]:
 def vnclog() -> None:
     from vncdotool import __version__
 
-    usage = "%prog [options] OUTPUT"
+    usage = "%prog [options] [OUTPUT]"
     description = "Capture user interactions with a VNC Server"
     version = "%prog " + __version__
 
@@ -449,15 +451,36 @@ def vnclog() -> None:
         default=False,
         help="a VNC password is required to connect to the server",
     )
+    op.add_option(
+        "--capture",
+        metavar="DIR",
+        help="also write a raw wire capture (scrubbed of auth secrets) into DIR, "
+        "alongside session.vdo -- see docs/capture.rst. DIR must not exist or be "
+        "empty; OUTPUT is implied (DIR/session.vdo) and should be omitted.",
+    )
     options, args = op.parse_args()
 
     setup_logging(options)
 
     options.address_family, options.host, options.port = parse_server(options.server)
 
-    if len(args) != 1:
+    output = None
+    if options.capture:
+        if args:
+            op.error("OUTPUT is implied by --capture (DIR/session.vdo); do not also pass OUTPUT")
+        try:
+            check_capture_dir(options.capture)
+        except ValueError as exc:
+            op.error(str(exc))
+    elif len(args) != 1:
         op.error("incorrect number of arguments")
-    output = args[0]
+    else:
+        output = args[0]
+
+    # Created only after every argument validates, so an op.error() above
+    # leaves no stray directory behind.
+    if options.capture:
+        os.makedirs(options.capture, exist_ok=True)
 
     factory = build_proxy(options)
     # stderr, because stdout may carry the recorded session (OUTPUT of `-`)
@@ -467,7 +490,9 @@ def vnclog() -> None:
         flush=True,
     )
 
-    if options.forever and os.path.isdir(output):
+    if options.capture:
+        factory.capture_dir = options.capture
+    elif options.forever and os.path.isdir(output):
         factory.output = output
     elif options.forever:
         op.error("--forever requires OUTPUT to be a directory")

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -26,7 +26,7 @@ from twisted.internet.interfaces import IConnector
 from twisted.python.failure import Failure
 from twisted.python.log import PythonLoggingObserver
 
-from .capture import check_capture_dir
+from .capture import check_capture_target
 from .client import (
     AuthenticationError,
     ProtocolError,
@@ -453,10 +453,18 @@ def vnclog() -> None:
     )
     op.add_option(
         "--capture",
-        metavar="DIR",
-        help="also write a raw wire capture (scrubbed of auth secrets) into DIR, "
-        "alongside session.vdo -- see docs/capture.rst. DIR must not exist or be "
-        "empty; OUTPUT is implied (DIR/session.vdo) and should be omitted.",
+        metavar="FILE.zip",
+        help="write a raw wire capture (scrubbed of auth secrets) to FILE.zip, "
+        "ready to attach to an issue -- see docs/capture.rst. FILE.zip must not "
+        "exist; OUTPUT is implied (session.vdo inside the archive) and should be omitted.",
+    )
+    op.add_option(
+        "--capture-unsafe-auth",
+        action="store_true",
+        default=False,
+        help="allow --capture to record auth types vncdotool cannot scrub, storing "
+        "the credential exchange verbatim. Use a disposable password and rotate it "
+        "afterwards.",
     )
     options, args = op.parse_args()
 
@@ -467,20 +475,17 @@ def vnclog() -> None:
     output = None
     if options.capture:
         if args:
-            op.error("OUTPUT is implied by --capture (DIR/session.vdo); do not also pass OUTPUT")
+            op.error("OUTPUT is implied by --capture (session.vdo in the archive); do not also pass OUTPUT")
         try:
-            check_capture_dir(options.capture)
+            check_capture_target(options.capture)
         except ValueError as exc:
             op.error(str(exc))
+    elif options.capture_unsafe_auth:
+        op.error("--capture-unsafe-auth is only meaningful with --capture")
     elif len(args) != 1:
         op.error("incorrect number of arguments")
     else:
         output = args[0]
-
-    # Created only after every argument validates, so an op.error() above
-    # leaves no stray directory behind.
-    if options.capture:
-        os.makedirs(options.capture, exist_ok=True)
 
     factory = build_proxy(options)
     # stderr, because stdout may carry the recorded session (OUTPUT of `-`)
@@ -491,7 +496,8 @@ def vnclog() -> None:
     )
 
     if options.capture:
-        factory.capture_dir = options.capture
+        factory.capture_path = options.capture
+        factory.capture_unsafe_auth = options.capture_unsafe_auth
     elif options.forever and os.path.isdir(output):
         factory.output = output
     elif options.forever:

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -435,9 +435,11 @@ def vnclog() -> None:
         help="listen for client connections on PORT [%default]",
     )
     op.add_option(
-        "--forever",
+        "--file-per-client",
         action="store_true",
-        help="continually accept new connections",
+        default=False,
+        help="record each client connection to its own .vdo in OUTPUT, which must "
+        "be a directory (was --forever, which never controlled how long vnclog ran)",
     )
     op.add_option(
         "--viewer",
@@ -479,11 +481,8 @@ def vnclog() -> None:
     options.address_family, options.host, options.port = parse_server(options.server)
 
     output = None
-    if options.one_shot and options.forever:
-        # --forever names an output layout (a .vdo per client), not a
-        # lifetime -- vnclog has always served connections until killed. It
-        # is still incoherent to ask for a file per client and stop after one.
-        op.error("--forever writes a file per client, so it cannot be combined with --one-shot")
+    if options.one_shot and options.file_per_client:
+        op.error("--file-per-client records several clients, so it cannot be combined with --one-shot")
     if options.capture_raw:
         if args:
             op.error("OUTPUT is implied by --capture-raw (session.vdo in the archive); do not also pass OUTPUT")
@@ -511,10 +510,10 @@ def vnclog() -> None:
     if options.capture_raw:
         factory.capture_path = options.capture_raw
         factory.capture_unsafe_auth = options.capture_raw_unsafe_auth
-    elif options.forever and os.path.isdir(output):
+    elif options.file_per_client and os.path.isdir(output):
         factory.output = output
-    elif options.forever:
-        op.error("--forever requires OUTPUT to be a directory")
+    elif options.file_per_client:
+        op.error("--file-per-client requires OUTPUT to be a directory")
     elif output == "-":
         factory.output = sys.stdout
     else:

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -321,7 +321,7 @@ def build_tool(options: optparse.Values, args: list[str]) -> VNCDoCLIFactory:
 def build_proxy(options: optparse.Values) -> VNCLoggingServerFactory:
     factory = VNCLoggingServerFactory(options.host, int(options.port))
     factory.password_required = options.password_required
-    factory.server_str = options.server
+    factory.server_address = options.server
     port = reactor.listenTCP(options.listen, factory)
     reactor.exit_status = 0
     factory.listen_port = port.getHost().port
@@ -452,6 +452,12 @@ def vnclog() -> None:
         help="a VNC password is required to connect to the server",
     )
     op.add_option(
+        "--one-shot",
+        action="store_true",
+        default=False,
+        help="serve a single session, then exit; implied by --capture-raw",
+    )
+    op.add_option(
         "--capture-raw",
         metavar="FILE.zip",
         help="write a raw wire capture (scrubbed of auth secrets) to FILE.zip, "
@@ -473,6 +479,8 @@ def vnclog() -> None:
     options.address_family, options.host, options.port = parse_server(options.server)
 
     output = None
+    if options.one_shot and options.forever:
+        op.error("--one-shot and --forever are mutually exclusive")
     if options.capture_raw:
         if args:
             op.error("OUTPUT is implied by --capture-raw (session.vdo in the archive); do not also pass OUTPUT")
@@ -494,6 +502,8 @@ def vnclog() -> None:
         file=sys.stderr,
         flush=True,
     )
+
+    factory.one_shot = options.one_shot or bool(options.capture_raw)
 
     if options.capture_raw:
         factory.capture_path = options.capture_raw

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -452,17 +452,17 @@ def vnclog() -> None:
         help="a VNC password is required to connect to the server",
     )
     op.add_option(
-        "--capture",
+        "--capture-raw",
         metavar="FILE.zip",
         help="write a raw wire capture (scrubbed of auth secrets) to FILE.zip, "
         "ready to attach to an issue -- see docs/capture.rst. FILE.zip must not "
         "exist; OUTPUT is implied (session.vdo inside the archive) and should be omitted.",
     )
     op.add_option(
-        "--capture-unsafe-auth",
+        "--capture-raw-unsafe-auth",
         action="store_true",
         default=False,
-        help="allow --capture to record auth types vncdotool cannot scrub, storing "
+        help="allow --capture-raw to record auth types vncdotool cannot scrub, storing "
         "the credential exchange verbatim. Use a disposable password and rotate it "
         "afterwards.",
     )
@@ -473,15 +473,15 @@ def vnclog() -> None:
     options.address_family, options.host, options.port = parse_server(options.server)
 
     output = None
-    if options.capture:
+    if options.capture_raw:
         if args:
-            op.error("OUTPUT is implied by --capture (session.vdo in the archive); do not also pass OUTPUT")
+            op.error("OUTPUT is implied by --capture-raw (session.vdo in the archive); do not also pass OUTPUT")
         try:
-            check_capture_target(options.capture)
+            check_capture_target(options.capture_raw)
         except ValueError as exc:
             op.error(str(exc))
-    elif options.capture_unsafe_auth:
-        op.error("--capture-unsafe-auth is only meaningful with --capture")
+    elif options.capture_raw_unsafe_auth:
+        op.error("--capture-raw-unsafe-auth is only meaningful with --capture-raw")
     elif len(args) != 1:
         op.error("incorrect number of arguments")
     else:
@@ -495,9 +495,9 @@ def vnclog() -> None:
         flush=True,
     )
 
-    if options.capture:
-        factory.capture_path = options.capture
-        factory.capture_unsafe_auth = options.capture_unsafe_auth
+    if options.capture_raw:
+        factory.capture_path = options.capture_raw
+        factory.capture_unsafe_auth = options.capture_raw_unsafe_auth
     elif options.forever and os.path.isdir(output):
         factory.output = output
     elif options.forever:

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -192,9 +192,8 @@ class VNCLoggingClient(VNCDoToolClient):
     capture: CaptureWriter | None = None
 
     def _handleRectangle(self, block: bytes) -> None:
-        # Tallied here, off the decoded stream, because this is the only
-        # place that knows what the server actually sent. SetEncodings only
-        # says what the client asked for, and a server may ignore it.
+        # Tallied off the decoded stream: SetEncodings only says what the
+        # client asked for, and a server may ignore it.
         if self.capture is not None:
             (encoding,) = unpack("!i", block[8:12])
             self.capture.note_encoding(encoding)
@@ -276,13 +275,11 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
     capture: CaptureWriter | None = None
 
     def connectionMade(self) -> None:
-        # One capture per directory: the format is singular, and a viewer
-        # that reconnects would otherwise overwrite the capture the
-        # contributor wanted. Claimed on accept, not on write, so a second
-        # concurrent connection is refused too.
+        # Claimed on accept rather than on write, so a second concurrent
+        # connection is refused too instead of overwriting the capture.
         if self.factory.capture_path and self.factory.capture_claimed:
             log.warning(
-                "--capture %s already has a session; refusing connection from %s",
+                "--capture-raw %s already has a session; refusing connection from %s",
                 self.factory.capture_path,
                 self.transport.getPeer().host,
             )
@@ -297,26 +294,23 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
         self.recorder = self.factory.getRecorder()
         if self.factory.capture_path:
             self.factory.capture_claimed = True
-            password = self.factory.password.encode() if self.factory.password else None
             self.capture = CaptureWriter(
                 server=self.factory.server_str,
-                password=password,
                 scrubber=HandshakeScrubber(allow_unsafe_auth=self.factory.capture_unsafe_auth),
             )
 
     def connectionLost(self, reason: Failure) -> None:
         if self.capture is not None:
             if self.capture.s2c or self.capture.c2s:
-                # Bytes in either direction count, including a server that
-                # rejects the client before the client sends anything -- that
-                # rejection is the evidence being captured. So nothing may
-                # port-probe a capture-mode vnclog: the forwarded greeting
-                # would look like a session and claim the capture.
+                # Bytes in either direction count: a server rejecting the
+                # client before it speaks is itself the evidence. So nothing
+                # may port-probe a capture-mode vnclog -- the forwarded
+                # greeting would look like a session and claim the capture.
                 self._writeCapture()
             else:
                 # A bare TCP open/close is not a session. Release the claim
                 # rather than lock out the real connection behind it.
-                log.debug("--capture: connection produced no bytes, not claiming the capture")
+                log.debug("--capture-raw: connection produced no bytes, not claiming the capture")
                 self.factory.capture_claimed = False
                 self.capture = None
         super().connectionLost(reason)
@@ -331,18 +325,17 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
             self.capture.meta(VNCDOTOOL_VERSION),
             session_vdo=self.factory.getRecordedSession(),
         )
-        log.info("--capture: wrote %s", capture_path)
+        log.info("--capture-raw: wrote %s", capture_path)
         # Guard against a double connectionLost (peer already gone) writing twice.
         self.capture = None
 
     def _abortCapture(self, reason: str) -> None:
         """Drop an in-flight capture we are not allowed to write.
 
-        Nothing reaches disk and the connection ends: a contributor who
-        cannot get a scrubbed capture should find out now, not on reading
-        the warning under an archive they already attached to an issue.
+        Nothing reaches disk and the connection ends, so a contributor finds
+        out now rather than after attaching the archive to an issue.
         """
-        log.error("--capture aborted: %s", reason)
+        log.error("--capture-raw aborted: %s", reason)
         self.capture = None
         if self.vnclog_client is not None:
             self.vnclog_client.capture = None
@@ -440,9 +433,8 @@ class VNCLoggingServerFactory(portforward.ProxyFactory):  # type: ignore[misc]
 
     def getRecorder(self) -> Callable[[str], int]:
         if self.capture_path:
-            # Buffered, not written straight to disk: the session log is one
-            # member of the capture archive, and nothing may exist on disk
-            # until the whole capture is known to be writable.
+            # Buffered: the session log is one member of the archive, so
+            # nothing lands on disk until the whole capture is writable.
             self._capture_vdo = io.StringIO()
             return self._capture_vdo.write
         elif isinstance(self.output, str):

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -278,6 +278,12 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
     recorder: Callable[[str], int] | None = None
     capture: CaptureWriter | None = None
     saw_bytes: bool = False
+    # A refused connection owns nothing: it never ran ProxyServer's
+    # connectionMade, so it has no peer, no recorder and no claim to release.
+    # It can still receive bytes -- pauseProducing() is part of the setup it
+    # skipped -- so every later hook has to check this first.
+    refused: bool = False
+    took_session: bool = False
 
     def connectionMade(self) -> None:
         # Taken on accept rather than on first byte, so a second concurrent
@@ -287,6 +293,7 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
                 "--one-shot: already serving a session; refusing connection from %s",
                 self.transport.getPeer().host,
             )
+            self.refused = True
             self.transport.loseConnection()
             return
 
@@ -298,6 +305,7 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
         self.recorder = self.factory.getRecorder()
         if self.factory.one_shot:
             self.factory.session_taken = True
+            self.took_session = True
         if self.factory.capture_path:
             self.capture = CaptureWriter(
                 server=self.factory.server_address,
@@ -305,18 +313,33 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
             )
 
     def connectionLost(self, reason: Failure) -> None:
+        if self.refused:
+            # Touching the factory here would release the live session's
+            # claim, or close the recorder it is still writing to.
+            return
+
         # Bytes in either direction make it a session, including a server
         # rejecting the client before it speaks -- that rejection is itself
         # the evidence. A bare TCP open/close is not one, so a port probe
         # neither writes a capture nor uses up a --one-shot run.
         if self.saw_bytes:
-            if self.capture is not None:
-                self._writeCapture()
-            if self.factory.one_shot:
-                self.factory.sessionFinished()
+            try:
+                if self.capture is not None:
+                    self._writeCapture()
+            except Exception:
+                # Unwritable path, full disk: the contributor has no archive,
+                # so the exit status has to say so.
+                log.error("--capture-raw: could not write %s", self.factory.capture_path, exc_info=True)
+                self.factory.capture_failed = True
+            finally:
+                # Even a failed write has to end a --one-shot run: the
+                # alternative is a process that never exits.
+                if self.factory.one_shot:
+                    self.factory.sessionFinished()
         else:
             log.debug("connection produced no bytes; not counting it as a session")
-            self.factory.session_taken = False
+            if self.took_session:
+                self.factory.session_taken = False
             self.capture = None
         super().connectionLost(reason)
         self.factory.clientConnectionLost(self)
@@ -341,6 +364,7 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
         out now rather than after attaching the archive to an issue.
         """
         log.error("--capture-raw aborted: %s", reason)
+        self.factory.capture_failed = True
         self.capture = None
         if self.vnclog_client is not None:
             self.vnclog_client.capture = None
@@ -352,6 +376,11 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
         return getattr(peer, "vnclog", None) if peer is not None else None
 
     def dataReceived(self, data: bytes) -> None:
+        if self.refused:
+            # loseConnection() is not instant and this connection never got
+            # ProxyServer's pauseProducing(), so bytes can still arrive.
+            return
+
         # Capture first: a parse failure below must never truncate it.
         if data:
             self.saw_bytes = True
@@ -433,6 +462,8 @@ class VNCLoggingServerFactory(portforward.ProxyFactory):  # type: ignore[misc]
 
     capture_path: str | None = None
     capture_unsafe_auth: bool = False
+    # Aborted or unwritable: read by the CLI to pick a non-zero exit status.
+    capture_failed: bool = False
     server_address: str = ""
     _capture_vdo: io.StringIO | None = None
 

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import logging
 import os.path
 import socket
@@ -13,7 +14,7 @@ from twisted.protocols import portforward
 from twisted.python.failure import Failure
 
 from . import __version__ as VNCDOTOOL_VERSION
-from .capture import CaptureWriter, write_meta
+from .capture import CaptureWriter, HandshakeScrubber
 from .const import AuthTypes, Encoding, MsgC2S, QemuClientMessage
 from .client import VNCDoToolClient
 from .keys import KEYMAP
@@ -188,6 +189,16 @@ class VNCLoggingClient(VNCDoToolClient):
     """Specialization of a :class:`VNCDoToolClient` that will save screen captures."""
 
     capture_file: str | None = None
+    capture: CaptureWriter | None = None
+
+    def _handleRectangle(self, block: bytes) -> None:
+        # Tallied here, off the decoded stream, because this is the only
+        # place that knows what the server actually sent. SetEncodings only
+        # says what the client asked for, and a server may ignore it.
+        if self.capture is not None:
+            (encoding,) = unpack("!i", block[8:12])
+            self.capture.note_encoding(encoding)
+        super()._handleRectangle(block)
 
     def commitUpdate(self, rectangles: list[Rect] | None = None) -> None:
         if self.capture_file:
@@ -214,6 +225,7 @@ class VNCLoggingClientProxy(portforward.ProxyClient):  # type: ignore[misc]
         self.vnclog.transport = NullTransport()
         self.vnclog.factory = self.peer.factory
         self.vnclog.recorder = peer.recorder
+        self.vnclog.capture = peer.capture
         # XXX double call to connectionMade?
         self.vnclog.connectionMade()
         self.vnclog._handler = self.vnclog._handleExpected
@@ -224,6 +236,11 @@ class VNCLoggingClientProxy(portforward.ProxyClient):  # type: ignore[misc]
         # truncate the recording.
         if self.peer is not None and self.peer.capture is not None:
             self.peer.capture.feed_s2c(data)
+            # Pre-3.7 the *server* picks the security type, so an
+            # unscrubbable one surfaces on this side of the proxy.
+            if self.peer.capture.abort_reason is not None:
+                self.peer._abortCapture(self.peer.capture.abort_reason)
+                return
         if self.vnclog:
             try:
                 self.vnclog.dataReceived(data)
@@ -263,10 +280,10 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
         # that reconnects would otherwise overwrite the capture the
         # contributor wanted. Claimed on accept, not on write, so a second
         # concurrent connection is refused too.
-        if self.factory.capture_dir and self.factory.capture_claimed:
+        if self.factory.capture_path and self.factory.capture_claimed:
             log.warning(
                 "--capture %s already has a session; refusing connection from %s",
-                self.factory.capture_dir,
+                self.factory.capture_path,
                 self.transport.getPeer().host,
             )
             self.transport.loseConnection()
@@ -278,10 +295,14 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
         self.mouse: tuple[int | None, int | None] = (None, None)
         self.last_event = time.time()
         self.recorder = self.factory.getRecorder()
-        if self.factory.capture_dir:
+        if self.factory.capture_path:
             self.factory.capture_claimed = True
             password = self.factory.password.encode() if self.factory.password else None
-            self.capture = CaptureWriter(server=self.factory.server_str, password=password)
+            self.capture = CaptureWriter(
+                server=self.factory.server_str,
+                password=password,
+                scrubber=HandshakeScrubber(allow_unsafe_auth=self.factory.capture_unsafe_auth),
+            )
 
     def connectionLost(self, reason: Failure) -> None:
         if self.capture is not None:
@@ -303,21 +324,44 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
 
     def _writeCapture(self) -> None:
         assert self.capture is not None
-        capture_dir = self.factory.capture_dir
-        assert capture_dir is not None
-        self.capture.write(capture_dir)
-        write_meta(
-            os.path.join(capture_dir, "meta.json"),
+        capture_path = self.factory.capture_path
+        assert capture_path is not None
+        self.capture.write_archive(
+            capture_path,
             self.capture.meta(VNCDOTOOL_VERSION),
+            session_vdo=self.factory.getRecordedSession(),
         )
+        log.info("--capture: wrote %s", capture_path)
         # Guard against a double connectionLost (peer already gone) writing twice.
         self.capture = None
+
+    def _abortCapture(self, reason: str) -> None:
+        """Drop an in-flight capture we are not allowed to write.
+
+        Nothing reaches disk and the connection ends: a contributor who
+        cannot get a scrubbed capture should find out now, not on reading
+        the warning under an archive they already attached to an issue.
+        """
+        log.error("--capture aborted: %s", reason)
+        self.capture = None
+        if self.vnclog_client is not None:
+            self.vnclog_client.capture = None
+        self.factory.capture_aborted = True
+        self.transport.loseConnection()
+
+    @property
+    def vnclog_client(self) -> VNCLoggingClient | None:
+        peer = getattr(self, "peer", None)
+        return getattr(peer, "vnclog", None) if peer is not None else None
 
     def dataReceived(self, data: bytes) -> None:
         # Capture first, unconditionally: a parse failure below must never
         # truncate the recording.
         if self.capture is not None:
             self.capture.feed_c2s(data)
+            if self.capture.abort_reason is not None:
+                self._abortCapture(self.capture.abort_reason)
+                return
         try:
             RFBServer.dataReceived(self, data)
         except Exception:
@@ -387,17 +431,20 @@ class VNCLoggingServerFactory(portforward.ProxyFactory):  # type: ignore[misc]
 
     # `capture_claimed` latches on the first connection accepted in capture
     # mode, so a later one is refused rather than clobbering the capture.
-    capture_dir: str | None = None
+    capture_path: str | None = None
     capture_claimed: bool = False
+    capture_aborted: bool = False
+    capture_unsafe_auth: bool = False
     server_str: str = ""
+    _capture_vdo: io.StringIO | None = None
 
     def getRecorder(self) -> Callable[[str], int]:
-        if self.capture_dir:
-            # Opened and closed per connection, like --forever, so
-            # session.vdo is complete when the client disconnects.
-            outfile = os.path.join(self.capture_dir, "session.vdo")
-            self._out = open(outfile, "w")
-            return self._out.write
+        if self.capture_path:
+            # Buffered, not written straight to disk: the session log is one
+            # member of the capture archive, and nothing may exist on disk
+            # until the whole capture is known to be writable.
+            self._capture_vdo = io.StringIO()
+            return self._capture_vdo.write
         elif isinstance(self.output, str):
             now = time.strftime("%y%m%d-%H%M%S")
             outfile = os.path.join(self.output, "%s.vdo" % now)
@@ -406,6 +453,10 @@ class VNCLoggingServerFactory(portforward.ProxyFactory):  # type: ignore[misc]
         else:
             return self.output.write
 
+    def getRecordedSession(self) -> bytes:
+        """The buffered session.vdo for this capture, for the archive."""
+        return self._capture_vdo.getvalue().encode() if self._capture_vdo else b""
+
     def clientConnectionMade(self, client: VNCLoggingServerProxy) -> None:
         pass
 
@@ -413,3 +464,4 @@ class VNCLoggingServerFactory(portforward.ProxyFactory):  # type: ignore[misc]
         if self._out:
             self._out.close()
             self._out = None
+        self._capture_vdo = None

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -9,6 +9,7 @@ import time
 from struct import unpack, unpack_from
 from typing import IO, Callable, Sequence
 
+from twisted.internet.error import ReactorNotRunning
 from twisted.internet.protocol import Protocol
 from twisted.protocols import portforward
 from twisted.python.failure import Failure
@@ -231,8 +232,9 @@ class VNCLoggingClientProxy(portforward.ProxyClient):  # type: ignore[misc]
         self.vnclog.expect(self.vnclog._handleServerInit, 24)
 
     def dataReceived(self, data: bytes) -> None:
-        # Capture first, unconditionally: a parse failure below must never
-        # truncate the recording.
+        # Capture first: a parse failure below must never truncate it.
+        if self.peer is not None and data:
+            self.peer.saw_bytes = True
         if self.peer is not None and self.peer.capture is not None:
             self.peer.capture.feed_s2c(data)
             # Pre-3.7 the *server* picks the security type, so an
@@ -241,17 +243,19 @@ class VNCLoggingClientProxy(portforward.ProxyClient):  # type: ignore[misc]
                 self.peer._abortCapture(self.peer.capture.abort_reason)
                 return
         if self.vnclog:
+            # The decoder is an observer: it feeds the log, never the client.
+            # Killing a session the server was happy with, because our own
+            # optional logging choked, would record a vnclog artefact.
             try:
                 self.vnclog.dataReceived(data)
             except Exception:
                 log.warning(
-                    "vnclog client failed to parse %d server bytes; capture and forwarding continue",
+                    "vnclog client failed to parse %d server bytes; forwarding continues",
                     len(data), exc_info=True,
                 )
-        try:
-            super().dataReceived(data)
-        except Exception:
-            log.warning("failed forwarding %d server bytes to client", len(data), exc_info=True)
+        # Forwarding is not wrapped: if bytes cannot reach the client, the
+        # session has to fail like it always did rather than hang.
+        super().dataReceived(data)
 
 
 class VNCLoggingClientFactory(portforward.ProxyClientFactory):  # type: ignore[misc]
@@ -273,14 +277,14 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
     buttons = 0
     recorder: Callable[[str], int] | None = None
     capture: CaptureWriter | None = None
+    saw_bytes: bool = False
 
     def connectionMade(self) -> None:
-        # Claimed on accept rather than on write, so a second concurrent
-        # connection is refused too instead of overwriting the capture.
-        if self.factory.capture_path and self.factory.capture_claimed:
+        # Taken on accept rather than on first byte, so a second concurrent
+        # connection is refused rather than interleaved into the session.
+        if self.factory.one_shot and self.factory.session_taken:
             log.warning(
-                "--capture-raw %s already has a session; refusing connection from %s",
-                self.factory.capture_path,
+                "--one-shot: already serving a session; refusing connection from %s",
                 self.transport.getPeer().host,
             )
             self.transport.loseConnection()
@@ -292,27 +296,28 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
         self.mouse: tuple[int | None, int | None] = (None, None)
         self.last_event = time.time()
         self.recorder = self.factory.getRecorder()
+        if self.factory.one_shot:
+            self.factory.session_taken = True
         if self.factory.capture_path:
-            self.factory.capture_claimed = True
             self.capture = CaptureWriter(
-                server=self.factory.server_str,
+                server=self.factory.server_address,
                 scrubber=HandshakeScrubber(allow_unsafe_auth=self.factory.capture_unsafe_auth),
             )
 
     def connectionLost(self, reason: Failure) -> None:
-        if self.capture is not None:
-            if self.capture.s2c or self.capture.c2s:
-                # Bytes in either direction count: a server rejecting the
-                # client before it speaks is itself the evidence. So nothing
-                # may port-probe a capture-mode vnclog -- the forwarded
-                # greeting would look like a session and claim the capture.
+        # Bytes in either direction make it a session, including a server
+        # rejecting the client before it speaks -- that rejection is itself
+        # the evidence. A bare TCP open/close is not one, so a port probe
+        # neither writes a capture nor uses up a --one-shot run.
+        if self.saw_bytes:
+            if self.capture is not None:
                 self._writeCapture()
-            else:
-                # A bare TCP open/close is not a session. Release the claim
-                # rather than lock out the real connection behind it.
-                log.debug("--capture-raw: connection produced no bytes, not claiming the capture")
-                self.factory.capture_claimed = False
-                self.capture = None
+            if self.factory.one_shot:
+                self.factory.sessionFinished()
+        else:
+            log.debug("connection produced no bytes; not counting it as a session")
+            self.factory.session_taken = False
+            self.capture = None
         super().connectionLost(reason)
         self.factory.clientConnectionLost(self)
 
@@ -339,7 +344,6 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
         self.capture = None
         if self.vnclog_client is not None:
             self.vnclog_client.capture = None
-        self.factory.capture_aborted = True
         self.transport.loseConnection()
 
     @property
@@ -348,24 +352,24 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
         return getattr(peer, "vnclog", None) if peer is not None else None
 
     def dataReceived(self, data: bytes) -> None:
-        # Capture first, unconditionally: a parse failure below must never
-        # truncate the recording.
+        # Capture first: a parse failure below must never truncate it.
+        if data:
+            self.saw_bytes = True
         if self.capture is not None:
             self.capture.feed_c2s(data)
             if self.capture.abort_reason is not None:
                 self._abortCapture(self.capture.abort_reason)
                 return
+        # See VNCLoggingClientProxy.dataReceived: the semantic parser is an
+        # observer, the forwarding is not.
         try:
             RFBServer.dataReceived(self, data)
         except Exception:
             log.warning(
-                "RFBServer failed to parse %d client bytes; capture and forwarding continue",
+                "RFBServer failed to parse %d client bytes; forwarding continues",
                 len(data), exc_info=True,
             )
-        try:
-            super().dataReceived(data)
-        except Exception:
-            log.warning("failed forwarding %d client bytes to server", len(data), exc_info=True)
+        super().dataReceived(data)
 
     def _handle_clientInit(self) -> None:
         RFBServer._handle_clientInit(self)
@@ -422,14 +426,25 @@ class VNCLoggingServerFactory(portforward.ProxyFactory):  # type: ignore[misc]
     output: IO[str] | str = sys.stdout
     _out: IO[str] | None = None
 
-    # `capture_claimed` latches on the first connection accepted in capture
-    # mode, so a later one is refused rather than clobbering the capture.
+    # --one-shot: serve a single session, then exit. `session_taken` latches
+    # on the connection that gets it, so a concurrent second one is refused.
+    one_shot: bool = False
+    session_taken: bool = False
+
     capture_path: str | None = None
-    capture_claimed: bool = False
-    capture_aborted: bool = False
     capture_unsafe_auth: bool = False
-    server_str: str = ""
+    server_address: str = ""
     _capture_vdo: io.StringIO | None = None
+
+    def sessionFinished(self) -> None:
+        """End the process after a --one-shot session, once it has closed."""
+        from twisted.internet import reactor
+
+        log.info("--one-shot: session finished, shutting down")
+        try:
+            reactor.stop()
+        except ReactorNotRunning:
+            pass
 
     def getRecorder(self) -> Callable[[str], int]:
         if self.capture_path:

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -12,6 +12,8 @@ from twisted.internet.protocol import Protocol
 from twisted.protocols import portforward
 from twisted.python.failure import Failure
 
+from . import __version__ as VNCDOTOOL_VERSION
+from .capture import CaptureWriter, write_meta
 from .const import AuthTypes, Encoding, MsgC2S, QemuClientMessage
 from .client import VNCDoToolClient
 from .keys import KEYMAP
@@ -72,7 +74,14 @@ class RFBServer(Protocol):  # type: ignore[misc]
         sectype = self.buffer[0]
         log.debug("Client selected %r", AuthTypes.lookup(sectype))
         del self.buffer[:1]
-        self._handler = self._handle_clientInit, 1
+        if sectype == AuthTypes.VNC_AUTHENTICATION:
+            # The challenge/response is the same 16 bytes as on the pre-3.7
+            # path, and must be skipped the same way: otherwise the response's
+            # first byte is read as ClientInit's `shared` flag and everything
+            # downstream desyncs.
+            self._handler = self._handle_VNCAuthResponse, 16
+        else:
+            self._handler = self._handle_clientInit, 1
 
     def _handle_VNCAuthResponse(self) -> None:
         del self.buffer[:16]
@@ -211,9 +220,22 @@ class VNCLoggingClientProxy(portforward.ProxyClient):  # type: ignore[misc]
         self.vnclog.expect(self.vnclog._handleServerInit, 24)
 
     def dataReceived(self, data: bytes) -> None:
-        super().dataReceived(data)
+        # Capture first, unconditionally: a parse failure below must never
+        # truncate the recording.
+        if self.peer is not None and self.peer.capture is not None:
+            self.peer.capture.feed_s2c(data)
         if self.vnclog:
-            self.vnclog.dataReceived(data)
+            try:
+                self.vnclog.dataReceived(data)
+            except Exception:
+                log.warning(
+                    "vnclog client failed to parse %d server bytes; capture and forwarding continue",
+                    len(data), exc_info=True,
+                )
+        try:
+            super().dataReceived(data)
+        except Exception:
+            log.warning("failed forwarding %d server bytes to client", len(data), exc_info=True)
 
 
 class VNCLoggingClientFactory(portforward.ProxyClientFactory):  # type: ignore[misc]
@@ -234,22 +256,79 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
     server: str | None = None
     buttons = 0
     recorder: Callable[[str], int] | None = None
+    capture: CaptureWriter | None = None
 
     def connectionMade(self) -> None:
+        # One capture per directory: the format is singular, and a viewer
+        # that reconnects would otherwise overwrite the capture the
+        # contributor wanted. Claimed on accept, not on write, so a second
+        # concurrent connection is refused too.
+        if self.factory.capture_dir and self.factory.capture_claimed:
+            log.warning(
+                "--capture %s already has a session; refusing connection from %s",
+                self.factory.capture_dir,
+                self.transport.getPeer().host,
+            )
+            self.transport.loseConnection()
+            return
+
         log.info("new connection from %s", self.transport.getPeer().host)
         super().connectionMade()
         RFBServer.connectionMade(self)
         self.mouse: tuple[int | None, int | None] = (None, None)
         self.last_event = time.time()
         self.recorder = self.factory.getRecorder()
+        if self.factory.capture_dir:
+            self.factory.capture_claimed = True
+            password = self.factory.password.encode() if self.factory.password else None
+            self.capture = CaptureWriter(server=self.factory.server_str, password=password)
 
     def connectionLost(self, reason: Failure) -> None:
+        if self.capture is not None:
+            if self.capture.s2c or self.capture.c2s:
+                # Bytes in either direction count, including a server that
+                # rejects the client before the client sends anything -- that
+                # rejection is the evidence being captured. So nothing may
+                # port-probe a capture-mode vnclog: the forwarded greeting
+                # would look like a session and claim the capture.
+                self._writeCapture()
+            else:
+                # A bare TCP open/close is not a session. Release the claim
+                # rather than lock out the real connection behind it.
+                log.debug("--capture: connection produced no bytes, not claiming the capture")
+                self.factory.capture_claimed = False
+                self.capture = None
         super().connectionLost(reason)
         self.factory.clientConnectionLost(self)
 
+    def _writeCapture(self) -> None:
+        assert self.capture is not None
+        capture_dir = self.factory.capture_dir
+        assert capture_dir is not None
+        self.capture.write(capture_dir)
+        write_meta(
+            os.path.join(capture_dir, "meta.json"),
+            self.capture.meta(VNCDOTOOL_VERSION),
+        )
+        # Guard against a double connectionLost (peer already gone) writing twice.
+        self.capture = None
+
     def dataReceived(self, data: bytes) -> None:
-        RFBServer.dataReceived(self, data)
-        super().dataReceived(data)
+        # Capture first, unconditionally: a parse failure below must never
+        # truncate the recording.
+        if self.capture is not None:
+            self.capture.feed_c2s(data)
+        try:
+            RFBServer.dataReceived(self, data)
+        except Exception:
+            log.warning(
+                "RFBServer failed to parse %d client bytes; capture and forwarding continue",
+                len(data), exc_info=True,
+            )
+        try:
+            super().dataReceived(data)
+        except Exception:
+            log.warning("failed forwarding %d client bytes to server", len(data), exc_info=True)
 
     def _handle_clientInit(self) -> None:
         RFBServer._handle_clientInit(self)
@@ -299,12 +378,27 @@ class VNCLoggingServerFactory(portforward.ProxyFactory):  # type: ignore[misc]
     force_caps = False
 
     password_required = False
+    # Declared so a factory built without the CLI parser still has a value
+    # here rather than raising AttributeError.
+    password: str | None = None
 
     output: IO[str] | str = sys.stdout
     _out: IO[str] | None = None
 
+    # `capture_claimed` latches on the first connection accepted in capture
+    # mode, so a later one is refused rather than clobbering the capture.
+    capture_dir: str | None = None
+    capture_claimed: bool = False
+    server_str: str = ""
+
     def getRecorder(self) -> Callable[[str], int]:
-        if isinstance(self.output, str):
+        if self.capture_dir:
+            # Opened and closed per connection, like --forever, so
+            # session.vdo is complete when the client disconnects.
+            outfile = os.path.join(self.capture_dir, "session.vdo")
+            self._out = open(outfile, "w")
+            return self._out.write
+        elif isinstance(self.output, str):
             now = time.strftime("%y%m%d-%H%M%S")
             outfile = os.path.join(self.output, "%s.vdo" % now)
             self._out = open(outfile, "w")


### PR DESCRIPTION
Phase 3 of the server testing framework: the capture kit from `docs/testing-framework-design.md`.

`vnclog --capture DIR` records the raw server-to-client and client-to-server streams (`s2c.bin`, `c2s.bin`) alongside the semantic `session.vdo`, plus a `meta.json` fingerprint (server, versions, security types offered, geometry, what was scrubbed). Contributors running a server we cannot host in CI run one documented command and attach the directory to an issue. `docs/capture.rst` is the paved road.

## Scrubbing

Scrubbing happens before bytes touch disk. A handshake state machine in the new `vncdotool/capture.py` walks both directions of the proxied RFB handshake and replaces the 16-byte VNC-auth challenge and response with a same-length marker.

It branches on the version the *client* actually negotiates, not the server's greeting, so a client-side downgrade to 3.3 cannot route the scrubber off the real exchange. Auth types it cannot scrub (ARD/DH) are named in `meta.json`'s `unscrubbed_auth`, and `docs/capture.rst` warns that those captures contain encrypted credentials.

The capture tap runs before the proxy's own RFB parsers, and both are exception-isolated, so a parse failure can never truncate what reaches disk. One capture per directory: the first byte-bearing connection claims it, later connections are refused, and a zero-byte TCP open/close releases the claim.

## Found and fixed along the way

- **vnclog desynced against RFB 3.7+ servers using VNC password auth.** `RFBServer` never skipped the 16-byte auth response on the negotiated path, misread it as `ClientInit`, and lost the client stream. Real proxy bug, CHANGELOG entry included.
- **TigerVNC's brute-force blacklist counts failed auth attempts cumulatively per client IP** for the server process lifetime, so the suite's deliberate bad-password test poisoned `tigervnc-auth` for later runs — suite results depended on run history. The fleet now runs `Xvnc` with the blacklist disabled.
- **x11vnc raced its own Xvfb at container start** and exited 1 under load; the entrypoint now waits for the display, like the xev sink already did.
- **Capture-mode readiness is detected from vnclog's `accepting connections` stderr line, never by port-probing.** A probe races the forwarded server greeting into looking like a session and steals the one capture. A greeting-only session (server rejects before the client gets a byte through) is deliberately kept — that rejection is exactly the evidence a contributor is trying to capture.

## Verification

- `make test` — 117 tests, OK (expected failures=1)
- `flake8 --count --statistics vncdotool tests` — 0
- Functional suite against the docker fleet — 30 tests green, three consecutive runs

Stack note: Phase 2 (#350) is parked in draft. Its fixtures were hand-derived from the decoder source, so they pin behaviour rather than verify it independently. Phase 2 will be rebuilt on top of this PR and Phase 4, using real server-generated captures round-tripped against a source PNG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
