### PR TITLE
fix(servers): supervise x11vnc's xev sink so a lost startup race self-heals

### DIFF
--- a/tests/functional/test_events.py
+++ b/tests/functional/test_events.py
@@ -128,6 +128,24 @@ class TestVncevSink(TestCase):
         )
 
 
+def _sink_alive(service: str, pattern: str) -> bool:
+    """Is the container's event sink process still running?
+
+    A sink that died leaves the container serving VNC quite happily, so
+    nothing else in the suite notices; asking the container directly is
+    the only way to tell "the event never arrived" from "nothing was
+    listening for it".
+    """
+    result = subprocess.run(
+        ["docker", "compose", "-f", str(COMPOSE_FILE), "exec", "-T", service, "pgrep", "-f", pattern],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        stdin=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
+
+
 class TestX11SideSink(TestCase):
     """Server processing: did x11vnc's X display see a real X event.
 
@@ -143,6 +161,14 @@ class TestX11SideSink(TestCase):
                 f"x11vnc not reachable on {HOST}:{X11VNC.port} -- start the servers first "
                 "with `make servers-up`"
             )
+        # Fail as the infrastructure problem it is. Without this the symptom
+        # of a dead sink is an assertion about a keypress, pointing at
+        # vncdotool for something vncdotool did not do.
+        self.assertTrue(
+            _sink_alive("x11vnc", "xev -root"),
+            "x11vnc's xev sink is not running, so no event can be observed no matter what "
+            "the client sends. Check `docker compose logs x11vnc` for why it exited.",
+        )
 
     def test_keypress_seen_by_xev(self) -> None:
         offset = len(_compose_logs("x11vnc"))

--- a/tests/functional/test_events.py
+++ b/tests/functional/test_events.py
@@ -128,24 +128,6 @@ class TestVncevSink(TestCase):
         )
 
 
-def _sink_alive(service: str, pattern: str) -> bool:
-    """Is the container's event sink process still running?
-
-    A sink that died leaves the container serving VNC quite happily, so
-    nothing else in the suite notices; asking the container directly is
-    the only way to tell "the event never arrived" from "nothing was
-    listening for it".
-    """
-    result = subprocess.run(
-        ["docker", "compose", "-f", str(COMPOSE_FILE), "exec", "-T", service, "pgrep", "-f", pattern],
-        capture_output=True,
-        text=True,
-        timeout=30,
-        stdin=subprocess.DEVNULL,
-    )
-    return result.returncode == 0
-
-
 class TestX11SideSink(TestCase):
     """Server processing: did x11vnc's X display see a real X event.
 
@@ -161,14 +143,6 @@ class TestX11SideSink(TestCase):
                 f"x11vnc not reachable on {HOST}:{X11VNC.port} -- start the servers first "
                 "with `make servers-up`"
             )
-        # Fail as the infrastructure problem it is. Without this the symptom
-        # of a dead sink is an assertion about a keypress, pointing at
-        # vncdotool for something vncdotool did not do.
-        self.assertTrue(
-            _sink_alive("x11vnc", "xev -root"),
-            "x11vnc's xev sink is not running, so no event can be observed no matter what "
-            "the client sends. Check `docker compose logs x11vnc` for why it exited.",
-        )
 
     def test_keypress_seen_by_xev(self) -> None:
         offset = len(_compose_logs("x11vnc"))

--- a/tests/servers/Dockerfile
+++ b/tests/servers/Dockerfile
@@ -66,12 +66,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY x11vnc-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Extends base's check with the X-side event sink, because this container
-# promises two things and the port only evidences one. A dead xev used to
-# leave the container "healthy" and every smoke test passing, while the
-# event tests polled a log nothing would ever write to again -- the sink
-# has to be part of what healthy means, or its absence is discovered as a
-# confusing assertion failure thirty tests later.
+# Extends base's check with the event sink: the port evidences only half of
+# what this container promises, and the sink loses a startup race often
+# enough that readiness has to wait for it.
 HEALTHCHECK --interval=2s --timeout=2s --start-period=5s --retries=30 \
     CMD bash -c 'exec 3<>/dev/tcp/127.0.0.1/5900 && test -f /tmp/draw-content-ready && pgrep -f "xev -root" >/dev/null'
 

--- a/tests/servers/Dockerfile
+++ b/tests/servers/Dockerfile
@@ -60,10 +60,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         xvfb \
         x11vnc \
         x11-utils \
+        procps \
     && rm -rf /var/lib/apt/lists/*
 
 COPY x11vnc-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
+# Extends base's check with the X-side event sink, because this container
+# promises two things and the port only evidences one. A dead xev used to
+# leave the container "healthy" and every smoke test passing, while the
+# event tests polled a log nothing would ever write to again -- the sink
+# has to be part of what healthy means, or its absence is discovered as a
+# confusing assertion failure thirty tests later.
+HEALTHCHECK --interval=2s --timeout=2s --start-period=5s --retries=30 \
+    CMD bash -c 'exec 3<>/dev/tcp/127.0.0.1/5900 && test -f /tmp/draw-content-ready && pgrep -f "xev -root" >/dev/null'
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/tests/servers/x11vnc-entrypoint.sh
+++ b/tests/servers/x11vnc-entrypoint.sh
@@ -2,6 +2,10 @@
 # Start a virtual X display (Xvfb) with x11vnc serving it, no authentication.
 set -e
 
+# Restarting a stopped container reuses its filesystem, and Xvfb refuses to
+# start on the lock the previous run left behind.
+rm -f /tmp/.X0-lock /tmp/.X11-unix/X0 /tmp/draw-content-ready
+
 Xvfb :0 -screen 0 1024x768x24 &
 XVFB_PID=$!
 trap 'kill -TERM "$XVFB_PID" 2>/dev/null; exit 0' TERM INT
@@ -12,14 +16,12 @@ DISPLAY=:0 /draw-content.sh &
 # that the client put it on the wire. Prefixed so it greps cleanly out of
 # `docker compose logs x11vnc`.
 #
-# xev is supervised rather than started once. A successful xdpyinfo probe
-# does not mean the next client can connect -- Xvfb accepts connections
-# before it has finished initialising -- and an xev that loses that race
-# dies with "unable to open display" and never comes back. Nothing else
-# notices: x11vnc keeps serving, the container stays healthy, and every
-# event test for the rest of the run polls a log the dead sink will never
-# write to again. Restarting it turns that from a poisoned run into a
-# half-second gap.
+# xdpyinfo succeeding does not mean the next X client can connect -- Xvfb
+# accepts connections before it has finished initialising -- so xev is
+# restarted rather than started once. If it never comes up, PID 1 goes with
+# it: this container serves VNC *and* observes X events, and one without the
+# other is a container that passes every smoke test while silently answering
+# no event question correctly.
 (
     for _ in $(seq 1 30); do
         DISPLAY=:0 xdpyinfo >/dev/null 2>&1 && break
@@ -33,7 +35,8 @@ DISPLAY=:0 /draw-content.sh &
         echo "xev exited; restarting the X-side event sink"
         sleep 0.5
     done
-    echo "xev kept exiting; giving up on the X-side event sink"
+    echo "xev kept exiting; taking the container down with it"
+    kill -TERM 1
 ) 2>&1 | sed -u 's/^/xev: /' &
 
 # x11vnc exits 1 if the display isn't up yet, and Xvfb needs a moment.

--- a/tests/servers/x11vnc-entrypoint.sh
+++ b/tests/servers/x11vnc-entrypoint.sh
@@ -11,12 +11,29 @@ DISPLAY=:0 /draw-content.sh &
 # X-side event sink: confirms an event arrived as a real X event, not just
 # that the client put it on the wire. Prefixed so it greps cleanly out of
 # `docker compose logs x11vnc`.
+#
+# xev is supervised rather than started once. A successful xdpyinfo probe
+# does not mean the next client can connect -- Xvfb accepts connections
+# before it has finished initialising -- and an xev that loses that race
+# dies with "unable to open display" and never comes back. Nothing else
+# notices: x11vnc keeps serving, the container stays healthy, and every
+# event test for the rest of the run polls a log the dead sink will never
+# write to again. Restarting it turns that from a poisoned run into a
+# half-second gap.
 (
     for _ in $(seq 1 30); do
         DISPLAY=:0 xdpyinfo >/dev/null 2>&1 && break
         sleep 0.5
     done
-    DISPLAY=:0 xev -root
+    for _ in $(seq 1 60); do
+        # `|| true` is load-bearing under `set -e`: a failed xev would
+        # otherwise take this subshell down with it, which is the very
+        # thing being guarded against.
+        DISPLAY=:0 xev -root || true
+        echo "xev exited; restarting the X-side event sink"
+        sleep 0.5
+    done
+    echo "xev kept exiting; giving up on the X-side event sink"
 ) 2>&1 | sed -u 's/^/xev: /' &
 
 # x11vnc exits 1 if the display isn't up yet, and Xvfb needs a moment.


### PR DESCRIPTION
Fixes the intermittent `test_keypress_seen_by_xev` failure that red-flagged #352 (whose changes touch none of this).

## What actually happened

The failure looks like a lost keypress:

```
AssertionError: Regex didn't match: 'xev: KeyPress event' not found in '' :
no KeyPress seen in x11vnc's xev log:
```

The empty string is the tell — not "the KeyPress is missing from the log" but "there is no log". The container-log dump from that same CI run has it, as the very first line the container ever wrote:

```
x11vnc-1  | xev: xev:  unable to open display ':0'
```

The X-side event sink lost the startup race against Xvfb, died, and nothing restarted it. Nothing else noticed: x11vnc kept serving, the container stayed healthy through `--wait`, and all four x11vnc smoke tests passed in that run. Every event test afterwards polled a log the dead sink would never write to again.

A successful `xdpyinfo` probe does not make this safe — Xvfb accepts connections before it has finished initialising, the same "accepting connections is not the same as ready" problem `draw-content.sh` already documents for Xvnc. Lengthening the probe only changes the odds.

## The fix

Three parts, all in the container rather than in the tests:

1. **Supervise `xev`** instead of starting it once: restart it if it exits, bounded at 60 attempts. A lost race becomes a half-second gap rather than a poisoned run. `|| true` around `xev` is load-bearing under `set -e`, which would otherwise take the supervising subshell down with the process it exists to restart.
2. **Exit if the sink cannot be kept alive.** After the 60th attempt the supervisor does `kill -TERM 1`. This container promises to serve VNC *and* to observe X events; one without the other is a container that passes every smoke test while answering no event question correctly. Failing as a dead container beats failing as a keypress assertion that points at vncdotool.
3. **Make the sink part of `healthy`.** The HEALTHCHECK adds `pgrep -f "xev -root"`, so `up --wait` gates on the sink being up, not just the port.

The entrypoint also clears `/tmp/.X0-lock`, the X socket, and the readiness file on start. Restarting a stopped container reuses its filesystem, so without that, the first exit is unrecoverable — `make servers-up` comes back to `Fatal server error: Server is already active for display 0` forever.

## Verification

Against the local fleet, with the fixed image:

- baseline `vncdo key x` → 1 `KeyPress` in the log
- `pkill -x xev` once → log shows `xev exited; restarting the X-side event sink` and the next keypress lands
- `pkill -x xev` every 0.2s until the supervisor gives up → `xev: xev kept exiting; taking the container down with it`, container `Exited (2)`
- `docker compose up -d --wait x11vnc` on that stopped container → `Healthy`, `test_events` green again

Unfixed, a single lost race loses every event for the container's lifetime — which is exactly the CI failure. `python -m unittest tests.functional.test_events` green (4 tests); unit suite and flake8 clean.

## Discarded hypothesis, recorded so it isn't re-tried

First read was stdio block buffering: `xev | sed -u`, where `-u` unbuffers sed but not xev upstream of it. Measured instead of assumed — the log grows 627 bytes per keypress with no 4KB granularity, so xev's output is not block-buffered here and `stdbuf` fixes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
