### PR TITLE
fix(servers): disable TigerVNC's blacklist for the no-auth server too

### DIFF
--- a/tests/servers/tigervnc-entrypoint.sh
+++ b/tests/servers/tigervnc-entrypoint.sh
@@ -15,18 +15,20 @@ if [ -n "$VNC_PASSWORD" ]; then
     mkdir -p /root/.vnc
     printf '%s' "$VNC_PASSWORD" | vncpasswd -f > /root/.vnc/passwd
     chmod 600 /root/.vnc/passwd
-    # Xvnc counts every connection that closes before authenticating as a
-    # failed attempt, so the HEALTHCHECK's port probe blacklists 127.0.0.1
-    # within seconds of start-up and later authenticated sessions are
-    # refused. Disable the threshold rather than have results depend on how
-    # long the container has been up.
-    set -- -SecurityTypes VncAuth -PasswordFile /root/.vnc/passwd -BlacklistThreshold=1000000
+    set -- -SecurityTypes VncAuth -PasswordFile /root/.vnc/passwd
 else
     set -- -SecurityTypes None
 fi
 
+# Xvnc counts every connection that closes before authenticating as a
+# failed attempt, so the HEALTHCHECK's port probe blacklists 127.0.0.1
+# within seconds of start-up and later sessions are refused. The count is
+# cumulative for the container's whole life, so whether a suite passes
+# depends on how long the fleet has been up and how often it was probed.
+# SecurityTypes None is no exemption: the probe still closes mid-handshake.
 Xvnc :0 \
     "$@" \
+    -BlacklistThreshold=1000000 \
     -rfbport 5900 \
     -geometry 1024x768 \
     -depth 24 \


### PR DESCRIPTION
#351 raised TigerVNC's blacklist threshold, but only on the `VncAuth` branch of the entrypoint. The plain `tigervnc` service takes the `else` branch and kept the exact behaviour the auth one was fixed for.

Xvnc counts every connection that closes before completing the handshake as a failed attempt, the HEALTHCHECK probes the port every two seconds, and the count is cumulative for the life of the container. A fleet that has been up long enough starts refusing real sessions:

```
CRITICAL:root:Connection refused: b'Too many security failures'
```

`SecurityTypes None` is no exemption — the probe still closes mid-handshake, so it still counts. Moving the flag out of the `if` applies it to both services.

## How it was confirmed

Hammer the port with 1000 connect-then-close probes — the same thing the healthcheck does, only faster — then run `tests/functional/test_roundtrip.py` against it:

| | after the same 1000 probes |
|---|---|
| **without this change** | `Connection refused: b'Too many security failures'`, test fails |
| **with this change** | test passes, server serving normally |

Worth recording that **25 probes reproduce nothing and 1000 do it reliably**: my first attempt at this measurement used 25, saw both arms pass, and concluded the fix was unnecessary. The blacklist is real, it just needs volume to show up — which is precisely why it surfaces as "the fleet has been up too long" rather than as a reproducible failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
