### PR TITLE
Stop the readiness probe blacklisting itself, and gate the fleet on wait_for_servers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,14 @@ jobs:
       - name: Build and start the VNC test servers
         run: docker compose -f tests/servers/docker-compose.yml up -d --build --wait
 
+      # `up --wait` only reaches the containers' HEALTHCHECK, which is
+      # liveness. This is the readiness gate: it captures until every server
+      # serves the content it should, so a server that comes up blank fails
+      # here, named, rather than as a flat capture inside a test.
+      - name: Wait for the test servers to serve their screens
+        timeout-minutes: 5
+        run: python tests/functional/wait_for_servers.py docker
+
       # The steps below are diagnostics and teardown, so they carry
       # `if: always()`: when a test fails, the container status, the
       # screenshot of what the server was actually showing, and the server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,10 +98,9 @@ jobs:
       - name: Build and start the VNC test servers
         run: docker compose -f tests/servers/docker-compose.yml up -d --build --wait
 
-      # `up --wait` only reaches the containers' HEALTHCHECK, which is
-      # liveness. This is the readiness gate: it captures until every server
-      # serves the content it should, so a server that comes up blank fails
-      # here, named, rather than as a flat capture inside a test.
+      # `up --wait` only reaches the HEALTHCHECK, which is liveness. A
+      # server that comes up blank fails here, named, rather than as a flat
+      # capture inside a test.
       - name: Wait for the test servers to serve their screens
         timeout-minutes: 5
         run: python tests/functional/wait_for_servers.py docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,6 @@ jobs:
       - name: Build and start the VNC test servers
         run: docker compose -f tests/servers/docker-compose.yml up -d --build --wait
 
-      # `up --wait` only reaches the HEALTHCHECK, which is liveness. A
-      # server that comes up blank fails here, named, rather than as a flat
-      # capture inside a test.
       - name: Wait for the test servers to serve their screens
         timeout-minutes: 5
         run: python tests/functional/wait_for_servers.py docker

--- a/tests/functional/vncservers.py
+++ b/tests/functional/vncservers.py
@@ -155,12 +155,7 @@ def screenshot_dir() -> Path:
 
 
 def port_open(host: str, port: int, timeout: float = PORT_PROBE_TIMEOUT) -> bool:
-    """Whether ``port`` accepts a connection. Cheap liveness, not readiness.
-
-    This hangs up without authenticating, which TigerVNC counts towards
-    BlacklistThreshold -- see the note in tests/servers/tigervnc-entrypoint.sh
-    before adding more callers on the password-protected server.
-    """
+    """Whether ``port`` accepts a connection. Cheap liveness, not readiness."""
     try:
         with socket.create_connection((host, port), timeout=timeout):
             return True
@@ -197,11 +192,7 @@ def distinct_colours(image: Image.Image) -> Optional[int]:
 
 
 def has_expected_content(server: VNCServer, colours: Optional[int]) -> bool:
-    """Whether a capture of ``colours`` distinct colours is what ``server`` should serve.
-
-    A single flat colour means nothing was decoded, except on the servers
-    that have no rendered desktop behind them and are expected to be flat.
-    """
+    """Whether a capture of ``colours`` distinct colours is what ``server`` should serve."""
     if not server.renders_desktop:
         return True
     return colours != 1
@@ -214,20 +205,10 @@ def wait_until_ready(
 ) -> bool:
     """Block until ``server`` serves the screen the tests expect, or give up.
 
-    An open port is not readiness, and neither is a completed handshake.
-    Every server in the fleet starts accepting connections before it has
-    anything to show: Xvnc listens the instant it launches, well before
-    draw-content.sh has mapped a window, so a capture taken too early comes
-    back flat and is indistinguishable from a decode that failed. An
-    OS-hosted server needs the retry for a different reason -- macOS Screen
-    Sharing is socket-activated, so the first connection is also what starts
-    it and can stall indefinitely while the next one succeeds at once.
-
-    So readiness is asserted the same way test_capture asserts it: connect,
-    capture, and require the content that server is supposed to render.
-    Retrying the whole connection is the only probe that means anything --
-    a per-request timeout can't rescue a connection that never finished its
-    handshake.
+    Servers accept connections before they have anything to show, so
+    readiness has to be a capture. The whole connection is retried because
+    macOS Screen Sharing is socket-activated: the first connection starts
+    it and can stall indefinitely while the next succeeds at once.
     """
     deadline = time.monotonic() + deadline_seconds
     attempt = 0

--- a/tests/functional/vncservers.py
+++ b/tests/functional/vncservers.py
@@ -19,6 +19,7 @@ import os
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional, Tuple
@@ -189,23 +190,44 @@ def capture_screenshot(server: VNCServer, path: Path, timeout: Optional[float] =
     return path
 
 
+def distinct_colours(image: Image.Image) -> Optional[int]:
+    """How many colours ``image`` contains, or None above ``MAX_COLOURS``."""
+    colours = image.convert("RGB").getcolors(maxcolors=MAX_COLOURS)
+    return colours if colours is None else len(colours)
+
+
+def has_expected_content(server: VNCServer, colours: Optional[int]) -> bool:
+    """Whether a capture of ``colours`` distinct colours is what ``server`` should serve.
+
+    A single flat colour means nothing was decoded, except on the servers
+    that have no rendered desktop behind them and are expected to be flat.
+    """
+    if not server.renders_desktop:
+        return True
+    return colours != 1
+
+
 def wait_until_ready(
     server: VNCServer,
     deadline_seconds: float = READY_DEADLINE,
     attempt_timeout: float = READY_ATTEMPT_TIMEOUT,
 ) -> bool:
-    """Block until ``server`` completes a whole RFB round trip, or give up.
+    """Block until ``server`` serves the screen the tests expect, or give up.
 
-    An open port is not readiness. The Docker servers need a drawn-content
-    marker on top of it (tests/servers/draw-content.sh); an OS-hosted
-    server needs this instead, because the first connection can stall
-    indefinitely while the next one succeeds at once -- macOS Screen
-    Sharing is socket-activated, so that first connection is also what
-    starts the server.
+    An open port is not readiness, and neither is a completed handshake.
+    Every server in the fleet starts accepting connections before it has
+    anything to show: Xvnc listens the instant it launches, well before
+    draw-content.sh has mapped a window, so a capture taken too early comes
+    back flat and is indistinguishable from a decode that failed. An
+    OS-hosted server needs the retry for a different reason -- macOS Screen
+    Sharing is socket-activated, so the first connection is also what starts
+    it and can stall indefinitely while the next one succeeds at once.
 
-    Retrying a whole connection is therefore the only probe that means
-    anything: a per-request timeout can't rescue a connection that never
-    finished its handshake.
+    So readiness is asserted the same way test_capture asserts it: connect,
+    capture, and require the content that server is supposed to render.
+    Retrying the whole connection is the only probe that means anything --
+    a per-request timeout can't rescue a connection that never finished its
+    handshake.
     """
     deadline = time.monotonic() + deadline_seconds
     attempt = 0
@@ -215,15 +237,22 @@ def wait_until_ready(
             time.sleep(RETRY_DELAY)
             continue
         try:
-            with connect(server, timeout=attempt_timeout) as client:
-                client.refreshScreen()
+            with tempfile.TemporaryDirectory() as tmp:
+                probe = Path(tmp) / f"{server.name}-ready.png"
+                capture_screenshot(server, probe, timeout=attempt_timeout)
+                with Image.open(probe) as image:
+                    colours = distinct_colours(image)
         except Exception as exc:  # noqa: BLE001 - any failure means try again
             print(f"{server.name}: not ready yet (attempt {attempt}: {exc})")
+            continue
+        if not has_expected_content(server, colours):
+            print(f"{server.name}: not ready yet (attempt {attempt}: capture is flat)")
+            time.sleep(RETRY_DELAY)
             continue
         print(f"{server.name}: ready after {attempt} attempt(s)")
         return True
 
-    print(f"{server.name}: never completed an RFB round trip")
+    print(f"{server.name}: never served the content it is expected to render")
     return False
 
 
@@ -328,9 +357,8 @@ class _VNCServerTestMixin:
                     self.server.size,
                     f"{self.server.name}: capture is not the size the server serves",
                 )
-            colours = image.convert("RGB").getcolors(maxcolors=MAX_COLOURS)
+            distinct = distinct_colours(image)
 
-        distinct = colours if colours is None else len(colours)
         if not self.server.renders_desktop:
             print(
                 f"{self.server.name}: {distinct} colours captured; content is not "
@@ -338,9 +366,8 @@ class _VNCServerTestMixin:
             )
             return
 
-        self.assertNotEqual(
-            distinct,
-            1,
+        self.assertTrue(
+            has_expected_content(self.server, distinct),
             f"{self.server.name}: capture is a single flat colour, "
             "no screen content was decoded",
         )

--- a/tests/functional/vncservers.py
+++ b/tests/functional/vncservers.py
@@ -192,7 +192,6 @@ def distinct_colours(image: Image.Image) -> Optional[int]:
 
 
 def has_expected_content(server: VNCServer, colours: Optional[int]) -> bool:
-    """Whether a capture of ``colours`` distinct colours is what ``server`` should serve."""
     if not server.renders_desktop:
         return True
     return colours != 1

--- a/tests/functional/vncservers.py
+++ b/tests/functional/vncservers.py
@@ -154,6 +154,12 @@ def screenshot_dir() -> Path:
 
 
 def port_open(host: str, port: int, timeout: float = PORT_PROBE_TIMEOUT) -> bool:
+    """Whether ``port`` accepts a connection. Cheap liveness, not readiness.
+
+    This hangs up without authenticating, which TigerVNC counts towards
+    BlacklistThreshold -- see the note in tests/servers/tigervnc-entrypoint.sh
+    before adding more callers on the password-protected server.
+    """
     try:
         with socket.create_connection((host, port), timeout=timeout):
             return True

--- a/tests/functional/wait_for_servers.py
+++ b/tests/functional/wait_for_servers.py
@@ -1,13 +1,8 @@
 #!/usr/bin/env python3
 """Wait until a group of VNC test servers can actually serve a screen.
 
-Used as a readiness gate before the functional tests run, so a server that
-is slow to become usable shows up here -- as a wait, with per-attempt
-reasons -- rather than as a mysterious timeout inside a test.
-
 Takes the same server group as capture_screenshots.py: ``docker``, ``os``,
-or ``all`` (see vncservers.py). Exits non-zero if any server in the group
-never became ready.
+or ``all``. Exits non-zero if any server never became ready.
 """
 
 import sys
@@ -30,10 +25,7 @@ def main(argv: List[str]) -> int:
     group = argv[1] if len(argv) > 1 else DEFAULT_GROUP
     ready = [wait_until_ready(server) for server in select_servers(group)]
 
-    # api.connect() starts a background Twisted reactor thread that outlives
-    # any individual client connection -- without stopping it here this
-    # script hangs on exit instead of finishing.
-    api.shutdown()
+    api.shutdown()  # the reactor thread outlives its clients; this script hangs without it
 
     return 0 if all(ready) else 1
 

--- a/tests/servers/Dockerfile
+++ b/tests/servers/Dockerfile
@@ -76,11 +76,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY x11vnc-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Extends base's check with the event sink: the port evidences only half of
-# what this container promises, and the sink loses a startup race often
-# enough that readiness has to wait for it.
+# Extends base's liveness check with the event sink, which is the second
+# thing this container promises and the one that loses a startup race. The
+# probe stays connectionless for the same reason base's does, and leaves
+# "is there content on screen" to wait_for_servers.py along with every
+# other server.
 HEALTHCHECK --interval=2s --timeout=2s --start-period=5s --retries=30 \
-    CMD bash -c 'exec 3<>/dev/tcp/127.0.0.1/5900 && test -f /tmp/draw-content-ready && pgrep -f "xev -root" >/dev/null'
+    CMD ss -H -ltn 'sport = :5900' | grep -q . && pgrep -f "xev -root" >/dev/null
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/tests/servers/Dockerfile
+++ b/tests/servers/Dockerfile
@@ -25,22 +25,14 @@ RUN chmod +x /draw-content.sh
 
 EXPOSE 5900
 
-# Liveness only: the process came up and bound its port. Whether the server
-# is ready to serve is decided out of band by
-# `tests/functional/wait_for_servers.py docker`, which connects, captures,
-# and requires the content the server is supposed to render -- the same
-# assertion the tests make, so there is one definition of readiness for the
-# Docker fleet and the OS-hosted servers rather than a weaker in-container
-# imitation of it.
+# Liveness only; readiness is `tests/functional/wait_for_servers.py docker`.
 #
-# This must never open an RFB connection. Xvnc counts every connection
+# This must never open an RFB connection: Xvnc counts every connection
 # closed before a successful authentication towards BlacklistThreshold
-# (default 5), so a probe that connects and hangs up blacklists 127.0.0.1
-# within ~10s and refuses every later session. Completing the RFB version
-# handshake first does not help -- measured against TigerVNC 1.12.0, a bare
-# connect, a version exchange, and a version-plus-security-types exchange
-# all trip the counter identically. `ss` reads the kernel's socket table
-# instead, so the port is confirmed listening without a connection existing.
+# (default 5), so a connecting probe blacklists 127.0.0.1 within ~10s and
+# refuses every later session. Speaking more of the protocol first does not
+# help -- measured against TigerVNC 1.12.0, a bare connect, a version
+# exchange and a version-plus-security-types exchange trip it identically.
 HEALTHCHECK --interval=2s --timeout=2s --start-period=5s --retries=30 \
     CMD ss -H -ltn 'sport = :5900' | grep -q .
 
@@ -76,11 +68,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY x11vnc-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Extends base's liveness check with the event sink, which is the second
-# thing this container promises and the one that loses a startup race. The
-# probe stays connectionless for the same reason base's does, and leaves
-# "is there content on screen" to wait_for_servers.py along with every
-# other server.
+# The event sink is the second thing this container promises, and the one
+# that loses a startup race.
 HEALTHCHECK --interval=2s --timeout=2s --start-period=5s --retries=30 \
     CMD ss -H -ltn 'sport = :5900' | grep -q . && pgrep -f "xev -root" >/dev/null
 

--- a/tests/servers/Dockerfile
+++ b/tests/servers/Dockerfile
@@ -14,8 +14,10 @@ FROM debian:bookworm-slim AS base
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         x11-apps \
+        x11-utils \
         xauth \
         procps \
+        iproute2 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY draw-content.sh /draw-content.sh
@@ -23,16 +25,23 @@ RUN chmod +x /draw-content.sh
 
 EXPOSE 5900
 
-# bash's /dev/tcp rather than `nc`: same "is the RFB port accepting
-# connections" probe without pulling netcat into every image. That alone
-# isn't sufficient readiness, though -- Xvnc in particular starts
-# accepting connections the instant it launches, before draw-content.sh's
-# backgrounded xlogo has drawn anything, so a port-only check can report
-# healthy against a still-flat framebuffer. draw-content.sh only creates
-# /tmp/draw-content-ready once xlogo's window is actually mapped, so the
-# check also requires that file to exist.
+# Readiness must never open an RFB connection. Xvnc counts every connection
+# closed before a successful authentication towards BlacklistThreshold
+# (default 5), so a probe that connects and hangs up blacklists 127.0.0.1
+# within ~10s and refuses every later session. Completing the RFB version
+# handshake first does not help -- measured against TigerVNC 1.12.0, a bare
+# connect, a version exchange, and a version-plus-security-types exchange
+# all trip the counter identically.
+#
+# `ss` reads the kernel's socket table instead, so the port is confirmed
+# listening without a connection existing. That alone isn't sufficient
+# readiness, though -- Xvnc starts listening the instant it launches,
+# before draw-content.sh's backgrounded xlogo has drawn anything, so a
+# port-only check can report healthy against a still-flat framebuffer.
+# draw-content.sh only creates /tmp/draw-content-ready once xlogo's window
+# is actually mapped, so the check also requires that file to exist.
 HEALTHCHECK --interval=2s --timeout=2s --start-period=5s --retries=30 \
-    CMD bash -c 'exec 3<>/dev/tcp/127.0.0.1/5900 && test -f /tmp/draw-content-ready'
+    CMD ss -H -ltn 'sport = :5900' | grep -q . && test -f /tmp/draw-content-ready
 
 
 # TigerVNC's own X server. Serves with no authentication by default, or
@@ -116,7 +125,7 @@ COPY --from=libvncserver-build /tmp/libvncserver/libvncserver.so* /usr/local/lib
 RUN ldconfig
 
 HEALTHCHECK --interval=2s --timeout=2s --start-period=5s --retries=30 \
-    CMD bash -c 'exec 3<>/dev/tcp/127.0.0.1/5900'
+    CMD ss -H -ltn 'sport = :5900' | grep -q .
 
 ENTRYPOINT ["vncev", "-rfbport", "5900", "-rfbwait", "1000"]
 
@@ -133,6 +142,6 @@ COPY --from=libvncserver-build /tmp/libvncserver/libvncserver.so* /usr/local/lib
 RUN ldconfig
 
 HEALTHCHECK --interval=2s --timeout=2s --start-period=5s --retries=30 \
-    CMD bash -c 'exec 3<>/dev/tcp/127.0.0.1/5900'
+    CMD ss -H -ltn 'sport = :5900' | grep -q .
 
 ENTRYPOINT ["example", "-rfbport", "5900", "-rfbwait", "1000"]

--- a/tests/servers/Dockerfile
+++ b/tests/servers/Dockerfile
@@ -25,23 +25,24 @@ RUN chmod +x /draw-content.sh
 
 EXPOSE 5900
 
-# Readiness must never open an RFB connection. Xvnc counts every connection
+# Liveness only: the process came up and bound its port. Whether the server
+# is ready to serve is decided out of band by
+# `tests/functional/wait_for_servers.py docker`, which connects, captures,
+# and requires the content the server is supposed to render -- the same
+# assertion the tests make, so there is one definition of readiness for the
+# Docker fleet and the OS-hosted servers rather than a weaker in-container
+# imitation of it.
+#
+# This must never open an RFB connection. Xvnc counts every connection
 # closed before a successful authentication towards BlacklistThreshold
 # (default 5), so a probe that connects and hangs up blacklists 127.0.0.1
 # within ~10s and refuses every later session. Completing the RFB version
 # handshake first does not help -- measured against TigerVNC 1.12.0, a bare
 # connect, a version exchange, and a version-plus-security-types exchange
-# all trip the counter identically.
-#
-# `ss` reads the kernel's socket table instead, so the port is confirmed
-# listening without a connection existing. That alone isn't sufficient
-# readiness, though -- Xvnc starts listening the instant it launches,
-# before draw-content.sh's backgrounded xlogo has drawn anything, so a
-# port-only check can report healthy against a still-flat framebuffer.
-# draw-content.sh only creates /tmp/draw-content-ready once xlogo's window
-# is actually mapped, so the check also requires that file to exist.
+# all trip the counter identically. `ss` reads the kernel's socket table
+# instead, so the port is confirmed listening without a connection existing.
 HEALTHCHECK --interval=2s --timeout=2s --start-period=5s --retries=30 \
-    CMD ss -H -ltn 'sport = :5900' | grep -q . && test -f /tmp/draw-content-ready
+    CMD ss -H -ltn 'sport = :5900' | grep -q .
 
 
 # TigerVNC's own X server. Serves with no authentication by default, or
@@ -112,8 +113,8 @@ RUN cmake -DCMAKE_BUILD_TYPE=Release . \
     && cmake --build . --target examples_vncev examples_example -- -j"$(nproc)"
 
 
-# Event sink: prints events, renders no desktop, so the HEALTHCHECK drops
-# base's draw-content marker.
+# Event sink: prints events and renders no desktop, so vncservers.py marks
+# it renders_desktop=False and readiness stops at the handshake.
 FROM base AS vncev
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -124,13 +125,11 @@ COPY --from=libvncserver-build /tmp/libvncserver/examples/vncev /usr/local/bin/v
 COPY --from=libvncserver-build /tmp/libvncserver/libvncserver.so* /usr/local/lib/
 RUN ldconfig
 
-HEALTHCHECK --interval=2s --timeout=2s --start-period=5s --retries=30 \
-    CMD ss -H -ltn 'sport = :5900' | grep -q .
-
 ENTRYPOINT ["vncev", "-rfbport", "5900", "-rfbwait", "1000"]
 
 
-# Self-animated canvas, so there is no draw-content.sh marker to wait for.
+# Self-animated canvas, so it draws its own content rather than needing
+# draw-content.sh to put an X client on the screen.
 FROM base AS libvncserver-example
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -140,8 +139,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=libvncserver-build /tmp/libvncserver/examples/example /usr/local/bin/example
 COPY --from=libvncserver-build /tmp/libvncserver/libvncserver.so* /usr/local/lib/
 RUN ldconfig
-
-HEALTHCHECK --interval=2s --timeout=2s --start-period=5s --retries=30 \
-    CMD ss -H -ltn 'sport = :5900' | grep -q .
 
 ENTRYPOINT ["example", "-rfbport", "5900", "-rfbwait", "1000"]

--- a/tests/servers/draw-content.sh
+++ b/tests/servers/draw-content.sh
@@ -1,31 +1,26 @@
 #!/bin/sh
-# Wait for the X display to accept connections, draw a trivial X client on
-# it, and only then signal readiness via a marker file. Without a client
-# the framebuffer is pure black, and a black capture is indistinguishable
-# from "we never received an update" -- tests/functional/test_servers.py
-# asserts captures aren't flat.
+# Put a trivial X client on the display so captures aren't pure black.
+# Without one the framebuffer is flat, and a flat capture is
+# indistinguishable from "we never received an update" --
+# tests/functional/test_servers.py asserts captures aren't flat.
 #
-# The marker file matters because "the RFB port accepts connections" is
-# not the same thing as "there is content on screen": Xvnc in particular
-# starts accepting connections the instant it launches, well before this
-# script's backgrounded xlogo has mapped a window, so a probe of the port
-# alone lets the image report healthy while the framebuffer is still
-# flat. The image HEALTHCHECK checks for this file's existence in
-# addition to the port so `docker compose up --wait` only reports the
-# container ready once there is actually something to capture.
-#
-# Every failure here must stay loud. This script is the whole content half
-# of the readiness gate, so anything it lets through silently becomes a
-# green test run against a blank screen. It previously waited with
+# This script does not decide readiness. Whether the content actually
+# arrived is settled by `tests/functional/wait_for_servers.py docker`,
+# which connects and captures until the screen holds what the server is
+# supposed to render. An in-container marker file used to stand in for
+# that and was worse than nothing: it waited with
 # `cmd >/dev/null 2>&1 && break`, which cannot tell "not ready yet" from
-# "that program isn't installed" -- and x11-utils wasn't in the tigervnc
+# "that program isn't installed", and then created the marker whether or
+# not either wait had succeeded. x11-utils was missing from the tigervnc
 # image, so both waits ran to exhaustion and the marker was really a fixed
-# 21s sleep. Hence: missing tools are a hard error, and a wait that runs
-# out is a hard error rather than a fall-through to touching the marker.
+# 21s sleep that reported ready against a blank screen.
+#
+# The waits that remain are still worth getting right, because xlogo needs
+# a display to draw on, so failures here stay loud: a missing tool is a
+# hard error, and a wait that runs out is a hard error.
 set -e
 
 export DISPLAY="${DISPLAY:-:0}"
-READY_FILE="${DRAW_CONTENT_READY_FILE:-/tmp/draw-content-ready}"
 
 require() {
     command -v "$1" >/dev/null 2>&1 || {
@@ -60,7 +55,5 @@ xlogo -geometry 200x200+50+50 &
 XLOGO_PID=$!
 
 wait_for 30 0.2 xwininfo -name xlogo
-
-touch "$READY_FILE"
 
 wait "$XLOGO_PID"

--- a/tests/servers/draw-content.sh
+++ b/tests/servers/draw-content.sh
@@ -1,18 +1,10 @@
 #!/bin/sh
-# Put a trivial X client on the display so captures aren't pure black.
-# Without one the framebuffer is flat, and a flat capture is
-# indistinguishable from "we never received an update" --
-# tests/functional/test_servers.py asserts captures aren't flat.
+# Put a trivial X client on the display so captures aren't pure black: a
+# flat capture is indistinguishable from "we never received an update".
 #
-# This script does not decide readiness. Whether the content actually
-# arrived is settled by `tests/functional/wait_for_servers.py docker`,
-# which connects and captures until the screen holds what the server is
-# supposed to render.
-#
-# The waits below still have to be loud, because xlogo needs a display to
-# draw on: a wait that silently gives up leaves this drawing nothing on a
-# screen that later reports itself ready. So a missing tool is a hard
-# error, and so is a wait that runs out.
+# Readiness is decided elsewhere, by wait_for_servers.py. The waits below
+# still fail hard rather than give up quietly, because xlogo needs a
+# display to draw on and this would otherwise draw nothing at all.
 set -e
 
 export DISPLAY="${DISPLAY:-:0}"

--- a/tests/servers/draw-content.sh
+++ b/tests/servers/draw-content.sh
@@ -7,17 +7,12 @@
 # This script does not decide readiness. Whether the content actually
 # arrived is settled by `tests/functional/wait_for_servers.py docker`,
 # which connects and captures until the screen holds what the server is
-# supposed to render. An in-container marker file used to stand in for
-# that and was worse than nothing: it waited with
-# `cmd >/dev/null 2>&1 && break`, which cannot tell "not ready yet" from
-# "that program isn't installed", and then created the marker whether or
-# not either wait had succeeded. x11-utils was missing from the tigervnc
-# image, so both waits ran to exhaustion and the marker was really a fixed
-# 21s sleep that reported ready against a blank screen.
+# supposed to render.
 #
-# The waits that remain are still worth getting right, because xlogo needs
-# a display to draw on, so failures here stay loud: a missing tool is a
-# hard error, and a wait that runs out is a hard error.
+# The waits below still have to be loud, because xlogo needs a display to
+# draw on: a wait that silently gives up leaves this drawing nothing on a
+# screen that later reports itself ready. So a missing tool is a hard
+# error, and so is a wait that runs out.
 set -e
 
 export DISPLAY="${DISPLAY:-:0}"

--- a/tests/servers/draw-content.sh
+++ b/tests/servers/draw-content.sh
@@ -13,23 +13,53 @@
 # flat. The image HEALTHCHECK checks for this file's existence in
 # addition to the port so `docker compose up --wait` only reports the
 # container ready once there is actually something to capture.
+#
+# Every failure here must stay loud. This script is the whole content half
+# of the readiness gate, so anything it lets through silently becomes a
+# green test run against a blank screen. It previously waited with
+# `cmd >/dev/null 2>&1 && break`, which cannot tell "not ready yet" from
+# "that program isn't installed" -- and x11-utils wasn't in the tigervnc
+# image, so both waits ran to exhaustion and the marker was really a fixed
+# 21s sleep. Hence: missing tools are a hard error, and a wait that runs
+# out is a hard error rather than a fall-through to touching the marker.
 set -e
 
 export DISPLAY="${DISPLAY:-:0}"
 READY_FILE="${DRAW_CONTENT_READY_FILE:-/tmp/draw-content-ready}"
 
-for _ in $(seq 1 30); do
-    xdpyinfo >/dev/null 2>&1 && break
-    sleep 0.5
-done
+require() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "draw-content: $1 is not installed in this image" >&2
+        exit 1
+    }
+}
+
+# wait_for <attempts> <delay> <command...>
+wait_for() {
+    attempts=$1
+    delay=$2
+    shift 2
+    while [ "$attempts" -gt 0 ]; do
+        if "$@" >/dev/null 2>&1; then
+            return 0
+        fi
+        attempts=$((attempts - 1))
+        sleep "$delay"
+    done
+    echo "draw-content: gave up waiting for: $*" >&2
+    return 1
+}
+
+require xdpyinfo
+require xwininfo
+require xlogo
+
+wait_for 30 0.5 xdpyinfo
 
 xlogo -geometry 200x200+50+50 &
 XLOGO_PID=$!
 
-for _ in $(seq 1 30); do
-    xwininfo -name xlogo >/dev/null 2>&1 && break
-    sleep 0.2
-done
+wait_for 30 0.2 xwininfo -name xlogo
 
 touch "$READY_FILE"
 

--- a/tests/servers/servers.mk
+++ b/tests/servers/servers.mk
@@ -6,9 +6,14 @@ SCREENSHOT_DIR?=tests/servers/screenshots
 # tests/functional/vncservers.py.
 SCREENSHOT_GROUP?=docker
 
+# `up --wait` only gets as far as the containers' HEALTHCHECK, which is
+# liveness: the port is bound. wait_for_servers.py is the readiness gate --
+# it captures until each server serves the content it should, the same
+# assertion the tests make, and the same gate the OS-hosted servers use.
 .PHONY: servers-up
 servers-up:
 	$(DOCKER_COMPOSE) -f $(SERVERS_COMPOSE) up -d --build --wait
+	$(PYTHON) tests/functional/wait_for_servers.py docker
 
 .PHONY: servers-down
 servers-down:

--- a/tests/servers/tigervnc-entrypoint.sh
+++ b/tests/servers/tigervnc-entrypoint.sh
@@ -15,12 +15,16 @@ if [ -n "$VNC_PASSWORD" ]; then
     mkdir -p /root/.vnc
     printf '%s' "$VNC_PASSWORD" | vncpasswd -f > /root/.vnc/passwd
     chmod 600 /root/.vnc/passwd
-    # Xvnc counts every connection that closes before authenticating as a
-    # failed attempt, so the HEALTHCHECK's port probe blacklists 127.0.0.1
-    # within seconds of start-up and later authenticated sessions are
-    # refused. Disable the threshold rather than have results depend on how
-    # long the container has been up.
-    set -- -SecurityTypes VncAuth -PasswordFile /root/.vnc/passwd -BlacklistThreshold=1000000
+    # Xvnc counts every connection closed before a successful authentication
+    # towards BlacklistThreshold, and a successful authentication clears the
+    # host's blackmark. The readiness probe no longer connects at all (see the
+    # HEALTHCHECK in Dockerfile), but the harness still leaves some: about
+    # seven port_open() reachability probes per full run plus the one
+    # deliberate wrong password in tests/functional/test_cli.py. A full run
+    # interleaves enough successful authentications to stay under the default
+    # of 5, but running test_cli.py alone, repeatedly, chains them without one.
+    # 50 absorbs several such runs while still capping real password guessing.
+    set -- -SecurityTypes VncAuth -PasswordFile /root/.vnc/passwd -BlacklistThreshold=50
 else
     set -- -SecurityTypes None
 fi

--- a/tests/servers/tigervnc-entrypoint.sh
+++ b/tests/servers/tigervnc-entrypoint.sh
@@ -17,9 +17,9 @@ if [ -n "$VNC_PASSWORD" ]; then
     chmod 600 /root/.vnc/passwd
     # Xvnc counts every connection closed before a successful authentication
     # towards BlacklistThreshold, and a successful authentication clears the
-    # host's blackmark. The readiness probe no longer connects at all (see the
-    # HEALTHCHECK in Dockerfile), but the harness still leaves some: about
-    # seven port_open() reachability probes per full run plus the one
+    # host's blackmark. The harness leaves a few such closes even though the
+    # readiness probe never connects (see the HEALTHCHECK in Dockerfile):
+    # about seven port_open() reachability probes per full run, plus the one
     # deliberate wrong password in tests/functional/test_cli.py. A full run
     # interleaves enough successful authentications to stay under the default
     # of 5, but running test_cli.py alone, repeatedly, chains them without one.

--- a/tests/servers/tigervnc-entrypoint.sh
+++ b/tests/servers/tigervnc-entrypoint.sh
@@ -17,13 +17,9 @@ if [ -n "$VNC_PASSWORD" ]; then
     chmod 600 /root/.vnc/passwd
     # Xvnc counts every connection closed before a successful authentication
     # towards BlacklistThreshold, and a successful authentication clears the
-    # host's blackmark. The harness leaves a few such closes even though the
-    # readiness probe never connects (see the HEALTHCHECK in Dockerfile):
-    # about seven port_open() reachability probes per full run, plus the one
-    # deliberate wrong password in tests/functional/test_cli.py. A full run
-    # interleaves enough successful authentications to stay under the default
-    # of 5, but running test_cli.py alone, repeatedly, chains them without one.
-    # 50 absorbs several such runs while still capping real password guessing.
+    # host's blackmark. The readiness probe never authenticates (see the
+    # HEALTHCHECK in Dockerfile), so a generous threshold avoids blacklisting
+    # the harness itself while still capping real password guessing.
     set -- -SecurityTypes VncAuth -PasswordFile /root/.vnc/passwd -BlacklistThreshold=50
 else
     set -- -SecurityTypes None


### PR DESCRIPTION
This branch was written before #351/#353 and never got a PR, so it sat stranded while the stack moved on — and the problem it fixes kept resurfacing. Rebased onto current main and verified against a real fleet.

## The problem

The base HEALTHCHECK opened an RFB connection and hung up without speaking the protocol. Xvnc counts every connection closed before a successful authentication towards `BlacklistThreshold` (default 5), so the probe blacklisted 127.0.0.1 about ten seconds after start-up and refused every session after that — captures against tigervnc-auth silently produced no PNG.

The workaround at the time was `-BlacklistThreshold=1000000`, which turns the brute-force protection off rather than fixing the probe.

## The fix

Measured against TigerVNC 1.12.0, **no RFB-level probe avoids the counter**: a bare connect, a version exchange, and a version-plus-security-types exchange each trip it after five attempts, and only a successful authentication clears the mark. So the probe reads the kernel socket table with `ss` instead, confirming the port is listening without a connection ever existing.

The threshold is then *reduced* to a targeted 50 rather than removed, because the probe was not the only offender: `vncservers.py`'s `port_open()` guard leaves about seven unauthenticated closes per run, and `test_cli.py` adds one deliberate wrong password.

Readiness itself moves out of the container: `wait_for_servers.py` gates both server families by connecting, capturing, and requiring the content that server is supposed to render — the same assertion the tests make, so the gate and the tests cannot drift. The old marker file was written unconditionally, so its failure mode was a false green: a server that came up blank still reported healthy.

## Verification against a real fleet

- whole fleet rebuilt and started: all five containers reach `Healthy` on the connectionless probe
- `wait_for_servers.py docker`: every server ready on the first attempt
- full functional suite: **31 tests, OK** (4 skipped — OS-hosted servers)
- after that run, tigervnc's log shows **20 connection entries and 0 blacklist entries**, while roughly 35 healthcheck probes had elapsed. Connections track test sessions, not probes.

## One integration fix

x11vnc grew its own HEALTHCHECK while this branch sat unmerged, keeping both habits removed from base: an RFB connection via `/dev/tcp`, and the marker-file gate. The connection is harmless there — x11vnc has no blacklist — but it is the pattern that broke TigerVNC, and no reason to leave an exception lying around to be copied. Its check now uses `ss` plus the thing genuinely specific to that container, its event sink.

Supersedes #355, which raised the threshold on both entrypoint branches — spreading the workaround instead of deleting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
