### PR TITLE
Make the comment rule's test explicit: delete, don't shorten

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,10 @@ longer block needs a reason to be longer. Do not restate what the next line
 does, and do not narrate what a change replaced -- that belongs in the
 commit message. Design rationale belongs in `docs/`.
 
+Test each one by deleting it and asking what the reader lost. Being able
+to justify a comment is not the same as needing it: shortening an
+unnecessary comment leaves an unnecessary comment.
+
 A cross-reference is worth a clause when it saves the reader real work
 (`see docs/capture.rst`), so an explanation lives in exactly one place
 rather than being repeated. What it must not become is a paragraph


### PR DESCRIPTION
Your rewrite of the comment rule already covers what I got wrong — docstrings named, one or two lines as the norm, no narrating what a change replaced, rationale to `docs/`. I still needed three passes over one PR, so this adds the one thing missing: the check, rather than the standard.

I was asking *can I justify this comment?* and keeping anything that passed. The question that actually removes them is *what does the reader lose without it?* — which is why pass two kept five-line explanations and pass three shortened them instead of deleting them.

Four lines, no restructuring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)