### PR TITLE
Install vncdotool editable in the OS-servers workflow so the CLI under test is the checkout

### DIFF
--- a/.github/workflows/os-servers.yml
+++ b/.github/workflows/os-servers.yml
@@ -92,7 +92,8 @@ jobs:
       - name: Install vncdotool
         run: |
           python -m pip install --upgrade pip
-          pip install . pillow
+          pip install -r requirements-dev.txt
+          pip install -e .
 
       - name: Set up the VNC server
         run: ${{ matrix.setup }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,2 @@
 -r requirements.txt
 sphinx
-twine


### PR DESCRIPTION
The "macOS - Screen Sharing" job has failed since c4c7600 (#357), hidden by `continue-on-error: true` keeping the run green.

c4c7600 added `assert_cli_under_test()`, which requires the `vncdo` on PATH to import vncdotool from the checkout. The workflow used `pip install . pillow`, which never can. Now installs the way the sibling functional job in `ci.yml` does: `requirements-dev.txt` for the pinned floors, then `pip install -e .`. Naming pillow by hand was redundant with `install_requires` anyway.

Also drops `twine` from `requirements-dev.txt` — releases publish through `pypa/gh-action-pypi-publish` with trusted publishing, and nothing else in the repo invokes it, so every job installing that file was paying for it.

Two things a reviewer might otherwise assume:

* There is no shadowing vncdotool on the runner. The two paths in the error are one interpreter — setup-python's macOS build lives in `/Library/Frameworks`, and `hostedtoolcache/.../bin` symlinks into it.
* Windows passed only because the assertion bails when it cannot read a shebang, and `vncdo.exe` is a binary wrapper. Editable makes that job test the checkout too.

CI-only, so no CHANGELOG entry. Both OS jobs green, and the rest of CI passes on the trimmed requirements: https://github.com/sibson/vncdotool/actions/runs/31923690322

🤖 Generated with [Claude Code](https://claude.com/claude-code)