### PR TITLE
Functional tests fail loudly instead of skipping when a server is down

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,8 @@
 Tests are stdlib `unittest`, not pytest. Run the unit suite with `make test`
 (`python -m unittest discover tests/unit`) -- note the path: discovery over
 plain `tests` also collects `tests/functional/`, whose tests need the Docker
-Compose test server fleet (`make servers-up`) and skip cleanly without it.
+Compose test server fleet (`make servers-up`) and fail loudly without it --
+they never skip, so a down fleet can't pass as green.
 Unit tests need no VNC server: protocol classes are driven directly with a
 mocked Twisted transport (see `tests/unit/test_rfb.py` and `test_client.py`
 for the patterns).

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -24,7 +24,7 @@ _SERVER = next(s for s in DOCKER_SERVERS if s.name == "tigervnc-auth")
 class TestCLI(TestCase):
     def setUp(self) -> None:
         if not port_open(HOST, _SERVER.port):
-            self.skipTest(
+            self.fail(
                 f"tigervnc-auth not reachable on {HOST}:{_SERVER.port} -- "
                 "start the servers first with `make servers-up`"
             )

--- a/tests/functional/test_events.py
+++ b/tests/functional/test_events.py
@@ -66,9 +66,9 @@ class TestVncevSink(TestCase):
 
     def setUp(self) -> None:
         if not _docker_compose_available():
-            self.skipTest("docker not available")
+            self.fail("docker not available")
         if not port_open(HOST, VNCEV.port):
-            self.skipTest(
+            self.fail(
                 f"vncev not reachable on {HOST}:{VNCEV.port} -- "
                 "start the servers first with `make servers-up`"
             )
@@ -137,9 +137,9 @@ class TestX11SideSink(TestCase):
 
     def setUp(self) -> None:
         if not _docker_compose_available():
-            self.skipTest("docker not available")
+            self.fail("docker not available")
         if not port_open(HOST, X11VNC.port):
-            self.skipTest(
+            self.fail(
                 f"x11vnc not reachable on {HOST}:{X11VNC.port} -- start the servers first "
                 "with `make servers-up`"
             )

--- a/tests/functional/test_os_servers.py
+++ b/tests/functional/test_os_servers.py
@@ -8,7 +8,7 @@ and tests/servers/screen-sharing, and are what CI runs before this module.
 
 On a platform with no OS-hosted server described (Linux, say) there is
 simply nothing to register, and on a platform that has one but hasn't set
-it up the test skips with the command that would set it up.
+it up the test fails with the command that would set it up.
 """
 
 from .vncservers import os_servers, register_server_tests

--- a/tests/functional/test_proxy.py
+++ b/tests/functional/test_proxy.py
@@ -82,7 +82,7 @@ def _stop_proxy(proxy: subprocess.Popen) -> None:
 class TestVnclogProxy(TestCase):
     def setUp(self) -> None:
         if not port_open(HOST, VNCEV.port):
-            self.skipTest(
+            self.fail(
                 f"vncev not reachable on {HOST}:{VNCEV.port} -- "
                 "start the servers first with `make servers-up`"
             )
@@ -146,7 +146,7 @@ class TestVnclogCapture(TestCase):
 
     def setUp(self) -> None:
         if not port_open(HOST, VNCEV.port):
-            self.skipTest(
+            self.fail(
                 f"vncev not reachable on {HOST}:{VNCEV.port} -- "
                 "start the servers first with `make servers-up`"
             )
@@ -214,7 +214,7 @@ class TestVnclogCaptureVNCAuth(TestCase):
 
     def setUp(self) -> None:
         if not port_open(HOST, TIGERVNC_AUTH.port):
-            self.skipTest(
+            self.fail(
                 f"tigervnc-auth not reachable on {HOST}:{TIGERVNC_AUTH.port} -- "
                 "start the servers first with `make servers-up`"
             )

--- a/tests/functional/test_roundtrip.py
+++ b/tests/functional/test_roundtrip.py
@@ -23,7 +23,7 @@ SCREENSHOT = "screen.png"
 class TestCaptureReplayRoundtrip(TestCase):
     def setUp(self) -> None:
         if not port_open(HOST, TIGERVNC.port):
-            self.skipTest(f"tigervnc not reachable on {HOST}:{TIGERVNC.port} -- {TIGERVNC.how_to_start}")
+            self.fail(f"tigervnc not reachable on {HOST}:{TIGERVNC.port} -- {TIGERVNC.how_to_start}")
         self.tmp = Path(mkdtemp())
         self.live = self.tmp / "live"
         self.replayed = self.tmp / "replayed"

--- a/tests/functional/test_servers.py
+++ b/tests/functional/test_servers.py
@@ -2,9 +2,8 @@
 
 See tests/servers/docker-compose.yml and tests/servers/servers.mk. The test
 servers are expected to already be running (e.g. via ``make servers-up``)
-before this module executes; a server whose port isn't open is skipped with
-a clear message rather than failing the whole run, so this module is also
-safe to run outside of that make target.
+before this module executes; a server whose port isn't open fails with a
+clear message rather than passing silently as skipped.
 
 The servers themselves, and the round trip run against each of them, are
 described in vncservers.py and shared with the OS-hosted servers tested by

--- a/tests/functional/vncservers.py
+++ b/tests/functional/vncservers.py
@@ -350,7 +350,7 @@ class _VNCServerTestMixin:
 
     def setUp(self) -> None:
         if not port_open(HOST, self.server.port):
-            self.skipTest(
+            self.fail(
                 f"{self.server.name} not reachable on {HOST}:{self.server.port} -- "
                 f"{self.server.how_to_start}"
             )


### PR DESCRIPTION
## Summary
- Every `self.skipTest(...)` in `tests/functional/` (the shared server-test mixin, proxy, roundtrip, CLI, and event-sink tests) is now `self.fail(...)` with the same diagnostic message. A missing fleet server, OS-hosted server, or docker binary now produces an ERROR/FAILURE and a nonzero exit instead of a silent skip.
- Updated docstrings in `test_servers.py`, `test_os_servers.py`, and `CLAUDE.md` that documented skip-and-pass as intentional design.

## Why
A module- or test-level skip meant the whole functional suite (or a whole server's coverage) could go green with zero tests actually run if `make servers-up` failed, a healthcheck/probe raced, or a runner was misconfigured -- nothing would show red. Skips are silent by construction; failures aren't.

## Test plan
- [x] flake8 clean
- [x] full functional discover against the up fleet -- passes (4 known local failures are `test_os_servers.py`'s macOS Screen Sharing checks, unconfigured on this dev machine; `os-servers.yml` CI runs its setup script first)
- [x] verified the fail path directly: stopped tigervnc, confirmed a real ERROR + nonzero exit rather than a skip, restarted it and confirmed green again

`make test-servers` / `make test-os-server` (narrower Makefile targets) are unaffected; `make test-func`'s full discover now requires everything it collects to actually be running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)