### PR TITLE
Point the protocol references at documents that still exist

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 1.4.0 (UNRELEASED)
 ----------------------
+  - Fix the dead protocol reference in the published ``rfb`` module documentation, which pointed at a RealVNC PDF that has been 403 for years; RFC 6143 and the rfbproto community document replace it (@sibson)
   - Declare python_requires >=3.10, matching the versions CI tests and the development requirements. 3.9 was advertised but neither tested nor able to install the dev environment (@sibson, #357)
   - [BREAKING] vncdo exit codes now say what went wrong: single digits for bad input, including 3 for authentication, and tens grouped by cause out on the wire, 10s connection, 20s protocol, 30s command, 40s timeout, documented in docs/usage.rst.  Scripts reading the exit code see new values: authentication failure is now 3 and a session cut short 11, both of which used to be 0; an unknown action is now 2, previously 1 (@sibson, #345)
   - Fix: vncdo reports failure instead of success when the connection closes before the requested commands finish, including on VNC authentication failure (@sibson, #345)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,12 @@ A cross-reference is worth a clause when it saves the reader real work
 rather than being repeated. What it must not become is a paragraph
 re-explaining what the other file already says.
 
+Check the protocol documents before implementing anything that touches the
+wire -- a new encoding, security type, message or client command. The repo
+carries no copy of the spec; `DEVELOP.rst` says which of RFC 6143 and
+rfbproto covers what. Guessing a message layout from the surrounding code
+produces something that works against one server and no other.
+
 Lint is plain flake8, configured in `setup.cfg`: line length 127,
 `extend-ignore = E203`. CI runs `flake8 --count --statistics vncdotool tests`,
 so run that before pushing. No black, no isort.

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -44,7 +44,25 @@ both paths named, because nothing else notices.
 
 The RFB/VNC Protocol
 ------------------------
-There is a community effort to document the protcol, _rfbproto_.
+
+Two documents cover RFB, and which one answers a question depends on how
+far past the baseline it sits.
+
+`RFC 6143`_ is the normative specification. It defines RFB 3.8 and the
+encodings and security types that shipped with it, and it is the one to
+cite when the wire format is in dispute.
+
+rfbproto_ is a community effort to document everything servers grew
+afterwards: the later encodings and pseudo-encodings, the security types,
+the message extensions, and the vendor quirks the RFC never covered.
+Reach for it whenever the answer is not in the RFC -- which, for most of
+what vncdotool implements, it is not.
+
+rfbproto is a living document with no releases or version numbers, so link
+a commit permalink rather than ``master`` when a comment depends on its
+wording. Neither document describes how any particular server actually
+behaves; where one is known to diverge, ``docs/server-compatibility-plan.md``
+records what we do about it.
 
 
 Preparing a Release
@@ -54,4 +72,5 @@ Preparing a Release
   1. ``make release``
   1. blog post/twitter
 
+.. _RFC 6143: https://www.rfc-editor.org/rfc/rfc6143
 .. _rfbproto: https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -5,7 +5,8 @@ Override :class:`RFBClient` and :class:`RFBFactory` in your application.
 See vncviewer.py for an example.
 
 Reference:
-http://www.realvnc.com/docs/rfbproto.pdf
+https://www.rfc-editor.org/rfc/rfc6143
+https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst
 """
 # (C) 2003 cliechti@gmx.net
 #


### PR DESCRIPTION
The reference in rfb.py's module docstring, which Sphinx publishes as part
of the API docs, was a RealVNC PDF that has answered 403 for years. The
DEVELOP.rst pointer to rfbproto survived but never rendered as a link: a
leading underscore makes `_rfbproto_` literal text, not a reference.

Expand that section to say which of the two documents to consult when,
since the split is not obvious -- RFC 6143 is normative but stops at RFB
3.8, and nearly everything vncdotool implements past that is described
only by rfbproto. Neither is vendored: rfbproto ships no licence, and the
RFC is the weaker document for this codebase.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Rt9FavweJKhNp3ReWbQL8C