### PR TITLE
test: uppercase VNC acronym in functional test class names

### DIFF
--- a/tests/functional/test_events.py
+++ b/tests/functional/test_events.py
@@ -61,7 +61,7 @@ def wait_for_log_line(
     return logs
 
 
-class TestVncevSink(TestCase):
+class TestVNCEVSink(TestCase):
     """Client conformance: what vncev saw the client actually send."""
 
     def setUp(self) -> None:

--- a/tests/functional/test_proxy.py
+++ b/tests/functional/test_proxy.py
@@ -77,7 +77,7 @@ def _stop_proxy(proxy: subprocess.Popen) -> None:
             proxy.wait(timeout=PROXY_SHUTDOWN_TIMEOUT)
 
 
-class TestVnclogProxy(TestCase):
+class TestVNCLOGProxy(TestCase):
     def setUp(self) -> None:
         if not port_open(HOST, VNCEV.port):
             self.skipTest(
@@ -139,7 +139,7 @@ class TestVnclogProxy(TestCase):
         self.assertIn("keyup z", recorded, f"vnclog recorded:\n{recorded!r}")
 
 
-class TestVnclogCapture(TestCase):
+class TestVNCLOGCapture(TestCase):
     """`vnclog --capture-raw FILE.zip` against vncev, which uses auth None."""
 
     def setUp(self) -> None:
@@ -205,7 +205,7 @@ class TestVnclogCapture(TestCase):
         self.assertIn("already exists", second.stderr.lower())
 
 
-class TestVnclogCaptureVNCAuth(TestCase):
+class TestVNCLOGCaptureVNCAuth(TestCase):
     """`vnclog --capture-raw FILE.zip` against tigervnc-auth.
 
     The unit tests scrub a scripted challenge/response; only a live run


### PR DESCRIPTION
## Summary
- TestVnclogProxy/TestVnclogCapture/TestVnclogCaptureVNCAuth/TestVncevSink mixed-cased the vnclog/vncev tool names embedded in the class name
- VNC is an acronym; renamed to TestVNCLOGProxy/TestVNCLOGCapture/TestVNCLOGCaptureVNCAuth/TestVNCEVSink for consistency

## Test plan
- [x] flake8 clean on changed files
- [x] grep confirms no other mixed-case Vnc identifiers in the repo