### PR TITLE
ci: allow CI to be run manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `workflow_dispatch:` to `ci.yml`, so CI can be re-run on a branch from the Actions tab or with `gh workflow run ci.yml --ref <branch>` instead of pushing an empty commit.

## History

This PR started as a build cache for the VNC test server images and has been stripped back to the one line above. Recording why, so the idea does not get retried blind.

It came out of an evaluation of splitting CI into per-PR and nightly tiers. The measured durations said not to split: jobs run in parallel and the PR critical path is ~2 minutes (lint 11s, unit tests 15-26s per Python version, functional 105s, Windows 98s, macOS 121s). Runner minutes are free on a public repo, and nightly runs on a low-traffic repo either re-prove unchanged code or batch several commits into one unbisectable failure. So the plan was to cache the slow part instead: 58s of the functional job's 105s was rebuilding five images, re-running the same apt installs and the same libvncserver compile every push.

Measured, cold then warm:

| Step | Baseline | Cold | Warm |
|---|---|---|---|
| Set up Buildx | — | 6s | 5s |
| Build images | 58s (combined) | 80s | 20s |
| Start servers | — | 23s | 22s |
| **Changed segment** | **58s** | 109s | **47s** |

The cache worked — the build went 58s to 20s. But it does not pay for itself. Exporting a cache requires the docker-container driver, which builds into its own store, so the images then have to be exported and re-imported into dockerd for compose to find them. That is the 22s `Start servers` step, which cost nothing before when `compose up --build` built straight into dockerd. Net saving after the export tax and Buildx setup: **11s on a ~105s job**.

That is not worth a new overlay file, a third-party action, and the two path-resolution gotchas it took three pushes to get right (bake resolves `context: .` against the working directory where compose resolves it against the compose file; and bake-action's `source` defaults to the remote git context, so `workdir` and `source: .` are both needed).

The tax is structural, not a tuning problem: the gha cache backend needs the docker-container driver, and the docker driver cannot export a cache at all, so "cache the build" and "build directly into dockerd" are mutually exclusive here.

Worth revisiting only if the critical path passes ~10 minutes or the repo goes private, which would make runner minutes cost real money and change the arithmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)