### PR TITLE
CLAUDE.md: comments shouldn't reference the current task, fix, or callers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,10 @@ Keep comments and docstrings short. A comment earns its place by recording
 a *why* the code cannot show -- a protocol quirk, a server's misbehaviour,
 why the obvious alternative was rejected. One or two lines is the norm; a
 longer block needs a reason to be longer. Do not restate what the next line
-does, and do not narrate what a change replaced -- that belongs in the
-commit message. Design rationale belongs in `docs/`.
+does, and do not narrate what a change replaced or reference the current
+task, fix, or callers ("used by X", "added for the Y flow", "handles the
+case from issue #123") -- that belongs in the commit message. Design
+rationale belongs in `docs/`.
 
 A cross-reference is worth a clause when it saves the reader real work
 (`see docs/capture.rst`), so an explanation lives in exactly one place


### PR DESCRIPTION
## Summary
- Folds one missing rule into the existing comments paragraph (added independently in #348): a comment shouldn't reference the current task, fix, or caller ("used by X", "added for the Y flow", "handles the case from issue #123") -- that belongs in the commit message, since it rots as the codebase evolves.

## Why
A separate, unpushed local commit had drifted from #348's already-merged comments guidance and duplicated most of it while adding this one genuinely new clause. Folding it into the existing paragraph avoids two overlapping sections saying almost the same thing in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)