### PR TITLE
fix(servers): survive docker compose restart on TigerVNC

### DIFF
--- a/tests/functional/test_roundtrip.py
+++ b/tests/functional/test_roundtrip.py
@@ -11,7 +11,7 @@ from PIL import Image
 from .test_proxy import _await_capture, _start_vnclog, _stop_proxy
 from .vncservers import DOCKER_SERVERS, HOST, port_open, start_replay_server, vncdo_argv
 
-TIGERVNC = next(s for s in DOCKER_SERVERS if s.name == "tigervnc")
+TIGERVNC_AUTH = next(s for s in DOCKER_SERVERS if s.name == "tigervnc-auth")
 
 ROUNDTRIP_PROXY_PORT = 5996
 REPLAY_PORT = 5997
@@ -22,21 +22,21 @@ SCREENSHOT = "screen.png"
 
 class TestCaptureReplayRoundtrip(TestCase):
     def setUp(self) -> None:
-        if not port_open(HOST, TIGERVNC.port):
-            self.fail(f"tigervnc not reachable on {HOST}:{TIGERVNC.port} -- {TIGERVNC.how_to_start}")
+        if not port_open(HOST, TIGERVNC_AUTH.port):
+            self.fail(f"tigervnc-auth not reachable on {HOST}:{TIGERVNC_AUTH.port} -- {TIGERVNC_AUTH.how_to_start}")
         self.tmp = Path(mkdtemp())
         self.live = self.tmp / "live"
         self.replayed = self.tmp / "replayed"
         self.live.mkdir()
         self.replayed.mkdir()
         self.capture = self.tmp / "roundtrip.zip"
-        self.proxy = _start_vnclog(ROUNDTRIP_PROXY_PORT, f"{HOST}::{TIGERVNC.port}", self.capture)
+        self.proxy = _start_vnclog(ROUNDTRIP_PROXY_PORT, f"{HOST}::{TIGERVNC_AUTH.port}", self.capture)
         self.addCleanup(_stop_proxy, self.proxy)
 
     def test_replayed_capture_decodes_to_the_same_screenshot(self) -> None:
         # Relative, from its own directory: an absolute path would have the
         # replay overwrite the file it is compared against.
-        proxied = TIGERVNC._replace(port=ROUNDTRIP_PROXY_PORT)
+        proxied = TIGERVNC_AUTH._replace(port=ROUNDTRIP_PROXY_PORT)
         result = subprocess.run(
             vncdo_argv(proxied, "capture", SCREENSHOT),
             capture_output=True, text=True, timeout=TIMEOUT,

--- a/tests/servers/tigervnc-entrypoint.sh
+++ b/tests/servers/tigervnc-entrypoint.sh
@@ -11,6 +11,11 @@ set -e
 
 trap 'kill -TERM "$XVNC_PID" 2>/dev/null; exit 0' TERM INT
 
+# `docker compose restart` reuses the container filesystem, and a lock left
+# by an Xvnc that did not exit cleanly makes the next start die with
+# "Server is already active for display 0".
+rm -f /tmp/.X0-lock /tmp/.X11-unix/X0
+
 if [ -n "$VNC_PASSWORD" ]; then
     mkdir -p /root/.vnc
     printf '%s' "$VNC_PASSWORD" | vncpasswd -f > /root/.vnc/passwd


### PR DESCRIPTION
## Summary
- `docker compose restart` reuses the container filesystem. If Xvnc didn't exit cleanly, a stale `/tmp/.X0-lock` survives and the next start dies with "Server is already active for display 0".
- x11vnc's entrypoint already clears its lock for the same reason (`tests/servers/x11vnc-entrypoint.sh`); TigerVNC's did not.
- Fix mirrors that pattern: clear the lock and socket before starting Xvnc.
- Also fixes `test_roundtrip.py`: it claimed to capture password-protected tigervnc and replay without a password, but its `DOCKER_SERVERS` lookup picked `"tigervnc"` (no-auth) instead of `"tigervnc-auth"`. The no-password replay assertion was vacuous — there was never a password to strip. Now points at `tigervnc-auth`, verified passing against the live fleet.

Diagnosed and originally fixed together with an x11vnc/Xvfb start-up race on a local branch (`claude/goofy-mendel-87f383`) that was never pushed as a PR. That branch's other half — clearing `draw-content.sh`'s readiness marker on restart — is now moot: #356 moved readiness off the marker file entirely (`wait_for_servers.py` does a real capture instead), so there's no stale-marker failure mode left to guard against.

## Test plan
- [x] `tests/functional/test_roundtrip.py` run against the live fleet with the fix — passes
- [ ] `make servers-up`, `docker compose -f tests/servers/docker-compose.yml restart tigervnc tigervnc-auth`, confirm both come back healthy
- [ ] `make test-func` against the restarted fleet