### PR TITLE
test: name each docker-fleet server as a constant, drop the by-name scan

### DIFF
--- a/tests/functional/test_api_lifecycle.py
+++ b/tests/functional/test_api_lifecycle.py
@@ -25,9 +25,7 @@ from twisted.internet.protocol import Factory, Protocol
 
 from vncdotool import api
 
-from .vncservers import DOCKER_SERVERS, HOST, SUBPROCESS_TIMEOUT_HEADROOM, connect, port_open
-
-LIBVNC = next(s for s in DOCKER_SERVERS if s.name == "libvncserver-example")
+from .vncservers import HOST, LIBVNCSERVER_EXAMPLE as LIBVNC, SUBPROCESS_TIMEOUT_HEADROOM, connect, port_open
 
 # Same headroom the subprocess grid adds: the bare 5s server budget was
 # observed to flake under load.

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -8,9 +8,9 @@ duplicated per server.
 from unittest import TestCase
 
 from .vncservers import (
-    DOCKER_SERVERS,
     PNG_MAGIC,
     HOST,
+    TIGERVNC_AUTH,
     port_open,
     run_vncdo,
     screenshot_dir,
@@ -18,7 +18,7 @@ from .vncservers import (
 
 # The one fleet server with a password, so the only one that can prove a
 # wrong password is rejected rather than ignored.
-_SERVER = next(s for s in DOCKER_SERVERS if s.name == "tigervnc-auth")
+_SERVER = TIGERVNC_AUTH
 
 
 class TestCLI(TestCase):

--- a/tests/functional/test_events.py
+++ b/tests/functional/test_events.py
@@ -14,12 +14,10 @@ from pathlib import Path
 from typing import List
 from unittest import TestCase
 
-from .vncservers import DOCKER_SERVERS, HOST, VNCEV, port_open, run_vncdo
+from .vncservers import HOST, VNCEV, X11VNC, port_open, run_vncdo
 
 ROOT = Path(__file__).resolve().parents[2]
 COMPOSE_FILE = ROOT / "tests" / "servers" / "docker-compose.yml"
-
-X11VNC = next(s for s in DOCKER_SERVERS if s.name == "x11vnc")
 
 LOG_POLL_INTERVAL = 0.5
 LOG_POLL_DEADLINE = 15.0

--- a/tests/functional/test_proxy.py
+++ b/tests/functional/test_proxy.py
@@ -11,9 +11,7 @@ from unittest import TestCase
 
 from vncdotool.const import AuthTypes
 
-from .vncservers import DOCKER_SERVERS, HOST, VNCEV, port_open, run_vncdo
-
-TIGERVNC_AUTH = next(s for s in DOCKER_SERVERS if s.name == "tigervnc-auth")
+from .vncservers import HOST, TIGERVNC_AUTH, VNCEV, port_open, run_vncdo
 
 PROXY_PORT = 5993
 CAPTURE_PROXY_PORT = 5994

--- a/tests/functional/test_roundtrip.py
+++ b/tests/functional/test_roundtrip.py
@@ -9,9 +9,7 @@ from unittest import TestCase
 from PIL import Image
 
 from .test_proxy import _await_capture, _start_vnclog, _stop_proxy
-from .vncservers import DOCKER_SERVERS, HOST, port_open, start_replay_server, vncdo_argv
-
-TIGERVNC_AUTH = next(s for s in DOCKER_SERVERS if s.name == "tigervnc-auth")
+from .vncservers import HOST, TIGERVNC_AUTH, port_open, start_replay_server, vncdo_argv
 
 ROUNDTRIP_PROXY_PORT = 5996
 REPLAY_PORT = 5997

--- a/tests/functional/vncservers.py
+++ b/tests/functional/vncservers.py
@@ -76,14 +76,16 @@ class VNCServer(NamedTuple):
     how_to_start: str = "start the servers first with `make servers-up`"
 
 
-# One entry per service in tests/servers/docker-compose.yml.
-DOCKER_SERVERS = [
-    VNCServer("tigervnc", 5931),
-    VNCServer("tigervnc-auth", 5932, password="vncdotool"),
-    VNCServer("x11vnc", 5933),
-    # 800x600 is the demo's hard-coded size; it takes no -geometry option.
-    VNCServer("libvncserver-example", 5935, size=(800, 600)),
-]
+# One constant per service in tests/servers/docker-compose.yml, named so a
+# test that needs a specific one can import it directly instead of
+# searching DOCKER_SERVERS by name.
+TIGERVNC = VNCServer("tigervnc", 5931)
+TIGERVNC_AUTH = VNCServer("tigervnc-auth", 5932, password="vncdotool")
+X11VNC = VNCServer("x11vnc", 5933)
+# 800x600 is the demo's hard-coded size; it takes no -geometry option.
+LIBVNCSERVER_EXAMPLE = VNCServer("libvncserver-example", 5935, size=(800, 600))
+
+DOCKER_SERVERS = [TIGERVNC, TIGERVNC_AUTH, X11VNC, LIBVNCSERVER_EXAMPLE]
 
 # An event sink rather than a rendering server, so it stays out of the smoke
 # grid; test_events.py still needs its host/port.


### PR DESCRIPTION
## Summary
The tail commit of #367 (`3921aae`) landed after the PR was already merged (`4a3c8bb`), so it never made it to main. Recovering it here.

- Five call sites did `next(s for s in DOCKER_SERVERS if s.name == "...")` to pull one server out of the registry. `VNCEV` already showed the better pattern: a bare module-level constant.
- Named the other four the same way (`TIGERVNC`, `TIGERVNC_AUTH`, `X11VNC`, `LIBVNCSERVER_EXAMPLE`) and had callers import them directly.
- Addresses the review comment on #367 asking why these were searched for instead of exported.

Clean cherry-pick onto current main, no conflicts.

## Test plan
- [x] `flake8` clean
- [x] `test_cli.py`, `test_events.py`, `test_proxy.py`, `test_roundtrip.py` run against the live fleet — all pass