### PR TITLE
Design: pixel format layer for pluggable decoders

### DIFF
--- a/specs/decoder-architecture.md
+++ b/specs/decoder-architecture.md
@@ -366,6 +366,10 @@ This phase is an architecture proof, not a user win. RRE and CoRRE are rarely
 any server's preferred encoding and their bandwidth advantage is narrow. The
 user-visible payoff starts at Phase 4.
 
+The encoding probe lands here too, as a loop over the new flag, filling in the
+UltraVNC and Screen Sharing columns of the support table above and wired into
+`os-servers.yml` beside the pixel-format report.
+
 *Done when:* both render identically to Raw against every fleet server that
 supports them, and `--encodings` can select them. Discharges R4.
 
@@ -436,12 +440,13 @@ is safe; CoRRE survives on two of three servers, TigerVNC having dropped it;
 Hextile and ZRLE are universal; TRLE is emitted by nothing and is therefore out
 of scope entirely.
 
-The probe is not in the repository — the table above came from a throwaway that
-no longer exists, which is why two columns cannot be filled in now. It becomes
-Phase 0 tooling: a script setting `client.encoding` per connection, since
-`--encodings` does not arrive until Phase 3, run against both fleets and wired
-into `os-servers.yml` beside the pixel-format report. The matrix drifts as
-images update, and a phase needs to know what it can test before it starts.
+The probe is not in the repository — the table came from a throwaway that no
+longer exists, which is why two columns are blank. Building it waits for Phase 3
+rather than being Phase 0 tooling: `--encodings` lands there, so the probe is
+then a loop over a flag instead of a script reaching into `client.encoding`, and
+Phase 3 is also the first phase whose scope the missing columns could change.
+Until then the matrix is three servers nobody runs, and it drifts as their
+images update.
 
 ## Testing
 

--- a/specs/decoder-architecture.md
+++ b/specs/decoder-architecture.md
@@ -252,8 +252,10 @@ vncdotool/decoders/control.py    DesktopSize, LastRect, QEMU extended key
 vncdotool/rfb.py                 negotiation, auth, message framing, the pump
 ```
 
-`SUPPORTED_ENCODINGS` derives from the registry and is filterable per connection,
-which is R4.
+`SUPPORTED_ENCODINGS` stops being the set literal at `rfb.py:161` and derives
+from the registry, filterable per connection, which is R4. It is also what makes
+R1's zero-line `rfb.py` diff possible: registering an encoding is a line in
+`decoders/__init__.py`, and nothing has to tell `rfb.py` the encoding exists.
 
 Third-party decoder plugins via entry points are out of scope. Nobody ships
 out-of-tree VNC encodings; the registry is a dict.
@@ -381,8 +383,11 @@ unreachable code.
 meets N2. Discharges R5.
 
 **Phase 6 — Tight.** A new encoding as new files plus tests.
-*Done when:* it is added with a zero-line diff to `rfb.py`. That diff is the test
-of R1 — if it is not zero, the architecture did not deliver what it exists for.
+*Done when:* it is added with a zero-line diff to `rfb.py`. The one line that
+registers it goes in `decoders/__init__.py`, and `Encoding.TIGHT` already exists
+(`const.py:32`), so `rfb.py` and `const.py` are both untouched. That is the test
+of R1: today the same change edits `SUPPORTED_ENCODINGS` at `rfb.py:161`, and if
+it still does, the architecture did not deliver what it exists for.
 `libvncserver-example` falls back to Raw when asked for Tight, so its oracle
 comes from `tigervnc` and `x11vnc`.
 

--- a/specs/decoder-architecture.md
+++ b/specs/decoder-architecture.md
@@ -134,7 +134,7 @@ three shapes, distinguished by what the decoder produces:
 |---|---|---|---|
 | `PixelDecoder` | bytes | fills a `RectBuffer` | Raw, RRE, CoRRE, Hextile, ZRLE, Tight |
 | `ClientDecoder` | bytes | calls a client method | CopyRect, Cursor |
-| `Control` | nothing | changes client state | DesktopSize, LastRect, QEMU extended key |
+| `ControlDecoder` | nothing | changes client state | DesktopSize, LastRect, QEMU extended key |
 
 There is no separate sink object. The pump calls the existing client callbacks —
 `updateRectangle`, `copyRectangle`, `updateCursor` — which is the vocabulary the
@@ -151,7 +151,7 @@ padded to a whole number of bytes — `floor((width + 7) / 8)` — with the most
 significant bit of each byte representing the leftmost pixel and a 1-bit meaning
 the corresponding cursor pixel is valid.
 
-The genuine special cases are `Control`: `LastRect` mutates the rectangle loop
+The genuine special cases are `ControlDecoder`: `LastRect` mutates the rectangle loop
 counter, and the QEMU extended key encoding mutates `negotiated_encodings` and
 removes the entry it just appended to `rectanglePos`.
 

--- a/specs/decoder-architecture.md
+++ b/specs/decoder-architecture.md
@@ -46,8 +46,12 @@ Stated independently of how. Each design decision should trace to one.
   is unchanged. This is the motivating requirement.
 - **R2** Every decoder is unit-testable with no reactor, no transport, no
   server, and no `RFBClient`.
-- **R3** Decoder output does not depend on the pixel format the server
-  negotiated. Servers that ignore `SetPixelFormat` cause #90 and #275.
+- **R3** The framebuffer a client sees does not depend on the pixel format the
+  server negotiated. Stated over the framebuffer rather than over decoder
+  output, because decoders emit the layout they were sent and name it; the
+  format-independence is the client's paste, and the goldens' cross-format
+  comparison is what checks it. Servers that ignore `SetPixelFormat` cause #90
+  and #275.
 - **R4** The user can choose which encodings are offered (#167, #168). Without
   this, every encoding except Raw is dead code and none of it can be tested
   end-to-end.
@@ -97,7 +101,7 @@ A decoder yields the number of bytes it wants and receives them back:
 class RawDecoder:
     def decode(self, target: RectBuffer, pf: PixelFormat) -> Iterator[int]:
         data = yield target.width * target.height * pf.bypp
-        target.blit(0, 0, target.width, target.height, pf.to_canonical(data))
+        target.blit(0, 0, target.width, target.height, data)
 ```
 
 `RFBClient` keeps one adapter — the pump — that drives the generator against
@@ -153,53 +157,36 @@ removes the entry it just appended to `rectanglePos`.
 
 ## Pixel format is shared, not per-decoder
 
-Almost nothing about pixel format varies between decoders. Three layers, written
-once in `vncdotool/pixelformat.py`:
+Almost nothing about pixel format varies between decoders, so it lives once in
+`vncdotool/pixelformat.py`: the negotiated PIXEL width and its Pillow raw mode,
+CPIXEL's three-byte rule and its two placements (RFC 6143 §7.7.5), TPIXEL's
+narrower and differently-ordered one (rfbproto §Tight), and colour-map
+indirection. [pixel-format.md](pixel-format.md) is the design.
 
-**PIXEL** (RFC 6143 §7.4) is negotiated once by `SetPixelFormat`. Raw, RRE,
-CoRRE, Hextile and Cursor read plain PIXEL values with identical code.
-
-**CPIXEL** is used by ZRLE and TRLE. RFC 6143 §7.7.5 defines it as the same as a
-PIXEL for the agreed format, except that it uses a more compact form when
-`true-colour-flag` is non-zero, `bits-per-pixel` is 32, `depth` is 24 or less,
-and all of the bits making up the red, green and blue intensities fit in *either
-the least significant 3 bytes or the most significant 3 bytes*. When all hold, a
-CPIXEL is 3 bytes and contains the least significant or the most significant 3
-bytes as appropriate. Otherwise a CPIXEL is a PIXEL.
-
-Note the two cases. The condition concerns where the colour bits sit within the
-32-bit pixel, not the magnitude of the colour maxima, and a conforming decoder
-must handle both placements. That is a second defect in `rfb.py:800` beyond its
-fabricated alpha byte: `next(i), next(i), next(i)` implements one placement and
-silently mis-decodes the other.
-
-Tight's TPIXEL is believed to follow the same rule and Tight is believed to use
-four independent zlib streams, but neither has been checked — see Protocol
-validation.
-
-**Colour map** indirection applies when `true_colour` is false: the pixel value
-is an index resolved through `set_color_map`. Uniform across decoders.
+`rfb.py:800` gets both CPIXEL cases wrong in one line: `next(i), next(i),
+next(i)` implements the low placement, silently mis-decodes the high one, and
+appends a fabricated fourth byte.
 
 What varies per decoder is pixel *layout in the stream* — palettes, RLE runs,
 subrect coordinates. That is decoding, not formatting.
 
-### Decoders emit a canonical format
+### Decoders emit the bytes they were sent, and say what they are
 
-The current premise is that decoders emit bytes in the negotiated server format.
-That premise is already false: ZRLE's `cpixel()` (`rfb.py:800`) emits four-byte
-pixels regardless of what was negotiated. Tight's JPEG sub-encoding will break it
-a second way, since the JPEG decoder yields RGB and cannot produce an arbitrary
-server format at all.
+A decoder returns pixel bytes in whatever layout it produced them, tagged with
+the Pillow raw mode that unpacks it, and `client.py` materializes each rectangle
+with one `Image.frombytes(..., "raw", mode)`. Most decoders tag the negotiated
+format; Tight's JPEG tags `RGB`, a colour-mapped decoder tags `P` and carries
+the palette.
 
-So decoders convert to one canonical format — RGBX, 32bpp — using the shared
-readers. `client.PF2IM` (`client.py:67`) then goes: it is a five-entry lookup
-that raises `LookupError` and falls back to a hardcoded Apple Remote Desktop
-guess (`client.py:310-314`) for anything else. Test expectations also become
-format-independent, which is what lets one captured fixture verify a decoder
-regardless of what the capturing server negotiated.
+So a decoder never interprets a pixel. A background colour, a Hextile
+foreground, a ZRLE palette entry are opaque `bypp`-sized byte strings and a fill
+is one repeated — no shifts, no masks, no endianness, so that class of bug
+cannot be written. `client.PF2IM` (`client.py:67`) goes with it: a computed raw
+mode covers every layout Pillow can unpack, which is the bound this accepts.
 
-This is why pixel format comes early in the build order. Every decoder's output
-contract depends on it, so deferring it means writing the decoders twice.
+[pixel-format.md](pixel-format.md) has the module, the coverage, and what
+happens for a layout Pillow cannot unpack. Pixel format still comes early in the
+build order: every decoder's output contract depends on it.
 
 Cursor keeps its `(image, mask)` shape rather than folding the mask into alpha.
 Folding would move bit-unpacking and interleaving into the decoder to save
@@ -232,7 +219,8 @@ Tests improve correspondingly: one expected byte array replaces an ordered log o
 callbacks with absolute coordinates, which is a test that breaks when tile
 iteration order changes even though the rendered result is identical.
 
-The buffer is `w*h*4` — 8.3MB for full-screen 1080p — and is sized from
+The buffer is `w*h*bypp` — 8.3MB for full-screen 1080p at the 32 bpp every
+measured server sends — and is sized from
 server-declared dimensions, so the pump validates those against
 `MAX_DESKTOP_SIZE` before allocating. That is R6, not a separate concern: an
 unhandled `MemoryError` is as undiagnosed a failure as an indefinite wait. The
@@ -251,7 +239,7 @@ diagnosed disconnect. This is a larger user-facing win than the split itself.
 ## Module layout
 
 ```
-vncdotool/pixelformat.py         PixelFormat, cpixel(), PIXEL reader, canonical converter
+vncdotool/pixelformat.py         PixelFormat -> Pillow raw mode, CPIXEL/TPIXEL widths
 vncdotool/decoders/__init__.py   registry, the three shape protocols
 vncdotool/decoders/buffer.py     RectBuffer
 vncdotool/decoders/{raw,rre,corre,hextile,zrle,cursor}.py
@@ -274,8 +262,11 @@ we cannot observe is speculative, and so is breaking it silently.
 
 Two hooks change:
 
-- `updateRectangle` receives canonical-format bytes instead of server-format
-  ones, and one call per rectangle instead of one per tile.
+- `updateRectangle` gains the raw mode its bytes are in, and is called once per
+  rectangle instead of once per tile. The bytes stay in the server's format for
+  every encoding in use today, so a subclass that reads them with the session's
+  format still reads them correctly; what changes is that the format now
+  travels with the data rather than being assumed.
 - `fillRectangle` stops being called, because decoders fill a rect buffer
   instead. Its docstring actively invites overriding it "for better
   performance", so a subclass that did so silently stops being invoked.
@@ -318,8 +309,9 @@ which is the failure mode being detected.
 
 `self.image_mode` is the one break `__init_subclass__` cannot see, since reading
 an attribute overrides nothing. It becomes a property that warns on access and
-returns the canonical mode, which is truthful under the new design; `setImageMode`
-becomes a warning no-op.
+returns the mode the negotiated format resolves to, which stays truthful under
+the new design for as long as one session has one format; `setImageMode` becomes
+a warning no-op.
 
 **This machinery is temporary.** Once the contracts have actually changed the
 warnings are false, and they are removed. If the survey turns up nobody, they are
@@ -338,12 +330,15 @@ code, and the only one that gates on information we do not have.
 with no reactor, and the capture tooling described under Testing. Discharges R2,
 C1.
 
-**Phase 1 — pixel format.** `pixelformat.py` complete: arbitrary
-bits-per-pixel, endianness, shifts, both CPIXEL placements, colour-map
-indirection. `PF2IM` removed.
-*Done when:* a test asserts identical canonical output across at least three
-negotiated formats including a non-32bpp one and a colour-mapped one. Discharges
-R3. This comes before any decoder migrates so no decoder is written twice.
+**Phase 1 — pixel format.** `pixelformat.py`: a negotiated format resolved to a
+Pillow raw mode, both CPIXEL placements, TPIXEL's narrower rule, and the
+`--pixel-format` flag that makes a second format reachable. `PF2IM` removed.
+Designed in [pixel-format.md](pixel-format.md).
+*Done when:* the same scene, captured at two negotiated formats, decodes to the
+same framebuffer within the reduced format's quantization. Discharges R3 for
+those two; colour map and the formats Pillow cannot unpack follow with the
+servers that need them. This comes before any decoder migrates so no decoder is
+written twice.
 
 **Phase 2 — pump, Raw, CopyRect.** The pump lands with `DecodeError` handling and
 `MAX_DESKTOP_SIZE` validation. Raw and CopyRect move; everything else stays on
@@ -452,9 +447,9 @@ The scene source, the capture path, the fixture format and the matrix this
 tooling produces are designed in [decoder-goldens.md](decoder-goldens.md).
 
 **Tier 1 — unit, offline.** Captured wire bytes into the decoder, compare the
-resulting buffer against the Raw ground truth. Fast, no fleet, no reactor.
-Canonical output is what makes this comparison possible across captures from
-servers that negotiated different formats.
+resulting buffer against the Raw ground truth. Fast, no fleet, no reactor. The
+comparison is on the framebuffer after the client's paste, which is what makes
+it hold across captures from servers that negotiated different formats.
 
 **Tier 2 — live, against the fleet.** Force `--encodings` to one encoding, drive
 the same script, compare the rendered screen to the Raw run. Catches everything
@@ -521,9 +516,10 @@ pixel-then-coordinates correctly (`rfb.py:492`) and the ZRLE run-length branch
 already permits palettes to 127 (`subencoding & 127`). Neither needs changing;
 the packed-palette cap of 16 is in the correct branch.
 
-**Not verified, and must be before implementation:** Tight's TPIXEL rule and its
-zlib stream count. Both fetches of rfbproto truncated before that section. Blocks
-nothing before Phase 6.
+**Verified against rfbproto, since:** Tight's TPIXEL rule — narrower than
+CPIXEL, fixed in red-green-blue order — and its four zlib streams; CPIXEL's
+tie-break at depth ≤ 16, absent from RFC 6143; and that *bits-per-pixel* must be
+8, 16 or 32. Detail in [pixel-format.md](pixel-format.md).
 
 Per `DEVELOP.rst`, rfbproto is a living document with no releases, so any comment
 or test depending on its wording cites a commit permalink rather than `master`.

--- a/specs/decoder-architecture.md
+++ b/specs/decoder-architecture.md
@@ -173,10 +173,15 @@ subrect coordinates. That is decoding, not formatting.
 ### Decoders emit the bytes they were sent, and say what they are
 
 A decoder returns pixel bytes in whatever layout it produced them, tagged with
-the Pillow raw mode that unpacks it, and `client.py` materializes each rectangle
-with one `Image.frombytes(..., "raw", mode)`. Most decoders tag the negotiated
-format; Tight's JPEG tags `RGB`, a colour-mapped decoder tags `P` and carries
-the palette.
+the `PixelFormat` that describes it. `client.py` resolves that to a Pillow raw
+mode and materializes each rectangle with one `Image.frombytes(..., "raw",
+mode)`. Most decoders tag the negotiated format; Tight's JPEG and TPIXEL tag
+24 bpp RGB, a colour-mapped decoder tags the colour-mapped format.
+
+The tag is a `PixelFormat`, not a Pillow mode string: decoders implement a
+specification written in shifts and maxima, so Pillow stays in `client.py` and
+in `pixelformat.raw_mode`, and a decoder unit test needs no rendering library
+(R2).
 
 So a decoder never interprets a pixel. A background colour, a Hextile
 foreground, a ZRLE palette entry are opaque `bypp`-sized byte strings and a fill

--- a/specs/decoder-architecture.md
+++ b/specs/decoder-architecture.md
@@ -367,8 +367,10 @@ any server's preferred encoding and their bandwidth advantage is narrow. The
 user-visible payoff starts at Phase 4.
 
 The encoding probe lands here too, as a loop over the new flag, filling in the
-UltraVNC and Screen Sharing columns of the support table above and wired into
-`os-servers.yml` beside the pixel-format report.
+UltraVNC and Screen Sharing columns of the support table above. Whether it stays
+in CI or runs once and leaves its results in that table is the same question the
+pixel-format probe answered by leaving: a measurement that only moves when a
+runner image does is a record, not a test.
 
 *Done when:* both render identically to Raw against every fleet server that
 supports them, and `--encodings` can select them. Discharges R4.

--- a/specs/decoder-architecture.md
+++ b/specs/decoder-architecture.md
@@ -408,16 +408,22 @@ Because fixtures must come from a real server, an encoding no fleet server emits
 cannot be tested, and therefore cannot be built. Measured by offering each server
 exactly one encoding and reading back the encoding it actually used:
 
-| Encoding | tigervnc | x11vnc | libvncserver-example |
-|---|---|---|---|
-| RRE | yes | yes | yes |
-| CoRRE | no | yes | yes |
-| Hextile | yes | yes | yes |
-| ZRLE | yes | yes | yes |
-| Tight | yes | no | — see below |
-| TRLE | no | no | no |
+| Encoding | tigervnc | x11vnc | libvncserver-example | ultravnc | screen-sharing |
+|---|---|---|---|---|---|
+| RRE | yes | yes | yes | ? | ? |
+| CoRRE | no | yes | yes | ? | ? |
+| Hextile | yes | yes | yes | ? | ? |
+| ZRLE | yes | yes | yes | ? | ? |
+| Tight | yes | no | — see below | ? | ? |
+| TRLE | no | no | no | ? | ? |
 
 A "no" means the server answered a request for that encoding with Raw.
+
+**The two Tier 2 columns are unmeasured**, and they are the servers users run.
+That matters most for Tight, the encoding this whole document exists for (#264):
+UltraVNC is the likeliest server in the fleet to speak it, and nothing here
+knows whether it does. Both already authenticate in CI (`os-servers.yml`), so
+the probe is what is missing, not access.
 
 Read these asymmetrically. A "yes" is proof: the server really emitted that
 encoding. A "no" is strong evidence but not certainty, because servers choose
@@ -430,9 +436,12 @@ is safe; CoRRE survives on two of three servers, TigerVNC having dropped it;
 Hextile and ZRLE are universal; TRLE is emitted by nothing and is therefore out
 of scope entirely.
 
-The probe belongs in the repository as Phase 0 tooling rather than as a
-throwaway. The matrix will drift as the fleet's images update, and a phase needs
-to know what it can actually test before it starts.
+The probe is not in the repository — the table above came from a throwaway that
+no longer exists, which is why two columns cannot be filled in now. It becomes
+Phase 0 tooling: a script setting `client.encoding` per connection, since
+`--encodings` does not arrive until Phase 3, run against both fleets and wired
+into `os-servers.yml` beside the pixel-format report. The matrix drifts as
+images update, and a phase needs to know what it can test before it starts.
 
 ## Testing
 
@@ -442,47 +451,42 @@ misunderstanding produces a fixture and a decoder that agree with each other and
 with nothing else — the test then pins the misunderstanding. This is the same
 trap as reading goldens off the implementation.
 
-**Capture tooling (Phase 0).** `loggingproxy.py` already sits between client and
-server at the byte level, which is the right place to record. The tooling drives
-a fleet server through a scripted set of screen changes and records, for each
-encoding: the wire bytes of each framebuffer update, and the ground-truth image
-obtained by replaying the same script with Raw negotiated. The oracle is the
-server itself rendering the same screen under an encoding we already trust — not
-our own decoder, and not our own reading of the spec.
+**Capture tooling (Phase 0), built.** `loggingproxy.py` sits between client and
+server at the byte level, which is the right place to record, and `vnclog
+--capture-raw` is the recorder. A scene player pushes committed PNGs to a fleet
+server's X framebuffer on keypress; the capture is distilled into per-step
+fixtures under `tests/unit/fixtures/goldens/`.
 
-No fleet server can be scripted into a screen change today, and libvncserver
-detects none of its own; see
-[testing-framework.md](testing-framework.md#the-screen-change-source-phase-2-prerequisite).
-The scene source, the capture path, the fixture format and the matrix this
-tooling produces are designed in [decoder-goldens.md](decoder-goldens.md).
+**The oracle is the committed PNG the server was shown**, not a Raw replay. An
+earlier revision proposed replaying each script with Raw negotiated and treating
+that render as ground truth, which makes the oracle a second capture — subject
+to the same server, the same session, and its own decode. Comparing against the
+file that was displayed removes the server from the oracle entirely, and there
+is nothing to keep in sync because the fixture names the scene and the scene is
+the file. [decoder-goldens.md](decoder-goldens.md) has the scene source, the
+capture path, the fixture format and the matrix.
 
 **Tier 1 — unit, offline.** Captured wire bytes into the decoder, compare the
-resulting buffer against the Raw ground truth. Fast, no fleet, no reactor. The
+resulting framebuffer against the scene PNG. Fast, no fleet, no reactor. The
 comparison is on the framebuffer after the client's paste, which is what makes
 it hold across captures from servers that negotiated different formats.
 
 **Tier 2 — live, against the fleet.** Force `--encodings` to one encoding, drive
-the same script, compare the rendered screen to the Raw run. Catches everything
-the capture missed: negotiation, ordering, zlib stream continuity across
-rectangles.
+the same scene script, compare the captured screen to the same PNGs. Catches
+everything the capture missed: negotiation, ordering, zlib stream continuity
+across rectangles.
 
 **Tier 3 — screen-change stress.** Fixtures are only as good as the screen
-changes that produced them. The scripted changes must provoke the cases that
-otherwise never appear:
+changes that produced them, and a decoder that passes Tier 1 and Tier 2 on a
+blank-ish screen has been barely tested. The scene catalogue in
+[decoder-goldens.md](decoder-goldens.md) is this tier: solid fills for RRE and
+ZRLE's single-colour palette, dense detail for raw-tile fallback, scattered
+rects for ordering and R7's stream continuity, a scrolled region for CopyRect —
+the one encoding whose correctness depends on prior framebuffer contents.
 
-- **Scrolling and window drags**, which are what make a server emit CopyRect at
-  all. CopyRect is the one encoding whose correctness depends on prior
-  framebuffer contents, so a test that starts from a blank screen cannot fail.
-- **Large solid regions**, which drive RRE and ZRLE into their fill and
-  single-colour-palette paths.
-- **Dense detail**, which drives them into raw-tile fallback.
-- **Small scattered changes**, which produce many-rectangle updates and exercise
-  ordering and the ZRLE stream continuity requirement of R7.
-- **Desktop resize mid-session**, which exercises the pseudo-encodings against a
-  changing framebuffer.
-
-A decoder that passes Tier 1 and Tier 2 on a blank-ish screen has been barely
-tested. Tier 3 is where the coverage actually comes from.
+Mid-session desktop resize is the case the catalogue cannot reach, since the
+scene player cannot make a server change geometry; it is deferred there with the
+libvncserver example that could.
 
 **Segmentation.** One test at the pump feeding a capture one byte at a time and
 asserting identical output. Because the pump satisfies every yielded byte count

--- a/specs/decoder-goldens.md
+++ b/specs/decoder-goldens.md
@@ -191,12 +191,13 @@ different things and share one capture run:
 - **Source with tolerance.** Compare against the oracle allowing per-channel
   error bounded by the format's step. This bounds the server's rounding without
   modelling it, and still catches channel swaps, wrong shifts, endianness
-  errors and colour-map misindexing — the whole defect class R3, decoder output
+  errors and colour-map misindexing — the whole defect class R3, the framebuffer
   not depending on the negotiated format, is about.
 - **Cross-format self-consistency.** Decode the same scene at every format and
-  assert the canonical outputs agree within tolerance. This is R3 stated
-  directly, and needs no external truth, but a decoder wrong the same way at
-  every depth passes it.
+  assert the framebuffers agree within tolerance. This is R3 stated directly —
+  and it is where R3 is checked at all, since decoders emit the layout they were
+  sent (see [pixel-format.md](pixel-format.md)). It needs no external truth, but
+  a decoder wrong the same way at every depth passes it.
 
 Both are deferred until a second format exists. Today's tolerance is zero.
 

--- a/specs/pixel-format.md
+++ b/specs/pixel-format.md
@@ -73,7 +73,7 @@ The tag is a `PixelFormat` and not a Pillow mode string so that decoders speak
 only RFB — they implement a specification written in shifts and maxima, and
 naming `BGRX` there would put the rendering library inside code that has no
 other reason to know it exists. Pillow stays in `client.py` and in `raw_mode`,
-which is also the single place to change if the four unsupported layouts below
+which is also the single place to change if the unsupported layouts below
 ever need a converter. A decoder unit test asserts bytes and a `PixelFormat`,
 with no Pillow in it (R2).
 
@@ -115,6 +115,10 @@ and every colour bit sits in either the low or the high three bytes; which
 placement is a function of the shifts. rfbproto adds a tie-break the RFC omits:
 at depth ≤ 16 both placements fit, and the low three bytes are sent.
 
+Placement is in value space and `cpixel_offset` is in byte space, so big-endian
+reverses which end of the pixel they sit at. Slicing at the wrong end takes the
+pad byte and drops a channel.
+
 **TPIXEL** is narrower and fixed — depth exactly 24, all channels exactly 8
 bits, bytes red, green, blue — so a Tight rect tags 24 bpp RGB whatever was
 negotiated. It arrives with Tight at decoder Phase 6.
@@ -130,16 +134,18 @@ Probed by feeding known words through each mode:
 |---|---|
 | 32 bpp, 8-bit channels, any order or endianness | `RGBX` `BGRX` `XRGB` `XBGR` |
 | 24 bpp packed, either order | `RGB` `BGR` |
-| 16 bpp 565, 555, 444, either order, **little-endian** | `BGR;16` `RGB;16` `BGR;15` `RGB;15` `RGB;4B` |
+| 16 bpp 565 and 555, either order, **little-endian** | `BGR;16` `RGB;16` `BGR;15` `RGB;15` |
+| 16 bpp 444, **blue-high only**, little-endian | `RGB;4B` |
 
 `rgb565` is `BGR;16`: `0x00F8` little-endian yields `(255, 0, 0)`, so it is
 red-in-the-high-bits 565, matching `PixelFormat(16, 16, False, True, 31, 63, 31,
 11, 5, 0)` — the constant `client.py` calls `BGR16`.
 
-Four layouts fall outside: **big-endian 16 bpp** (big-endian 32 bpp is another
+Five layouts fall outside: **big-endian 16 bpp** (big-endian 32 bpp is another
 byte permutation, covered); **channel widths outside 8/8/8, 5/6/5, 5/5/5,
-4/4/4**; **non-byte-aligned shifts at 32 bpp**; and **colour-mapped**, which is
-`P` plus `putpalette` rather than a raw mode.
+4/4/4**; **non-byte-aligned shifts at 32 bpp**; **444 with red in the high
+nibble**, since Pillow has `RGB;4B` and no mirror of it; and **colour-mapped**,
+which is `P` plus `putpalette` rather than a raw mode.
 
 None needs a converter, because none is reachable while a server honours
 `SetPixelFormat` — an unreadable native means we ask for `bgrx8888`. A converter
@@ -199,8 +205,8 @@ gets no flag: the client negotiates, the proxy records what it saw.
 ## Testing
 
 **Unit.** `raw_mode` over a table of formats, including pairs differing only by
-`depth` and only by endianness, plus `UnsupportedPixelFormat` for the four
-uncovered layouts. Then, per mode, known bytes through `Image.frombytes` to
+`depth` and only by endianness, plus `UnsupportedPixelFormat` for each uncovered
+layout. Then, per mode, known bytes through `Image.frombytes` to
 known RGB pixels — the mode string is a claim about Pillow, and that is the
 claim that can be wrong. CPIXEL gets both placements, the depth ≤ 16 tie-break,
 and the negative cases falling back to PIXEL width.

--- a/specs/pixel-format.md
+++ b/specs/pixel-format.md
@@ -33,16 +33,11 @@ nothing re-derives it. It goes stale when a runner image changes its display
 depth, and `vncdo -v` against any server reprints both the native format and the
 one we request.
 
-| Server | bpp | depth | endian | shifts r/g/b | Wire | In `PF2IM`? |
-|---|---|---|---|---|---|---|
-| tigervnc | 32 | 24 | LE | 16/8/0 | BGRX | yes |
-| x11vnc | 32 | 24 | LE | 16/8/0 | BGRX | yes |
-| ultravnc (windows-latest) | 32 | 24 | LE | 16/8/0 | BGRX | yes |
-| screen-sharing (macos-latest) | 32 | 24 | LE | 16/8/0 | BGRX | yes |
-| libvncserver-example | 32 | **32** | LE | 0/8/16 | RGBX | **no** |
-| vncev | 8 | 8 | — | **colour-mapped** | index | **no** |
-
-Maxima are 255 for every true-colour row.
+| Server | ServerInit format | Wire | In `PF2IM`? |
+|---|---|---|---|
+| tigervnc, x11vnc, ultravnc, screen-sharing | 32 bpp, depth 24, LE, max 255, shifts 16/8/0 | BGRX | yes |
+| libvncserver-example | 32 bpp, **depth 32**, LE, max 255, shifts 0/8/16 | RGBX | **no** |
+| vncev | 8 bpp, depth 8, **colour-mapped** | index | **no** |
 
 The two misses are libvncserver's example programs, in the fleet because they
 are scriptable, not because anyone runs them. **Every server anyone runs sends

--- a/specs/pixel-format.md
+++ b/specs/pixel-format.md
@@ -33,13 +33,16 @@ nothing re-derives it. It goes stale when a runner image changes its display
 depth, and `vncdo -v` against any server reprints both the native format and the
 one we request.
 
-| Server | ServerInit format | Wire | In `PF2IM`? |
-|---|---|---|---|
-| tigervnc, x11vnc | 32 bpp, depth 24, LE, max 255, shifts 16/8/0 | BGRX | yes |
-| ultravnc (windows-latest) | identical | BGRX | yes |
-| screen-sharing (macos-latest) | identical | BGRX | yes |
-| libvncserver-example | 32 bpp, **depth 32**, LE, max 255, shifts 0/8/16 | RGBX | **no** |
-| vncev | 8 bpp, depth 8, **colour-mapped** | index | **no** |
+| Server | bpp | depth | endian | shifts r/g/b | Wire | In `PF2IM`? |
+|---|---|---|---|---|---|---|
+| tigervnc | 32 | 24 | LE | 16/8/0 | BGRX | yes |
+| x11vnc | 32 | 24 | LE | 16/8/0 | BGRX | yes |
+| ultravnc (windows-latest) | 32 | 24 | LE | 16/8/0 | BGRX | yes |
+| screen-sharing (macos-latest) | 32 | 24 | LE | 16/8/0 | BGRX | yes |
+| libvncserver-example | 32 | **32** | LE | 0/8/16 | RGBX | **no** |
+| vncev | 8 | 8 | — | **colour-mapped** | index | **no** |
+
+Maxima are 255 for every true-colour row.
 
 The two misses are libvncserver's example programs, in the fleet because they
 are scriptable, not because anyone runs them. **Every server anyone runs sends

--- a/specs/pixel-format.md
+++ b/specs/pixel-format.md
@@ -1,0 +1,264 @@
+# Pixel Format — Design
+
+Status: draft, under review. The first slice of
+[decoder-architecture.md](decoder-architecture.md) Phase 1, and the `rgb565`
+entry point [decoder-goldens.md](decoder-goldens.md) names in its phasing.
+
+## Problem
+
+`client.PF2IM` (`client.py:68`) is a five-entry dict keyed on the whole
+`PixelFormat` dataclass, valued with a Pillow raw mode. A format outside those
+five raises `LookupError`, and `setImageMode` (`client.py:318-329`) guesses —
+`BGR16` if the server announced 3.889, `RGB32` otherwise — sends
+`SetPixelFormat`, and assumes it was obeyed. A server that ignores it keeps
+sending its own format, decoded as the requested one: #90 and #275.
+
+Nothing can request a format from the command line (#167, #168), so the golden
+matrix has one fixture and the pixel plumbing has never run at a second format.
+
+## Scope
+
+The `pixelformat.py` machinery, plus one new negotiated format: `rgb565`. That
+discharges R3 for two formats — one scene decoding to the same framebuffer at
+both. Colour map, and the layouts Pillow cannot unpack, wait for a server that
+needs them.
+
+## What servers actually send
+
+ServerInit read off each running server, not from documentation. Tier 1 locally,
+Tier 2 from run
+[32386264566](https://github.com/sibson/vncdotool/actions/runs/32386264566):
+
+| Server | ServerInit format | Wire | In `PF2IM`? |
+|---|---|---|---|
+| tigervnc, x11vnc | 32 bpp, depth 24, LE, max 255, shifts 16/8/0 | BGRX | yes |
+| ultravnc (windows-latest) | identical | BGRX | yes |
+| screen-sharing (macos-latest) | identical | BGRX | yes |
+| libvncserver-example | 32 bpp, **depth 32**, LE, max 255, shifts 0/8/16 | RGBX | **no** |
+| vncev | 8 bpp, depth 8, **colour-mapped** | index | **no** |
+
+The two misses are libvncserver's example programs, in the fleet because they
+are scriptable, not because anyone runs them. **Every server anyone runs sends
+BGRX at 32 bpp, depth 24, little-endian**, and neither Tier 2 job logged a
+`Requesting` line, so today's code already reads both natives without
+renegotiating.
+
+Three consequences:
+
+- **`PF2IM` misses on `depth`, which does not affect byte layout.**
+  libvncserver-example's format *is* the layout `PF2IM` calls `RGBX`, differing
+  only by declaring depth 32 — the historical quirk rfbproto warns about — so we
+  renegotiate to a format byte-identical to the one already arriving. Computing
+  the mode from the fields removes the failure mode.
+- **The 3.889 Apple branch never fires against current Screen Sharing**, whose
+  native is in `PF2IM` already. It is dropped rather than carried forward; if an
+  older ARD server needs it, it returns as a measurement.
+- **One dominant native is not a safe assumption.** `PF2IM` was shaped around
+  the formats someone had met, and libvncserver-example is a depth declaration
+  away from an entry.
+
+## Decoders emit what they were sent
+
+A decoder returns bytes in the layout it produced them, tagged with the Pillow
+raw mode that unpacks it. `client.py` materializes each rectangle with one
+`Image.frombytes(..., "raw", mode)`. Raw, RRE, CoRRE, Hextile and ZRLE tag the
+negotiated format; Tight's JPEG tags `RGB`; a colour-mapped decoder tags `P` and
+carries the palette.
+
+Converting inside each decoder to one canonical layout was designed first and
+dropped. It materializes every rectangle twice — bytes, image, bytes, image, for
+~1.2 ms per 1080p frame of copying — and forces JPEG, TPIXEL and colour map to
+produce a layout that then has to be undone.
+
+Tagging means **a decoder never interprets a pixel**. A background colour, a
+Hextile foreground, a ZRLE palette entry are opaque `bypp`-sized byte strings,
+and a fill is one repeated. No shifts, no masks, no endianness in any decoder,
+so that class of bug cannot be written — including the live one, ZRLE's
+`cpixel()` reading three bytes least-significant-first and appending `0xFF`
+(`rfb.py:820`).
+
+R3 moves with it: stated over the framebuffer, not decoder output, and checked
+by the goldens' cross-format comparison.
+
+## Surface
+
+```python
+def raw_mode(pixel_format: rfb.PixelFormat) -> str: ...      # raises UnsupportedPixelFormat
+def cpixel_bytes(pixel_format: rfb.PixelFormat) -> int: ...  # 3 or bypp
+def cpixel_offset(pixel_format: rfb.PixelFormat) -> int: ... # 0 or bypp - 3
+```
+
+`raw_mode` ignores `depth` — it does not affect where the channels sit.
+`cpixel_bytes` must obey it, since the encoder used the same declaration.
+
+`UnsupportedPixelFormat` rather than a guess, though under the policy below a
+caller only reaches it when a server ignores what we asked for.
+
+**CPIXEL** (RFC 6143 §7.7.5) is three bytes when true colour, 32 bpp, depth ≤ 24
+and every colour bit sits in either the low or the high three bytes; which
+placement is a function of the shifts. rfbproto adds a tie-break the RFC omits:
+at depth ≤ 16 both placements fit, and the low three bytes are sent.
+
+**TPIXEL** is narrower and fixed — depth exactly 24, all channels exactly 8
+bits, bytes red, green, blue — so a Tight rect tags `RGB` unconditionally. It
+arrives with Tight at decoder Phase 6.
+
+This pass writes the CPIXEL functions and their tests; ZRLE keeps its current
+bytes until Phase 5, per R5.
+
+## What Pillow can unpack
+
+Probed by feeding known words through each mode:
+
+| Negotiated layout | Pillow raw mode |
+|---|---|
+| 32 bpp, 8-bit channels, any order or endianness | `RGBX` `BGRX` `XRGB` `XBGR` |
+| 24 bpp packed, either order | `RGB` `BGR` |
+| 16 bpp 565, 555, 444, either order, **little-endian** | `BGR;16` `RGB;16` `BGR;15` `RGB;15` `RGB;4B` |
+
+`rgb565` is `BGR;16`: `0x00F8` little-endian yields `(255, 0, 0)`, so it is
+red-in-the-high-bits 565, matching `PixelFormat(16, 16, False, True, 31, 63, 31,
+11, 5, 0)` — the constant `client.py` calls `BGR16`.
+
+Four layouts fall outside: **big-endian 16 bpp** (big-endian 32 bpp is another
+byte permutation, covered); **channel widths outside 8/8/8, 5/6/5, 5/5/5,
+4/4/4**; **non-byte-aligned shifts at 32 bpp**; and **colour-mapped**, which is
+`P` plus `putpalette` rather than a raw mode.
+
+None needs a converter, because none is reachable while a server honours
+`SetPixelFormat` — an unreadable native means we ask for `bgrx8888`. A converter
+is for a server that sends an exotic native *and* ignores the request, which no
+capture has shown. Measured for whenever one does: a 2^16-entry lookup table
+converts a 1080p frame in 23.7 ms, per-pixel Python in 160 ms.
+
+## Negotiation
+
+`setImageMode`, `PF2IM` and the `image_mode` property all go; its
+`FutureWarning` shipped in 1.4 (#385) and this is 2.0.
+
+The replacement runs at `vncConnectionMade`, before the first
+`FramebufferUpdateRequest`. Required, not tidy: rfbproto states a client **must
+not** have an outstanding request when it sends `SetPixelFormat`, since the next
+update would be undecidable between formats. There is no acknowledgement and no
+fence, so `--pixel-format` is connect-time only — a later switch needs the
+request drained or the Fence pseudo-encoding, which we do not implement.
+
+1. `--pixel-format NAME` given: send it.
+2. Otherwise, if `raw_mode` resolves the native: send nothing.
+3. Otherwise: request `rgbx8888`.
+
+Sending nothing is both the default and, for every measured server, the whole
+policy. rfbproto is explicit that absent a `SetPixelFormat` the server sends its
+ServerInit format, and that servers **must support** the message while clients
+need not send one. #90 and #275 are servers that keep sending native after being
+asked otherwise; a client that never asked cannot be bitten by them. Step 3 has
+no measured caller.
+
+Nothing detects a server ignoring the request — the protocol offers no way. What
+changes is that an unreadable native is a diagnosed error rather than a silent
+guess.
+
+A colour-mapped request leaves the map empty until `SetColourMapEntries`
+arrives, whatever the server set before; that lands with the colour-map slice.
+
+## Command line
+
+    vncdo --pixel-format rgb565 capture screen.png
+
+Names from a registry, not a ten-field tuple: `bgrx8888`, `rgbx8888`, `rgb565`.
+Channel order as the bytes arrive, per-channel widths, `x` for a pad byte —
+naming the pad because it distinguishes the 32 bpp formats every server sends
+from the 24 bpp ones the specification does not allow. Fixtures use the same
+vocabulary, which is why `tigervnc-raw-rgb888` became `tigervnc-raw-bgrx8888`:
+a fixture is named for the format it holds, never for how that format was
+chosen.
+
+Every requestable name is 8, 16 or 32 bpp, all the specification permits. The
+24 bpp modes stay reachable by `raw_mode` and out of the registry — reading one
+is tolerance for an out-of-spec server, never something we ask for.
+
+`api.connect` gains a `pixel_format=` keyword taking the same names. `vnclog`
+gets no flag: the client negotiates, the proxy records what it saw.
+
+## Testing
+
+**Unit.** `raw_mode` over a table of formats, including pairs differing only by
+`depth` and only by endianness, plus `UnsupportedPixelFormat` for the four
+uncovered layouts. Then, per mode, known bytes through `Image.frombytes` to
+known RGB pixels — the mode string is a claim about Pillow, and that is the
+claim that can be wrong. CPIXEL gets both placements, the depth ≤ 16 tie-break,
+and the negative cases falling back to PIXEL width.
+
+**Negotiation.** Mocked transport asserting the `SetPixelFormat` bytes, or their
+absence, which is step 2 and the case a test would otherwise skip.
+
+**Golden.** A second fixture, `tigervnc-raw-rgb565`, from `make goldens`. Its
+oracle is the same committed scene PNG, so tolerance stops being zero: the bound
+is the format's own step, 255/31 for the 5-bit channels and 255/63 for the
+6-bit, rounded up, which covers truncation and round-to-nearest alike without
+modelling either. Two fixtures then allow the cross-format check — decode both,
+assert the framebuffers agree — which is R3 as restated.
+
+`conditions.json` grows the pixel format, both the ServerInit one and any we
+requested. They are different facts and the interesting fixtures are where they
+differ.
+
+**Functional.** One fleet case: `--pixel-format rgb565` capture is not flat.
+
+**Capture script.** `scene.vdo` steps with `expect scenes/X.png 0`, a histogram
+RMS of exactly zero, which `rgb565` can never reach — every step would poll
+until the capture hung rather than failed. The driving script becomes
+per-format, `make goldens` supplying the maxrms; `session.vdo` in the archive
+records which ran.
+
+## Phasing
+
+1. `pixelformat.py`, the registry, unit tests. No call sites change.
+2. `client.py` resolves the mode per rectangle; `PF2IM`, `setImageMode`,
+   `image_mode` go. BGRX behaviour unchanged (R5).
+3. `--pixel-format`, the policy, the `api.connect` keyword.
+4. Capture `tigervnc-raw-rgb565`; tolerance and the cross-format check in
+   `test_goldens.py`; the fleet case.
+
+## Validated against the specs
+
+C2. Read from a local rfbproto clone (`DEVELOP.rst` says where) and RFC 6143.
+
+- **Format fields** (rfbproto §ServerInit, RFC 6143 §7.4): bpp must be 8, 16 or
+  32 and ≥ depth; big-endian is meaningless at 8 bpp; each max is 2^n - 1, each
+  shift brings its channel to the least significant bit. Also that "some servers
+  will send a *depth* identical to *bits-per-pixel* for historical reasons".
+- **SetPixelFormat** (rfbproto §SetPixelFormat and §Client to Server Messages,
+  RFC 6143 §7.5.1): optional for clients, mandatory for servers to support;
+  absent it the ServerInit format applies; no acknowledgement; no outstanding
+  `FramebufferUpdateRequest` when sent; colour map empty immediately after.
+- **CPIXEL** (rfbproto §ZRLE, RFC 6143 §7.7.5): the four conditions, both
+  placements, the low-three-bytes tie-break at depth ≤ 16.
+- **TPIXEL** (rfbproto §Tight): narrower, fixed RGB order. Corrects a "believed
+  to follow the same rule" note in `decoder-architecture.md`.
+
+Unverified: how a real server behaves when asked for a format it dislikes. No
+document covers it; a capture will.
+
+## Deferred
+
+- The four layouts Pillow cannot unpack, each waiting for a capture from a
+  server that sends one and ignores `SetPixelFormat`.
+- Colour map: `P` plus a palette, and the `SetColourMapEntries` ordering above.
+  vncev is the server to build it against once a real one turns up behind it.
+- The CPIXEL functions' use, which lands with ZRLE at decoder Phase 5.
+- A raw-tuple form of `--pixel-format`.
+
+## Risks
+
+- A tolerance wide enough for 5-bit quantization can hide a real defect. The
+  cross-format check compensates: no external truth needed, and it fails on the
+  channel-order and shift errors the loose bound would swallow.
+- Tagging moves the trust from our arithmetic to Pillow's mode strings. A mode
+  meaning something other than we think decodes silently wrong, where a bad
+  shift would at least be ours to read — hence unit tests asserting Pillow's
+  behaviour per mode, not only which mode we picked.
+- Retiring the 3.889 branch rests on one macOS version on a hosted runner. If an
+  older ARD server announces something unreadable, it now gets a
+  `SetPixelFormat` for `rgbx8888` — the correct fallback, untested against that
+  server.

--- a/specs/pixel-format.md
+++ b/specs/pixel-format.md
@@ -27,7 +27,11 @@ needs them.
 
 ServerInit read off each running server, not from documentation. Tier 1 locally,
 Tier 2 from run
-[32386264566](https://github.com/sibson/vncdotool/actions/runs/32386264566):
+[32386264566](https://github.com/sibson/vncdotool/actions/runs/32386264566),
+which ran a probe test that has since been removed: this table is the record, and
+nothing re-derives it. It goes stale when a runner image changes its display
+depth, and `vncdo -v` against any server reprints both the native format and the
+one we request.
 
 | Server | ServerInit format | Wire | In `PF2IM`? |
 |---|---|---|---|

--- a/specs/pixel-format.md
+++ b/specs/pixel-format.md
@@ -59,11 +59,25 @@ Three consequences:
 
 ## Decoders emit what they were sent
 
-A decoder returns bytes in the layout it produced them, tagged with the Pillow
-raw mode that unpacks it. `client.py` materializes each rectangle with one
-`Image.frombytes(..., "raw", mode)`. Raw, RRE, CoRRE, Hextile and ZRLE tag the
-negotiated format; Tight's JPEG tags `RGB`; a colour-mapped decoder tags `P` and
-carries the palette.
+A decoder returns bytes in the layout it produced them, tagged with the
+`PixelFormat` describing that layout. `client.py` resolves the tag with
+`raw_mode()` and materializes each rectangle with one `Image.frombytes(...,
+"raw", mode)`. Raw, RRE, CoRRE, Hextile and ZRLE tag the negotiated format;
+Tight's JPEG and TPIXEL tag 24 bpp RGB; a colour-mapped decoder tags the
+colour-mapped format and the client resolves indices through the palette it
+already holds.
+
+The tag is a `PixelFormat` and not a Pillow mode string so that decoders speak
+only RFB — they implement a specification written in shifts and maxima, and
+naming `BGRX` there would put the rendering library inside code that has no
+other reason to know it exists. Pillow stays in `client.py` and in `raw_mode`,
+which is also the single place to change if the four unsupported layouts below
+ever need a converter. A decoder unit test asserts bytes and a `PixelFormat`,
+with no Pillow in it (R2).
+
+The one artefact: JPEG and TPIXEL tag a 24 bpp format, which the specification
+does not permit on the wire. Internally that is the honest description of three
+packed bytes, and the negotiation registry still refuses to ask a server for it.
 
 Converting inside each decoder to one canonical layout was designed first and
 dropped. It materializes every rectangle twice — bytes, image, bytes, image, for
@@ -100,8 +114,8 @@ placement is a function of the shifts. rfbproto adds a tie-break the RFC omits:
 at depth ≤ 16 both placements fit, and the low three bytes are sent.
 
 **TPIXEL** is narrower and fixed — depth exactly 24, all channels exactly 8
-bits, bytes red, green, blue — so a Tight rect tags `RGB` unconditionally. It
-arrives with Tight at decoder Phase 6.
+bits, bytes red, green, blue — so a Tight rect tags 24 bpp RGB whatever was
+negotiated. It arrives with Tight at decoder Phase 6.
 
 This pass writes the CPIXEL functions and their tests; ZRLE keeps its current
 bytes until Phase 5, per R5.


### PR DESCRIPTION
Phase 1 of the decoder work needs a design; `specs/pixel-format.md` is it, and writing it against measured servers changed two decisions in `decoder-architecture.md`.

**Decoders no longer convert to a canonical layout.** They return the bytes they were sent, tagged with the Pillow raw mode that unpacks them, and `client.py` materializes each rectangle with one `Image.frombytes`. Canonical output materializes every rectangle twice, and forces JPEG, TPIXEL and colour-map decoders to produce a layout that then has to be undone. The payoff is that a decoder never interprets a pixel — a background colour or palette entry is an opaque byte string — so the channel-extraction bugs cannot be written. **R3 is restated over the framebuffer** as a result, and `decoder-goldens.md` says where it is checked.

**The negotiation default becomes sending no `SetPixelFormat` at all.** Every server anyone runs — TigerVNC, x11vnc, UltraVNC, Apple Screen Sharing — announces BGRX at 32bpp depth 24 LE, and today's client already reads all four without renegotiating (measured in #394). rfbproto permits the omission explicitly, and #90/#275 cannot bite a client that never asked. The Apple 3.889 branch goes on the same evidence.

Protocol facts checked against a local rfbproto clone rather than inferred: TPIXEL is *not* CPIXEL (depth exactly 24, 8-bit channels, fixed RGB order — correcting a "believed to follow the same rule" note), CPIXEL's depth ≤ 16 tie-break which RFC 6143 omits, and the rule that a client must not have an outstanding `FramebufferUpdateRequest` when it sends `SetPixelFormat` — which is why `--pixel-format` is connect-time only.

Docs only; no code. The branch was rebuilt on current main — its previous commit predated #386, which landed the same design doc, so rebasing would have conflicted against content already merged. Depends on #394 for the fixture name it references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)