### PR TITLE
Dispatch api.connect() setup onto the reactor thread (#192)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 1.4.0 (UNRELEASED)
 ----------------------
+  - Fix: ``api.connect()`` now hands the connection setup to the reactor thread rather than running it on the calling thread. Previously DNS resolution and connector setup ran on the application thread, reaching into reactor internals from outside the reactor (@sibson, #192)
   - Fix black screen captures from servers that announce DesktopSize before sending pixel data, e.g. TightVNC (@sibson, #90)
   - Fix the dead protocol reference in the published ``rfb`` module documentation, which pointed at a RealVNC PDF that has been 403 for years; RFC 6143 and the rfbproto community document replace it (@sibson)
   - Declare python_requires >=3.10, matching the versions CI tests and the development requirements. 3.9 was advertised but neither tested nor able to install the dev environment (@sibson, #357)

--- a/docs/library.rst
+++ b/docs/library.rst
@@ -4,6 +4,15 @@ vncdotool is built with the Twisted_ framework, as such it best integrates with 
 Rewriting your application to use Twisted may not be an option, so vncdotool provides a compatibility layer.
 It uses a separate thread to run the Twisted reactor and communicates with the main program using a thread-safe Queue.
 
+..  note::
+
+    The compatibility layer is designed for exactly two threads: one
+    application thread holding one client, and the single reactor thread
+    vncdotool starts for it.
+    Using clients from more than one application thread, or sharing one
+    client between threads, is not supported -- see `issue #192
+    <https://github.com/sibson/vncdotool/issues/192>`_.
+
 ..  warning::
 
     While the Twisted reactor runs as a *daemon* thread, the reactor itself will start additional *worker threads*, which are *no daemon threads*.

--- a/tests/functional/test_api_lifecycle.py
+++ b/tests/functional/test_api_lifecycle.py
@@ -18,10 +18,12 @@ import socket
 import threading
 import time
 import unittest
+from unittest import mock
 
 from twisted.internet import reactor
 from twisted.internet.error import ConnectError
 from twisted.internet.protocol import Factory, Protocol
+from twisted.python import threadable
 
 from vncdotool import api
 
@@ -102,6 +104,27 @@ class TestApiLifecycle(unittest.TestCase):
         # most. Padding this further would hide a real regression instead
         # of catching one.
         self.assertLess(elapsed, SHORT_TIMEOUT + 1.0)
+
+    def test_connect_dispatches_onto_reactor_thread(self) -> None:
+        """Asserts on thread identity rather than on an outcome: a connect
+        dispatched off the reactor thread still succeeds in practice, so
+        there is no failure to observe.
+        """
+        in_io_thread: "queue.Queue[bool]" = queue.Queue()
+        real_factory_connect = api.factory_connect
+
+        def spy(*args, **kwargs):
+            in_io_thread.put(threadable.isInIOThread())
+            return real_factory_connect(*args, **kwargs)
+
+        with mock.patch.object(api, "factory_connect", spy):
+            client = api.connect(f"{HOST}::{LIBVNC.port}", password=LIBVNC.password)
+            client.timeout = HAPPY_TIMEOUT
+            self.addCleanup(client.disconnect)
+            self.assertTrue(
+                in_io_thread.get(timeout=REACTOR_CALL_TIMEOUT),
+                "factory_connect ran outside the reactor thread",
+            )
 
     def test_closed_port_raises_promptly(self) -> None:
         """Bounded twice over -- a per-client timeout, and a helper thread

--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -68,7 +68,7 @@ class ThreadedVNCClientProxy:
             return protocol
 
         self.factory.deferred.addCallback(capture_protocol)
-        reactor.callWhenRunning(factory_connect, self.factory, host, port, family)
+        reactor.callFromThread(factory_connect, self.factory, host, port, family)
 
     def disconnect(self) -> None:
         event = threading.Event()


### PR DESCRIPTION
`ThreadedVNCClientProxy.connect()` used `reactor.callWhenRunning()`, which runs its callable inline in the *calling* thread whenever the reactor is already running. The reactor thread reaches `running = True` during the few statements between the thread start and the connect, so in practice every `api.connect()` — including the first in a process — did its `HostnameEndpoint` DNS resolution and connector setup on the application thread. `callFromThread()` queues onto `threadCallQueue` and wakes the reactor; a call queued before the reactor starts is drained on the first `mainLoop` iteration, so it also covers the not-yet-running case `callWhenRunning`'s else-branch handled.

Worth knowing as a reviewer: **this is not the multi-threaded support #192 asks for.** The bug is reachable entirely inside the supported one-app-thread model, which is why the fix stands alone. It also has no observable failure — an off-reactor-thread connect succeeds today, which is why it sat latent — so the test asserts on thread identity rather than on an outcome. #192 stays open, relabelled `feature`, with the remaining scope (bootstrap lock, reentrant `shutdown()`, per-call result queues) written into the issue. `docs/library.rst` now states the two-thread limit that was previously only implied.

Tests: flake8 clean; unit suite passes (181). `make test-api` passes against the Docker fleet, and fails with `AssertionError: factory_connect ran outside the reactor thread` when the fix is reverted — so the test does discriminate. Full `tests/functional` run is 40 tests, 4 failures, all `test_os_servers.TestServer_screen_sharing` from macOS Screen Sharing not being set up on this machine; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)