### PR TITLE
Fix Windows console-script resolution in functional test suite

### DIFF
--- a/tests/functional/vncservers.py
+++ b/tests/functional/vncservers.py
@@ -41,11 +41,26 @@ READY_DEADLINE = 180.0
 # Named by full path rather than resolved through PATH: another working tree's
 # .venv can come first there, and the suite would report its behaviour as this
 # branch's.
-_SCRIPTS = Path(sys.executable).parent
+_INTERPRETER_DIR = Path(sys.executable).parent
+# venvs put console scripts beside the interpreter on every platform; a
+# non-venv Windows install (e.g. actions/setup-python on windows-latest) puts
+# them in a sibling Scripts\ instead.
+_SCRIPT_DIRS = [_INTERPRETER_DIR, _INTERPRETER_DIR / "Scripts"] if os.name == "nt" else [_INTERPRETER_DIR]
 _EXE_SUFFIX = ".exe" if os.name == "nt" else ""
-VNCDO = str(_SCRIPTS / f"vncdo{_EXE_SUFFIX}")
-VNCDO_REPLAY = str(_SCRIPTS / f"vncdo-replay{_EXE_SUFFIX}")
-VNCLOG = str(_SCRIPTS / f"vnclog{_EXE_SUFFIX}")
+
+
+def _resolve_script(name: str) -> str:
+    filename = f"{name}{_EXE_SUFFIX}"
+    for script_dir in _SCRIPT_DIRS:
+        candidate = script_dir / filename
+        if candidate.exists():
+            return str(candidate)
+    return str(_SCRIPT_DIRS[0] / filename)
+
+
+VNCDO = _resolve_script("vncdo")
+VNCDO_REPLAY = _resolve_script("vncdo-replay")
+VNCLOG = _resolve_script("vnclog")
 # Added to the server's response budget for interpreter start-up and handshake.
 SUBPROCESS_TIMEOUT_HEADROOM = 10.0
 

--- a/tests/functional/vncservers.py
+++ b/tests/functional/vncservers.py
@@ -42,9 +42,6 @@ READY_DEADLINE = 180.0
 # .venv can come first there, and the suite would report its behaviour as this
 # branch's.
 _INTERPRETER_DIR = Path(sys.executable).parent
-# venvs put console scripts beside the interpreter on every platform; a
-# non-venv Windows install (e.g. actions/setup-python on windows-latest) puts
-# them in a sibling Scripts\ instead.
 _SCRIPT_DIRS = [_INTERPRETER_DIR, _INTERPRETER_DIR / "Scripts"] if os.name == "nt" else [_INTERPRETER_DIR]
 _EXE_SUFFIX = ".exe" if os.name == "nt" else ""
 


### PR DESCRIPTION
## Summary

#378 resolved `vncdo`/`vncdo-replay`/`vnclog` as siblings of `sys.executable`, which holds for venvs on every platform and for macOS's framework build. On `actions/setup-python`'s non-venv Windows interpreter, pip installs console-script `.exe` shims into a sibling `Scripts\` directory instead — so every Windows `os-servers.yml` run since #378 merged has failed `assert_cli_installed()` at import time. This was invisible because that job's Windows leg runs with `continue-on-error: true`.

`_resolve_script()` now checks `Scripts\` alongside the interpreter dir on Windows, falling back to the original single-directory behavior elsewhere.

## Test plan

- [x] `flake8 --count --statistics vncdotool tests` clean
- [x] `.venv/bin/python -m unittest discover tests/unit` — 181 passed
- [x] Verified macOS resolution unchanged (built worktree `.venv`, imported module, paths correct)
- [x] Simulated the Windows `Scripts\` layout standalone and confirmed the resolver finds it