### PR TITLE
build: drop servers.mk PYTHON, run its targets under $(VENV)/python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ testall: test-unit test-func
 test-unit: check-python
 	$(VENV)/python -m unittest discover tests/unit
 
-# Needs `make servers-up`; unreachable servers skip rather than fail, so
-# this still runs without docker.
+# Needs `make servers-up`: an unreachable server fails its tests rather
+# than skipping them, so a down fleet cannot pass as green.
 .PHONY: test-func
 test-func: check-python
 	$(VENV)/python -m unittest discover -s tests/functional -t .

--- a/tests/servers/servers.mk
+++ b/tests/servers/servers.mk
@@ -1,6 +1,5 @@
 SERVERS_COMPOSE?=tests/servers/docker-compose.yml
 DOCKER_COMPOSE?=docker compose
-PYTHON?=python3
 SCREENSHOT_DIR?=tests/servers/screenshots
 # Which servers `screenshots` captures: docker, os, or all. See
 # tests/functional/vncservers.py.
@@ -11,35 +10,35 @@ SCREENSHOT_GROUP?=docker
 # it captures until each server serves the content it should, the same
 # assertion the tests make, and the same gate the OS-hosted servers use.
 .PHONY: servers-up
-servers-up:
+servers-up: check-python | venv
 	$(DOCKER_COMPOSE) -f $(SERVERS_COMPOSE) up -d --build --wait
-	$(PYTHON) tests/functional/wait_for_servers.py docker
+	$(VENV)/python tests/functional/wait_for_servers.py docker
 
 .PHONY: servers-down
 servers-down:
 	$(DOCKER_COMPOSE) -f $(SERVERS_COMPOSE) down
 
 .PHONY: test-servers
-test-servers:
-	$(PYTHON) -m unittest discover $(UNITTEST_ARGS) -s tests/functional -t . -p 'test_servers.py'
+test-servers: check-python | venv
+	$(VENV)/python -m unittest discover $(UNITTEST_ARGS) -s tests/functional -t . -p 'test_servers.py'
 
 # The VNC server hosted by this OS (UltraVNC on Windows, Screen Sharing on
 # macOS), set up beforehand by the scripts in tests/servers/ultravnc and
 # tests/servers/screen-sharing.
 .PHONY: test-os-server
-test-os-server:
-	$(PYTHON) -m unittest discover $(UNITTEST_ARGS) -s tests/functional -t . -p 'test_os_servers.py'
+test-os-server: check-python | venv
+	$(VENV)/python -m unittest discover $(UNITTEST_ARGS) -s tests/functional -t . -p 'test_os_servers.py'
 
 # The in-process vncdotool.api lifecycle suite, against libvncserver-example
 # alone. Runs on its own because one process gets one Twisted reactor -- see
 # tests/functional/test_api_lifecycle.py.
 .PHONY: test-api
-test-api:
-	$(PYTHON) -m unittest discover $(UNITTEST_ARGS) -s tests/functional -t . -p 'test_api_lifecycle.py'
+test-api: check-python | venv
+	$(VENV)/python -m unittest discover $(UNITTEST_ARGS) -s tests/functional -t . -p 'test_api_lifecycle.py'
 
 # Screenshot every running test server into $(SCREENSHOT_DIR), including an
 # index.html gallery of them all, for eyeballing what the servers render.
 .PHONY: screenshots
-screenshots:
-	VNCDOTOOL_SCREENSHOT_DIR=$(SCREENSHOT_DIR) $(PYTHON) tests/functional/capture_screenshots.py $(SCREENSHOT_GROUP)
+screenshots: check-python | venv
+	VNCDOTOOL_SCREENSHOT_DIR=$(SCREENSHOT_DIR) $(VENV)/python tests/functional/capture_screenshots.py $(SCREENSHOT_GROUP)
 	@echo "open $(SCREENSHOT_DIR)/index.html"


### PR DESCRIPTION
`tests/servers/servers.mk` declared `PYTHON?=python3` — a third name for an interpreter the build already names twice: `PY` builds the venv (guarded by `check-python` against `PYTHON_FLOOR`), and `$(VENV)/python` runs every top-level target. The duplicate defaulted to the system interpreter, so on a machine whose bare `python3` predates the floor, `make servers-up` brought all containers up healthy and *then* died in the readiness gate on a missing twisted. `PY=` didn't help — different variable — so you had to discover `PYTHON=.venv/bin/python`.

servers.mk's targets now match the top-level ones: `$(VENV)/python` in the recipe, plus `check-python` and an order-only `venv` prerequisite, so the venv builds on demand and a too-old interpreter is reported before docker does any work. `servers-down` needs no interpreter and is unchanged.

Worth knowing for review:
- CI never reads servers.mk (ci.yml invokes `wait_for_servers.py` and docker compose directly), so this is local-developer-convenience only.
- Include order is fine: servers.mk is included before Makefile.venv, but `VENV` is a recursive `=` and recipes expand at execution time. `venv` is a literal target name, not a variable, so the Makefile:76 warning about prerequisites doesn't apply.
- Also corrects the `test-func` comment, which claimed unreachable servers skip. They fail (`vncservers.py` setUp calls `self.fail()`) — the point being that a down fleet can't pass as green.
- No CHANGELOG entry: every 1.4.0 entry is user-visible CLI/library behaviour; this is build-only.

Tested: `make servers-up` + `make test-api` (4 tests OK) with the gate running under `./.venv/bin/python`; `make test` 181 OK; `flake8 --count --statistics vncdotool tests` clean. With no override on a 3.9 host, `servers-up` now fails up front at `check-python` with the `PY=` hint instead of after the containers start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)