### PR TITLE
ci: install and run everything through uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,6 @@ on:
 permissions:
   contents: read
 
-env:
-  PIP_DISABLE_PIP_VERSION_CHECK: '1'
-  PIP_NO_PYTHON_VERSION_WARNING: '1'
-
 defaults:
   run:
     shell: bash
@@ -29,25 +25,23 @@ jobs:
       matrix:
         os: [ubuntu-latest] #, windows-latest] tests fail on windows
         python-version: ['3.10', '3.11', '3.12', '3.13']
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
 
     steps:
       - name: Check out source
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: pyproject.toml
+          enable-cache: true
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install --group dev -e .
+        run: uv sync
 
       - name: Run unittests
-        run: coverage run --parallel-mode -m unittest discover tests/unit
+        run: uv run coverage run --parallel-mode -m unittest discover tests/unit
 
       - name: Upload coverage data
         if: always()
@@ -66,20 +60,16 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
         with:
-          python-version: '3.13'
-          cache: pip
-          cache-dependency-path: pyproject.toml
+          enable-cache: true
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install flake8
+        run: uv sync
 
       - name: Run flake8
-        run: flake8 --count --statistics vncdotool tests
+        run: uv run flake8 --count --statistics vncdotool tests
 
   servers:
     name: Test server functional tests
@@ -91,26 +81,20 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
         with:
-          python-version: '3.13'
-          cache: pip
-          cache-dependency-path: pyproject.toml
+          enable-cache: true
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          # The functional suite shells out to the console scripts beside this
-          # interpreter, so they have to be installed, not merely importable.
-          pip install --group dev -e .
+        run: uv sync
 
       - name: Build and start the VNC test servers
         run: docker compose -f tests/servers/docker-compose.yml up -d --build --wait
 
       - name: Wait for the test servers to serve their screens
         timeout-minutes: 5
-        run: python tests/functional/wait_for_servers.py docker
+        run: uv run python tests/functional/wait_for_servers.py docker
 
       # The steps below are diagnostics and teardown, so they carry
       # `if: always()`: when a test fails, the container status, the
@@ -123,7 +107,7 @@ jobs:
         run: docker compose -f tests/servers/docker-compose.yml ps
 
       - name: Run functional tests
-        run: coverage run --parallel-mode -m unittest discover -v -s tests/functional -t .
+        run: uv run coverage run --parallel-mode -m unittest discover -v -s tests/functional -t .
 
       - name: Upload coverage data
         if: always()
@@ -137,7 +121,7 @@ jobs:
       - name: Capture screenshots and build the gallery
         if: always()
         timeout-minutes: 3
-        run: python tests/functional/capture_screenshots.py
+        run: uv run python tests/functional/capture_screenshots.py
 
       - name: Dump test server container logs
         if: always()
@@ -169,15 +153,13 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
         with:
-          python-version: '3.13'
-          cache: pip
-          cache-dependency-path: pyproject.toml
+          enable-cache: true
 
       - name: Install dependencies
-        run: pip install --group dev -e .
+        run: uv sync
 
       - name: Download unit tier coverage data
         uses: actions/download-artifact@v4
@@ -195,7 +177,7 @@ jobs:
 
       - name: Report
         run: |
-          .github/scripts/coverage-summary.sh unit=data/unit fleet=data/fleet
+          uv run .github/scripts/coverage-summary.sh unit=data/unit fleet=data/fleet
           cat combined/summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload the annotated HTML report

--- a/.github/workflows/os-servers.yml
+++ b/.github/workflows/os-servers.yml
@@ -38,8 +38,6 @@ permissions:
   contents: read
 
 env:
-  PIP_DISABLE_PIP_VERSION_CHECK: '1'
-  PIP_NO_PYTHON_VERSION_WARNING: '1'
   VNCDOTOOL_SCREENSHOT_DIR: screenshots
   # Spike credentials for a throwaway runner, deliberately visible as the
   # fallback. A repo secret overrides them without touching this file or
@@ -84,15 +82,13 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
         with:
-          python-version: '3.13'
+          enable-cache: true
 
       - name: Install vncdotool
-        run: |
-          python -m pip install --upgrade pip
-          pip install --group dev -e .
+        run: uv sync
 
       - name: Set up the VNC server
         run: ${{ matrix.setup }}
@@ -101,10 +97,10 @@ jobs:
       # Sharing is what starts it, and that connection can stall for good
       # while the next one succeeds immediately.
       - name: Wait for the server to serve a screen
-        run: python tests/functional/wait_for_servers.py os
+        run: uv run python tests/functional/wait_for_servers.py os
 
       - name: Run OS server functional tests
-        run: python -m unittest discover -v -s tests/functional -t . -p 'test_os_servers.py'
+        run: uv run python -m unittest discover -v -s tests/functional -t . -p 'test_os_servers.py'
 
       # Everything below is diagnostics and artifact collection, so it runs
       # with if: always() -- a failing test is exactly when the screenshot
@@ -113,7 +109,7 @@ jobs:
       - name: Capture screenshots and build the gallery
         if: always()
         timeout-minutes: 3
-        run: python tests/functional/capture_screenshots.py os
+        run: uv run python tests/functional/capture_screenshots.py os
 
       - name: Collect server diagnostics
         if: always()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,6 @@ on:
 permissions:
   contents: read
 
-env:
-  PIP_DISABLE_PIP_VERSION_CHECK: '1'
-  PIP_NO_PYTHON_VERSION_WARNING: '1'
-
 defaults:
   run:
     shell: bash
@@ -30,19 +26,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
         with:
-          python-version: '3.12'
-          cache: pip
-
-      - name: Install build tooling
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install build
+          enable-cache: true
 
       - name: Build a binary wheel and a source tarball
-        run: python -m build
+        run: uv build
 
       - name: Store the distribution packages
         uses: actions/upload-artifact@v4

--- a/tests/servers/screen-sharing/README.md
+++ b/tests/servers/screen-sharing/README.md
@@ -9,7 +9,7 @@ the evidence when something goes wrong.
 
 ```sh
 sudo bash tests/servers/screen-sharing/setup.sh
-python -m unittest discover -v -s tests/functional -t . -p 'test_os_servers.py'
+uv run python -m unittest discover -v -s tests/functional -t . -p 'test_os_servers.py'
 ```
 
 This turns the machine into an unattended remote-control target with a

--- a/tests/servers/ultravnc/README.md
+++ b/tests/servers/ultravnc/README.md
@@ -8,7 +8,7 @@ connect/type/capture round trip used for the Docker servers, and
 
 ```powershell
 pwsh tests/servers/ultravnc/setup.ps1
-python -m unittest discover -v -s tests/functional -t . -p 'test_os_servers.py'
+uv run python -m unittest discover -v -s tests/functional -t . -p 'test_os_servers.py'
 ```
 
 This turns the machine into an unattended remote-control target with a

--- a/tests/servers/ultravnc/setup.ps1
+++ b/tests/servers/ultravnc/setup.ps1
@@ -64,7 +64,7 @@ function Write-UltraVncIni {
     # The helper writes the hex to a file rather than to stdout, so the
     # value never lands in the step log; read it back and drop the file.
     $passwdFile = Join-Path ([System.IO.Path]::GetTempPath()) 'ultravnc-passwd.hex'
-    python $PasswdScript $Password $passwdFile
+    uv run python $PasswdScript $Password $passwdFile
     if ($LASTEXITCODE -ne 0 -or -not (Test-Path $passwdFile)) {
         throw 'could not compute the ultravnc.ini password hex'
     }


### PR DESCRIPTION
CI on uv. Base is #383.

setup-python and pip become `astral-sh/setup-uv` plus `uv sync` / `uv run` across all three workflows; the 3.10-3.13 matrix comes from `UV_PYTHON`, and publish.yml builds with `uv build`. setup-uv is pinned to an exact release because it stopped publishing floating major tags after v7. `coverage-summary.sh` needed no change: `uv run` puts `.venv/bin` on PATH.

Also fixes the UltraVNC setup script calling bare `python`, which resolved to a different interpreter than the one the package was installed into — harmless until #382 made `__version__` read installed metadata. Unproven: the re-run got past it and then died on a Chocolatey 503. That job is report-only.

Green: unit matrix, lint, fleet functional tests, coverage, macOS Screen Sharing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)