### PR TITLE
docs: write PR descriptions for the reviewer, not the record

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,13 @@ fix the underlying bug, move the test into the topical file, drop its
 `@unittest.expectedFailure` marker, and rename it for the behaviour it checks
 rather than the issue number.
 
+A pull request description is read by someone deciding where to spend their
+attention, not by the archive: a title plus a few sentences saying what
+changed, what a reviewer would not guess from the diff, and what was tested.
+Under ~15 lines. The commit bodies already carry the full rationale, and
+restaging them in the description only makes the reviewer read it twice.
+Findings outside the diff get a line and a pointer, not a section.
+
 # Release Process
 
 Version lives in `vncdotool/__init__.py` and is bumped by the release target.


### PR DESCRIPTION
One paragraph in CLAUDE.md. PR descriptions had drifted into restaging the commit bodies — a comment-cleanup PR shipped with a ~50-line description, all of it true and none of it worth the reading time. This says a title plus a few sentences, under ~15 lines, covering what a reviewer cannot get from the diff.

Independent of the uv stack (#382-#384), which is why it is off main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)