### PR TITLE
ci: pull the test server fleet from GHCR, and stop waiting on SIGTERM-deaf containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,9 +135,13 @@ jobs:
           path: screenshots/
           if-no-files-found: ignore
 
+      # vncev and libvncserver-example run their upstream binary as PID 1
+      # with no SIGTERM handling, so the default 10s stop grace period is
+      # pure dead time -- the tigervnc/x11vnc entrypoints' traps already
+      # exit in well under a second. Nothing here needs a clean shutdown.
       - name: Stop the VNC test servers
         if: always()
-        run: docker compose -f tests/servers/docker-compose.yml down
+        run: docker compose -f tests/servers/docker-compose.yml down --timeout 2
 
   coverage:
     name: Coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
     timeout-minutes: 20
     env:
       VNCDOTOOL_SCREENSHOT_DIR: screenshots
+      FLEET_IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/vncdotool-test
     steps:
       - name: Check out source
         uses: actions/checkout@v4
@@ -89,8 +90,14 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      - name: Build and start the VNC test servers
-        run: docker compose -f tests/servers/docker-compose.yml up -d --build --wait
+      - name: Resolve the fleet image tag
+        run: echo "FLEET_TAG=$(git rev-parse HEAD:tests/servers)" >> "$GITHUB_ENV"
+
+      - name: Fetch or build the VNC test servers
+        run: |
+          docker compose -f tests/servers/docker-compose.yml pull --quiet \
+            || docker compose -f tests/servers/docker-compose.yml build
+          docker compose -f tests/servers/docker-compose.yml up -d --wait
 
       - name: Wait for the test servers to serve their screens
         timeout-minutes: 5
@@ -135,10 +142,6 @@ jobs:
           path: screenshots/
           if-no-files-found: ignore
 
-      # vncev and libvncserver-example run their upstream binary as PID 1
-      # with no SIGTERM handling, so the default 10s stop grace period is
-      # pure dead time -- the tigervnc/x11vnc entrypoints' traps already
-      # exit in well under a second. Nothing here needs a clean shutdown.
       - name: Stop the VNC test servers
         if: always()
         run: docker compose -f tests/servers/docker-compose.yml down --timeout 2

--- a/.github/workflows/fleet-images.yml
+++ b/.github/workflows/fleet-images.yml
@@ -1,0 +1,53 @@
+name: Fleet images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'tests/servers/**'
+      - '.github/workflows/fleet-images.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  publish:
+    name: Build and publish the fleet images
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      FLEET_IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/vncdotool-test
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Resolve the fleet image tag
+        run: echo "FLEET_TAG=$(git rev-parse HEAD:tests/servers)" >> "$GITHUB_ENV"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build the fleet images
+        run: docker compose -f tests/servers/docker-compose.yml build
+
+      - name: Publish the fleet images
+        run: docker compose -f tests/servers/docker-compose.yml push
+
+      - name: Summarise what was published
+        run: |
+          {
+            echo "Published \`$FLEET_TAG\`:"
+            echo
+            docker compose -f tests/servers/docker-compose.yml config --images | sort -u | sed 's/^/- /'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/specs/server-compatibility-plan.md
+++ b/specs/server-compatibility-plan.md
@@ -362,10 +362,22 @@ Tier 1 follow-ups:
   image links, so they render inline where review happens.
 - **Stop paying the image build tax on every run.** GitHub-hosted runners
   start with an empty Docker cache, so layer caching only helps within a
-  run — each CI run rebuilds from scratch (~35s of the ~70s total).
-  Options: `docker/build-push-action` with `cache-from/to: type=gha`, or
-  publish the images to GHCR once and have CI pull pinned digests, which
-  folds into the digest-pinning item below.
+  run — each CI run rebuilds from scratch (~50s of the `servers` job).
+  The route is publishing the images to GHCR and having CI pull pinned
+  digests, which folds into the digest-pinning item below.
+
+  Not `type=gha` layer caching: it was measured on this fleet and every
+  configuration came out slower than the plain `docker compose --build`
+  it replaced (68–106s against ~50s). Two costs sink it. `docker buildx`
+  needs the `docker-container` driver to export cache at all, and pulling
+  `moby/buildkit` to get one costs 6–11s a run that plain compose never
+  pays; and `--load` then has to copy five finished images back out of
+  that container into the daemon. Restore never made that back — with
+  correct per-target `scope=` the manifests import, but the expensive
+  layers still rebuild, so all five `apt-get install`s and the
+  libvncserver compile re-ran on every warm run. GHCR wins even against
+  a cache that worked perfectly: pulling skips the build *and* the
+  builder setup.
 - Pin base images by digest and fold this workflow into the main CI one.
 - Deepen what the per-server scenario actually asserts (see Phase 0).
 

--- a/specs/server-compatibility-plan.md
+++ b/specs/server-compatibility-plan.md
@@ -360,11 +360,16 @@ Tier 1 follow-ups:
   option if Pages is unwanted: push captures to an orphan branch and have
   the workflow post/update a PR comment with `raw.githubusercontent.com`
   image links, so they render inline where review happens.
-- **Stop paying the image build tax on every run.** GitHub-hosted runners
-  start with an empty Docker cache, so layer caching only helps within a
-  run — each CI run rebuilds from scratch (~50s of the `servers` job).
-  The route is publishing the images to GHCR and having CI pull pinned
-  digests, which folds into the digest-pinning item below.
+- **Image build tax — done.** `.github/workflows/fleet-images.yml`
+  publishes the fleet to GHCR on every `main` push that touches
+  `tests/servers`, tagged with that directory's git tree hash, and the
+  `servers` job pulls that tag instead of rebuilding. A miss falls back to
+  building, so a PR that edits the fleet — and any fork PR — behaves as it
+  did before the registry existed. The packages have to be public for the
+  anonymous pull to work; a private package fails the pull and silently
+  costs a build every run. A tag also maps to one set of apt packages
+  forever, so Debian updates only arrive when that tree changes or the
+  workflow is dispatched by hand.
 
   Not `type=gha` layer caching: it was measured on this fleet and every
   configuration came out slower than the plain `docker compose --build`

--- a/tests/servers/docker-compose.yml
+++ b/tests/servers/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     build:
       context: .
       target: tigervnc
-    image: vncdotool-test-tigervnc
+    image: ${FLEET_IMAGE_PREFIX:-vncdotool-test}-tigervnc:${FLEET_TAG:-dev}
     ports:
       - "127.0.0.1:5931:5900"
 
@@ -27,7 +27,7 @@ services:
     build:
       context: .
       target: tigervnc
-    image: vncdotool-test-tigervnc
+    image: ${FLEET_IMAGE_PREFIX:-vncdotool-test}-tigervnc:${FLEET_TAG:-dev}
     environment:
       VNC_PASSWORD: vncdotool
     ports:
@@ -37,7 +37,7 @@ services:
     build:
       context: .
       target: x11vnc
-    image: vncdotool-test-x11vnc
+    image: ${FLEET_IMAGE_PREFIX:-vncdotool-test}-x11vnc:${FLEET_TAG:-dev}
     ports:
       - "127.0.0.1:5933:5900"
 
@@ -47,7 +47,7 @@ services:
     build:
       context: .
       target: vncev
-    image: vncdotool-test-vncev
+    image: ${FLEET_IMAGE_PREFIX:-vncdotool-test}-vncev:${FLEET_TAG:-dev}
     ports:
       - "127.0.0.1:5934:5900"
 
@@ -56,6 +56,6 @@ services:
     build:
       context: .
       target: libvncserver-example
-    image: vncdotool-test-libvncserver-example
+    image: ${FLEET_IMAGE_PREFIX:-vncdotool-test}-libvncserver-example:${FLEET_TAG:-dev}
     ports:
       - "127.0.0.1:5935:5900"


### PR DESCRIPTION
Two things making the `servers` job cheaper, plus a note.

**Pull the fleet instead of rebuilding it.** A hosted runner starts with an empty Docker cache, so every run rebuilt all five images (~50s). A new `fleet-images.yml` publishes them to GHCR from `main` whenever `tests/servers` changes, tagged with that directory's git tree hash, and the `servers` job pulls that tag. A pull miss falls back to building, so a PR that edits the fleet (its images don't exist until it lands) and any fork PR behave exactly as before. Local `make servers-up` sets neither override and still builds from source.

**Teardown.** `vncev` and `libvncserver-example` run their upstream binary as PID 1 with no signal handling, so they sat out the full 10s stop grace period; the other three exit in under a second via their entrypoint traps. Timeout drops to 2s.

**One thing needed after merge:** the GHCR packages are created private, and the anonymous pull needs them public — otherwise the pull just fails and every run quietly pays for a build, i.e. today's behaviour. Four packages, `vncdotool-test-{tigervnc,x11vnc,vncev,libvncserver-example}`.

I also tried `type=gha` layer caching, which this repo's follow-up list has proposed twice. It measured slower than plain `docker compose --build` in all four configurations (68–106s against ~50s), so none of it is here — just a note under that item recording why, so it isn't attempted a third time.

Tests: CI green on this branch; the build-fallback path is what ran, since nothing is published yet.