### PR TITLE
ci: promote os-servers.yml from report-only to blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest] #, windows-latest] tests fail on windows
         python-version: ['3.10', '3.11', '3.12', '3.13']
     env:
       UV_PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        os: [ubuntu-latest] #, windows-latest] tests fail on windows
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13']
     env:
       UV_PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/os-servers.yml
+++ b/.github/workflows/os-servers.yml
@@ -5,8 +5,7 @@ name: OS-hosted VNC servers
 # see specs/server-compatibility-plan.md, Tier 2. These are the only place
 # UltraVNC and Screen Sharing compatibility can be exercised live, so this
 # job runs on real changes rather than never, but it is deliberately
-# change-triggered (path-filtered, no schedule) and report-only: see the
-# `continue-on-error` note on the job below.
+# change-triggered (path-filtered, no schedule).
 #
 # What each server needs, and what it does and doesn't prove, is documented
 # next to the setup scripts in tests/servers/ultravnc/README.md and
@@ -50,13 +49,6 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
-    # Report-only, never PR-blocking: per the plan, Tier 2 runs on hosted
-    # Windows/macOS VMs we don't own, and drift in the runner image or the
-    # Chocolatey package surfaces here first. continue-on-error keeps a
-    # failure visible (the job shows as failed in the run) without turning
-    # it red on the PR. Promote to blocking (drop this line) only once the
-    # job has proven stable -- see specs/server-compatibility-plan.md, Tier 2.
-    continue-on-error: true
     strategy:
       # One OS failing must never take down the other: each is a separate
       # data point about that OS, not a step in a shared pipeline.

--- a/specs/server-compatibility-plan.md
+++ b/specs/server-compatibility-plan.md
@@ -256,8 +256,8 @@ spin them up when something relevant changes:
   VM, and a quiet repository consumes nothing.
 - Accepted trade-off: drift in the runner images or the Chocolatey
   package surfaces on the next change-triggered run rather than the night
-  it happens, and now blocks the PR that triggered it like any other
-  CI failure.
+  it happens, and blocks the PR that triggered it like any other CI
+  failure.
 - Each successful run can upload a wire capture as an artifact for
   offline debugging.
 
@@ -422,16 +422,9 @@ service-mode setup steps and move passwords into repository secrets.
 
 **Graduated:** this spike's workflow now lives at
 `.github/workflows/os-servers.yml` (renamed from `spike-os-servers.yml`),
-change-triggered and path-filtered per the policy above. Credentials come
-from `VNC_OS_SERVER_USERNAME`/`VNC_OS_SERVER_PASSWORD` repository secrets,
-falling back to the spike values when unset.
-
-**Promoted to blocking (2026-08-19):** macOS was 32/32 green across the
-job's full history with no failures anywhere. Windows had a run of
-failures, but all of them traced to the mid-`uv`-migration branches that
-hadn't yet picked up `uv run` prefixing (fixed by #384); every run since
-that landed is green, and history before the migration was clean too. Both
-jobs meet the stability bar, so `continue-on-error: true` is dropped.
+change-triggered, path-filtered, and PR-blocking per the policy above.
+Credentials come from `VNC_OS_SERVER_USERNAME`/`VNC_OS_SERVER_PASSWORD`
+repository secrets, falling back to the spike values when unset.
 
 ## Sequencing and effort
 

--- a/specs/server-compatibility-plan.md
+++ b/specs/server-compatibility-plan.md
@@ -256,11 +256,10 @@ spin them up when something relevant changes:
   VM, and a quiet repository consumes nothing.
 - Accepted trade-off: drift in the runner images or the Chocolatey
   package surfaces on the next change-triggered run rather than the night
-  it happens. Because these jobs are report-only (never PR-blocking), a
-  drift failure costs a tracked issue, not a broken merge queue.
+  it happens, and now blocks the PR that triggered it like any other
+  CI failure.
 - Each successful run can upload a wire capture as an artifact for
-  offline debugging; jobs are promoted to blocking only once they prove
-  stable.
+  offline debugging.
 
 ### Tier 3 — Capture-only servers (community-sourced evidence)
 
@@ -423,10 +422,16 @@ service-mode setup steps and move passwords into repository secrets.
 
 **Graduated:** this spike's workflow now lives at
 `.github/workflows/os-servers.yml` (renamed from `spike-os-servers.yml`),
-change-triggered and path-filtered per the policy above, report-only via
-`continue-on-error: true`. Credentials come from `VNC_OS_SERVER_USERNAME`/
-`VNC_OS_SERVER_PASSWORD` repository secrets, falling back to the spike
-values when unset.
+change-triggered and path-filtered per the policy above. Credentials come
+from `VNC_OS_SERVER_USERNAME`/`VNC_OS_SERVER_PASSWORD` repository secrets,
+falling back to the spike values when unset.
+
+**Promoted to blocking (2026-08-19):** macOS was 32/32 green across the
+job's full history with no failures anywhere. Windows had a run of
+failures, but all of them traced to the mid-`uv`-migration branches that
+hadn't yet picked up `uv run` prefixing (fixed by #384); every run since
+that landed is green, and history before the migration was clean too. Both
+jobs meet the stability bar, so `continue-on-error: true` is dropped.
 
 ## Sequencing and effort
 


### PR DESCRIPTION
Drops `continue-on-error: true` from the Tier 2 Windows/macOS job now that it's proven stable: macOS/Screen Sharing is 32/32 green across its whole history, and Windows/UltraVNC's only failures trace to the mid-uv-migration branches missing `uv run` (fixed by #384) -- clean before and after.

Dropped the earlier idea of adding windows-latest/macos-latest to the unit test matrix -- no value there, the protocol classes are driven against a mocked transport with nothing OS-specific to catch.

## Test plan
- [x] Reviewed os-servers.yml run history (32/32 macOS, Windows clean pre- and post-#384)
- [ ] CI green on this PR