### PR TITLE
Fix framebuffer offset when the first rectangle isn't at (0, 0)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 2.0.0.dev0 (UNRELEASED)
 ----------------------
+  - Fix screenshots shifted against any server whose first rectangle does not start at (0, 0): the client used to adopt that rectangle as the whole screen, offsetting every pixel by its position (@sibson)
   - Local development moves from a vendored Makefile.venv + pip to uv: ``make``
     targets run under ``uv run``, and a host's ``python3`` version no longer
     matters (@sibson, #383)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,5 +1,6 @@
 from unittest import TestCase, mock
 import io
+import struct
 import warnings
 
 from vncdotool import client
@@ -176,13 +177,31 @@ class TestVNCDoToolClient(TestCase):
     def test_updateRectangeFullScreen(self, frombytes):
         cli = self.client
         cli.image = mock.Mock()
+        cli.width, cli.height = 100, 200
         data = mock.Mock()
+        frombytes.return_value = client.Image.new("RGB", (100, 200), (10, 20, 30))
 
         cli.updateRectangle(0, 0, 100, 200, data)
 
         client.Image.frombytes.assert_called_once_with('RGB', (100, 200), data, 'raw', 'RGBX')
 
-        assert cli.screen == client.Image.frombytes.return_value
+        assert cli.screen.size == (100, 200)
+        assert cli.screen.getpixel((0, 0)) == (10, 20, 30)
+
+    def test_updateRectangle_first_rect_not_at_origin(self) -> None:
+        cli = self.client
+        cli._packet = bytearray(self.MSG_HANDSHAKE)
+        cli._handleInitial()
+        cli._handleServerInit(struct.pack("!HH", 300, 200) + self.MSG_INIT[4:])
+
+        color = (200, 150, 50)
+        data = (bytes(color) + b"\x00") * (10 * 10)
+        cli.updateRectangle(50, 30, 10, 10, data)
+
+        assert cli.screen is not None
+        assert cli.screen.size == (300, 200)
+        assert cli.screen.getpixel((50, 30)) == color
+        assert cli.screen.getpixel((0, 0)) == (0, 0, 0)
 
     @mock.patch('PIL.Image.frombytes')
     def test_updateRectangeRegion(self, frombytes):
@@ -355,6 +374,8 @@ class TestImageMode(TestCase):
     def test_updateRectangle_does_not_warn(self, frombytes):
         cli = self.client
         cli.image = mock.Mock()
+        cli.width, cli.height = 100, 200
+        frombytes.return_value = client.Image.new("RGB", (100, 200))
 
         with warnings.catch_warnings():
             warnings.simplefilter("error", FutureWarning)

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -384,7 +384,8 @@ class VNCDoToolClient(rfb.RFBClient):
         size = (width, height)
         update = Image.frombytes("RGB", size, data, "raw", self._image_mode)
         if not self.screen:
-            self.screen = update
+            self.screen = Image.new("RGB", (self.width, self.height), "black")
+            self.screen.paste(update, (x, y))
         # track upward screen resizes, often occurs during os boot of VMs
         # When the screen is sent in chunks (as observed on VMWare ESXi), the canvas
         # needs to be resized to fit all existing contents and the update.


### PR DESCRIPTION
`updateRectangle` adopted the first rectangle's pixel data as the whole framebuffer and discarded its x/y. TigerVNC opens with 22 rectangles and the first is at (21, 0), so the canvas was anchored 21 pixels off; later rectangles grew it back to the full size through the existing resize branch, leaving a black band where the shifted content left a hole. Screenshots came out the right size and quietly wrong.

`self.width`/`self.height` are known from ServerInit before any update arrives, so the first rectangle now pastes into a full desktop-sized canvas at its real position.

Two existing tests changed with it: they asserted `screen is Image.frombytes.return_value`, an identity the fix necessarily breaks, and they drove the path with no ServerInit, which cannot happen against a real server.

Found by a golden fixture captured from TigerVNC and checked against an oracle produced outside the decoder; that work is #392, which stacks on this.

Tested: unit suite green, flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)