### PR TITLE
Add pixelformat.py: negotiated format to Pillow raw mode, CPIXEL widths

### DIFF
--- a/tests/unit/test_pixelformat.py
+++ b/tests/unit/test_pixelformat.py
@@ -1,0 +1,179 @@
+from unittest import TestCase
+
+from PIL import Image
+
+from vncdotool import rfb
+from vncdotool.pixelformat import UnsupportedPixelFormat, cpixel_bytes, cpixel_offset, raw_mode
+
+# 32bpp, 8-bit channels, one PixelFormat per Pillow raw mode, plus a
+# depth-only variant and a bigendian variant of bgrx8888.
+BGRX8888 = rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 16, 8, 0)
+BGRX8888_DEPTH32 = rfb.PixelFormat(32, 32, False, True, 255, 255, 255, 16, 8, 0)
+BGRX8888_BIGENDIAN = rfb.PixelFormat(32, 24, True, True, 255, 255, 255, 16, 8, 0)
+RGBX8888 = rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 0, 8, 16)
+XRGB8888 = rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 8, 16, 24)
+XBGR8888 = rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 24, 16, 8)
+
+RGB24 = rfb.PixelFormat(24, 24, False, True, 255, 255, 255, 0, 8, 16)
+BGR24 = rfb.PixelFormat(24, 24, False, True, 255, 255, 255, 16, 8, 0)
+
+BGR565 = rfb.PixelFormat(16, 16, False, True, 31, 63, 31, 11, 5, 0)
+RGB565 = rfb.PixelFormat(16, 16, False, True, 31, 63, 31, 0, 5, 11)
+BGR555 = rfb.PixelFormat(16, 15, False, True, 31, 31, 31, 10, 5, 0)
+RGB555 = rfb.PixelFormat(16, 15, False, True, 31, 31, 31, 0, 5, 10)
+RGB444 = rfb.PixelFormat(16, 12, False, True, 15, 15, 15, 0, 4, 8)
+
+
+def pack(pixel_format: rfb.PixelFormat, red: int, green: int, blue: int) -> bytes:
+    """Encode (red, green, blue) as PIXEL bytes for pixel_format's own layout."""
+    value = (
+        (red << pixel_format.redshift)
+        | (green << pixel_format.greenshift)
+        | (blue << pixel_format.blueshift)
+    )
+    return value.to_bytes(pixel_format.bpp // 8, "big" if pixel_format.bigendian else "little")
+
+
+class TestRawMode(TestCase):
+
+    def test_resolves_every_format_pillow_can_read(self):
+        """raw_mode picks the Pillow mode string for each covered layout."""
+        cases = {
+            BGRX8888: "BGRX",
+            RGBX8888: "RGBX",
+            XRGB8888: "XRGB",
+            XBGR8888: "XBGR",
+            RGB24: "RGB",
+            BGR24: "BGR",
+            BGR565: "BGR;16",
+            RGB565: "RGB;16",
+            BGR555: "BGR;15",
+            RGB555: "RGB;15",
+            RGB444: "RGB;4B",
+        }
+        for pixel_format, expected in cases.items():
+            with self.subTest(pixel_format=pixel_format):
+                self.assertEqual(raw_mode(pixel_format), expected)
+
+    def test_depth_does_not_affect_the_resolved_mode(self):
+        """A libvncserver-example-style depth-32 declaration is still RGBX."""
+        self.assertEqual(raw_mode(BGRX8888), raw_mode(BGRX8888_DEPTH32))
+
+    def test_endianness_changes_the_resolved_mode(self):
+        """Byte order, unlike depth, does change which mode applies."""
+        self.assertNotEqual(raw_mode(BGRX8888), raw_mode(BGRX8888_BIGENDIAN))
+        self.assertEqual(raw_mode(BGRX8888_BIGENDIAN), "XRGB")
+
+    def test_known_bytes_decode_to_known_pixels(self):
+        """Each resolved mode is a correct claim about Pillow's own decoding."""
+        formats = [
+            BGRX8888,
+            RGBX8888,
+            XRGB8888,
+            XBGR8888,
+            BGRX8888_BIGENDIAN,
+            RGB24,
+            BGR24,
+            BGR565,
+            RGB565,
+            BGR555,
+            RGB555,
+            RGB444,
+        ]
+        for pixel_format in formats:
+            mode = raw_mode(pixel_format)
+            with self.subTest(pixel_format=pixel_format, mode=mode):
+                red = pack(pixel_format, pixel_format.redmax, 0, 0)
+                green = pack(pixel_format, 0, pixel_format.greenmax, 0)
+                blue = pack(pixel_format, 0, 0, pixel_format.bluemax)
+                red_pixel = Image.frombytes("RGB", (1, 1), red, "raw", mode).getpixel((0, 0))
+                green_pixel = Image.frombytes("RGB", (1, 1), green, "raw", mode).getpixel((0, 0))
+                blue_pixel = Image.frombytes("RGB", (1, 1), blue, "raw", mode).getpixel((0, 0))
+                self.assertEqual(red_pixel, (255, 0, 0))
+                self.assertEqual(green_pixel, (0, 255, 0))
+                self.assertEqual(blue_pixel, (0, 0, 255))
+
+    def test_rgb565_is_red_in_the_high_bits(self):
+        """0x00F8 little-endian through BGR;16 is pure red."""
+        self.assertEqual(raw_mode(BGR565), "BGR;16")
+        image = Image.frombytes("RGB", (1, 1), bytes([0x00, 0xF8]), "raw", "BGR;16")
+        self.assertEqual(image.getpixel((0, 0)), (255, 0, 0))
+
+    def test_colour_mapped_is_unsupported(self):
+        pixel_format = rfb.PixelFormat(8, 8, False, False, 0, 0, 0, 0, 0, 0)
+        with self.assertRaises(UnsupportedPixelFormat):
+            raw_mode(pixel_format)
+
+    def test_bigendian_16bpp_is_unsupported(self):
+        pixel_format = rfb.PixelFormat(16, 16, True, True, 31, 63, 31, 11, 5, 0)
+        with self.assertRaises(UnsupportedPixelFormat):
+            raw_mode(pixel_format)
+
+    def test_channel_widths_outside_the_covered_set_are_unsupported(self):
+        pixel_format = rfb.PixelFormat(16, 16, False, True, 63, 63, 63, 12, 6, 0)
+        with self.assertRaises(UnsupportedPixelFormat):
+            raw_mode(pixel_format)
+
+    def test_non_byte_aligned_32bpp_shifts_are_unsupported(self):
+        pixel_format = rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 4, 12, 20)
+        with self.assertRaises(UnsupportedPixelFormat):
+            raw_mode(pixel_format)
+
+
+class TestCPixel(TestCase):
+
+    def test_low_placement(self):
+        """bgrx8888's colour bits fit the low three bytes."""
+        self.assertEqual(cpixel_bytes(BGRX8888), 3)
+        self.assertEqual(cpixel_offset(BGRX8888), 0)
+
+    def test_high_placement(self):
+        """A pad byte in position 0 pushes the colour bits into the high three."""
+        pixel_format = rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 24, 16, 8)
+        self.assertEqual(cpixel_bytes(pixel_format), 3)
+        self.assertEqual(cpixel_offset(pixel_format), pixel_format.bypp - 3)
+
+    def test_depth_16_tie_break_prefers_low(self):
+        """rfbproto's corner case: depth <= 16 lets both placements fit."""
+        pixel_format = rfb.PixelFormat(32, 16, False, True, 31, 63, 31, 19, 13, 8)
+        self.assertEqual(cpixel_bytes(pixel_format), 3)
+        self.assertEqual(cpixel_offset(pixel_format), 0)
+
+    def test_placement_is_value_space_offset_is_byte_space(self):
+        """Big-endian reverses which end of the pixel the three bytes sit at."""
+        low = rfb.PixelFormat(32, 24, True, True, 255, 255, 255, 16, 8, 0)
+        high = rfb.PixelFormat(32, 24, True, True, 255, 255, 255, 24, 16, 8)
+
+        self.assertEqual(cpixel_offset(low), low.bypp - 3)
+        self.assertEqual(cpixel_offset(high), 0)
+
+    def test_the_three_bytes_carry_every_colour_bit(self):
+        """Slicing at the reported offset must not take the pad byte."""
+        for pixel_format in (BGRX8888, XBGR8888, BGRX8888_BIGENDIAN):
+            with self.subTest(pixel_format=pixel_format):
+                order = "big" if pixel_format.bigendian else "little"
+                value = (
+                    0xFF << pixel_format.redshift
+                    | 0x80 << pixel_format.greenshift
+                    | 0x40 << pixel_format.blueshift
+                )
+                pixel = value.to_bytes(pixel_format.bypp, order)
+                offset = cpixel_offset(pixel_format)
+
+                cpixel = pixel[offset:offset + cpixel_bytes(pixel_format)]
+
+                self.assertEqual(sorted(cpixel), [0x40, 0x80, 0xFF])
+
+    def test_16bpp_is_never_a_cpixel(self):
+        self.assertEqual(cpixel_bytes(BGR565), BGR565.bypp)
+        self.assertEqual(cpixel_offset(BGR565), 0)
+
+    def test_depth_32_is_never_a_cpixel(self):
+        pixel_format = rfb.PixelFormat(32, 32, False, True, 255, 255, 255, 0, 8, 16)
+        self.assertEqual(cpixel_bytes(pixel_format), pixel_format.bypp)
+        self.assertEqual(cpixel_offset(pixel_format), 0)
+
+    def test_colour_bits_straddling_the_middle_fall_back_to_pixel_width(self):
+        pixel_format = rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 4, 12, 20)
+        self.assertEqual(cpixel_bytes(pixel_format), pixel_format.bypp)
+        self.assertEqual(cpixel_offset(pixel_format), 0)

--- a/tests/unit/test_pixelformat.py
+++ b/tests/unit/test_pixelformat.py
@@ -5,8 +5,6 @@ from PIL import Image
 from vncdotool import rfb
 from vncdotool.pixelformat import UnsupportedPixelFormat, cpixel_bytes, cpixel_offset, raw_mode
 
-# 32bpp, 8-bit channels, one PixelFormat per Pillow raw mode, plus a
-# depth-only variant and a bigendian variant of bgrx8888.
 BGRX8888 = rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 16, 8, 0)
 BGRX8888_DEPTH32 = rfb.PixelFormat(32, 32, False, True, 255, 255, 255, 16, 8, 0)
 BGRX8888_BIGENDIAN = rfb.PixelFormat(32, 24, True, True, 255, 255, 255, 16, 8, 0)
@@ -56,7 +54,7 @@ class TestRawMode(TestCase):
                 self.assertEqual(raw_mode(pixel_format), expected)
 
     def test_depth_does_not_affect_the_resolved_mode(self):
-        """A libvncserver-example-style depth-32 declaration is still RGBX."""
+        """The depth-32 declaration libvncserver-example sends resolves the same."""
         self.assertEqual(raw_mode(BGRX8888), raw_mode(BGRX8888_DEPTH32))
 
     def test_endianness_changes_the_resolved_mode(self):
@@ -110,7 +108,8 @@ class TestRawMode(TestCase):
             raw_mode(pixel_format)
 
     def test_channel_widths_outside_the_covered_set_are_unsupported(self):
-        pixel_format = rfb.PixelFormat(16, 16, False, True, 63, 63, 63, 12, 6, 0)
+        """10-bit channels: a real deep-colour layout Pillow has no mode for."""
+        pixel_format = rfb.PixelFormat(32, 30, False, True, 1023, 1023, 1023, 20, 10, 0)
         with self.assertRaises(UnsupportedPixelFormat):
             raw_mode(pixel_format)
 

--- a/tests/unit/test_pixelformat.py
+++ b/tests/unit/test_pixelformat.py
@@ -43,6 +43,21 @@ def every_layout() -> Iterator[rfb.PixelFormat]:
                 yield rfb.PixelFormat(bpp, depth, bigendian, True, *maxima, *shifts)
 
 
+def every_colour(maxima: tuple[int, int, int]) -> Iterator[tuple[int, int, int]]:
+    """Primaries, black, white, and a mid value per channel.
+
+    Mid values are what separate a correct shift from one that happens to
+    look right at full intensity, where every bit of the channel is set.
+    """
+    yield (0, 0, 0)
+    yield maxima
+    for channel, maximum in enumerate(maxima):
+        for value in (maximum, maximum // 2, 1):
+            intensities = [0, 0, 0]
+            intensities[channel] = value
+            yield tuple(intensities)  # type: ignore[misc]
+
+
 def pack(pixel_format: rfb.PixelFormat, red: int, green: int, blue: int) -> bytes:
     """Encode (red, green, blue) as PIXEL bytes for pixel_format's own layout."""
     value = (
@@ -99,12 +114,15 @@ class TestRawMode(TestCase):
                 except UnsupportedPixelFormat:
                     continue
                 resolved.add(mode)
-                for channel, expected in enumerate(((255, 0, 0), (0, 255, 0), (0, 0, 255))):
-                    intensity = [0, 0, 0]
-                    intensity[channel] = (pixel_format.redmax, pixel_format.greenmax, pixel_format.bluemax)[channel]
-                    data = pack(pixel_format, *intensity)
+                maxima = (pixel_format.redmax, pixel_format.greenmax, pixel_format.bluemax)
+                for intensities in every_colour(maxima):
+                    data = pack(pixel_format, *intensities)
                     decoded = Image.frombytes("RGB", (1, 1), data, "raw", mode).getpixel((0, 0))
-                    self.assertEqual(decoded, expected)
+                    for channel, (value, maximum) in enumerate(zip(intensities, maxima)):
+                        # Pillow scales an n-bit channel to 8 bits by its own
+                        # rounding, so this bounds the result rather than
+                        # restating the rounding and passing by construction.
+                        self.assertAlmostEqual(decoded[channel], value * 255 / maximum, delta=1)
 
         self.assertEqual(
             resolved,
@@ -167,21 +185,27 @@ class TestCPixel(TestCase):
         self.assertEqual(cpixel_offset(high), 0)
 
     def test_the_three_bytes_carry_every_colour_bit(self):
-        """Slicing at the reported offset must not take the pad byte."""
-        for pixel_format in (BGRX8888, XBGR8888, BGRX8888_BIGENDIAN):
+        """Whatever is outside the reported window is pad, over every layout."""
+        eligible = 0
+
+        for pixel_format in every_layout():
+            if cpixel_bytes(pixel_format) != 3:
+                continue
+            eligible += 1
             with self.subTest(pixel_format=pixel_format):
-                order = "big" if pixel_format.bigendian else "little"
-                value = (
-                    0xFF << pixel_format.redshift
-                    | 0x80 << pixel_format.greenshift
-                    | 0x40 << pixel_format.blueshift
+                pixel = pack(
+                    pixel_format,
+                    pixel_format.redmax,
+                    pixel_format.greenmax,
+                    pixel_format.bluemax,
                 )
-                pixel = value.to_bytes(pixel_format.bypp, order)
                 offset = cpixel_offset(pixel_format)
 
-                cpixel = pixel[offset:offset + cpixel_bytes(pixel_format)]
+                outside = pixel[:offset] + pixel[offset + 3:]
 
-                self.assertEqual(sorted(cpixel), [0x40, 0x80, 0xFF])
+                self.assertEqual(outside, bytes(len(outside)))
+
+        self.assertTrue(eligible)
 
     def test_16bpp_is_never_a_cpixel(self):
         self.assertEqual(cpixel_bytes(BGR565), BGR565.bypp)

--- a/tests/unit/test_pixelformat.py
+++ b/tests/unit/test_pixelformat.py
@@ -1,3 +1,5 @@
+import itertools
+from typing import Iterator
 from unittest import TestCase
 
 from PIL import Image
@@ -20,6 +22,25 @@ RGB565 = rfb.PixelFormat(16, 16, False, True, 31, 63, 31, 0, 5, 11)
 BGR555 = rfb.PixelFormat(16, 15, False, True, 31, 31, 31, 10, 5, 0)
 RGB555 = rfb.PixelFormat(16, 15, False, True, 31, 31, 31, 0, 5, 10)
 RGB444 = rfb.PixelFormat(16, 12, False, True, 15, 15, 15, 0, 4, 8)
+
+
+def every_layout() -> Iterator[rfb.PixelFormat]:
+    """Every channel arrangement of the widths a server may negotiate.
+
+    Both endiannesses throughout, including the arrangements that have no
+    Pillow mode: what they must do is raise, and a generated case cannot be
+    forgotten the way a listed one can.
+    """
+    for bpp, depth, maxima, slots in (
+        (32, 24, (255, 255, 255), (0, 8, 16, 24)),
+        (24, 24, (255, 255, 255), (0, 8, 16)),
+        (16, 16, (31, 63, 31), (0, 5, 11)),
+        (16, 15, (31, 31, 31), (0, 5, 10)),
+        (16, 12, (15, 15, 15), (0, 4, 8)),
+    ):
+        for shifts in itertools.permutations(slots, 3):
+            for bigendian in (False, True):
+                yield rfb.PixelFormat(bpp, depth, bigendian, True, *maxima, *shifts)
 
 
 def pack(pixel_format: rfb.PixelFormat, red: int, green: int, blue: int) -> bytes:
@@ -62,34 +83,33 @@ class TestRawMode(TestCase):
         self.assertNotEqual(raw_mode(BGRX8888), raw_mode(BGRX8888_BIGENDIAN))
         self.assertEqual(raw_mode(BGRX8888_BIGENDIAN), "XRGB")
 
-    def test_known_bytes_decode_to_known_pixels(self):
-        """Each resolved mode is a correct claim about Pillow's own decoding."""
-        formats = [
-            BGRX8888,
-            RGBX8888,
-            XRGB8888,
-            XBGR8888,
-            BGRX8888_BIGENDIAN,
-            RGB24,
-            BGR24,
-            BGR565,
-            RGB565,
-            BGR555,
-            RGB555,
-            RGB444,
-        ]
-        for pixel_format in formats:
-            mode = raw_mode(pixel_format)
-            with self.subTest(pixel_format=pixel_format, mode=mode):
-                red = pack(pixel_format, pixel_format.redmax, 0, 0)
-                green = pack(pixel_format, 0, pixel_format.greenmax, 0)
-                blue = pack(pixel_format, 0, 0, pixel_format.bluemax)
-                red_pixel = Image.frombytes("RGB", (1, 1), red, "raw", mode).getpixel((0, 0))
-                green_pixel = Image.frombytes("RGB", (1, 1), green, "raw", mode).getpixel((0, 0))
-                blue_pixel = Image.frombytes("RGB", (1, 1), blue, "raw", mode).getpixel((0, 0))
-                self.assertEqual(red_pixel, (255, 0, 0))
-                self.assertEqual(green_pixel, (0, 255, 0))
-                self.assertEqual(blue_pixel, (0, 0, 255))
+    def test_every_layout_either_decodes_correctly_or_is_refused(self):
+        """Over every channel arrangement, not the handful we thought to list.
+
+        A mode that resolves must decode the primaries it claims to; a layout
+        Pillow cannot read must raise. There is no third outcome, and in
+        particular no silently wrong mode.
+        """
+        resolved = set()
+
+        for pixel_format in every_layout():
+            with self.subTest(pixel_format=pixel_format):
+                try:
+                    mode = raw_mode(pixel_format)
+                except UnsupportedPixelFormat:
+                    continue
+                resolved.add(mode)
+                for channel, expected in enumerate(((255, 0, 0), (0, 255, 0), (0, 0, 255))):
+                    intensity = [0, 0, 0]
+                    intensity[channel] = (pixel_format.redmax, pixel_format.greenmax, pixel_format.bluemax)[channel]
+                    data = pack(pixel_format, *intensity)
+                    decoded = Image.frombytes("RGB", (1, 1), data, "raw", mode).getpixel((0, 0))
+                    self.assertEqual(decoded, expected)
+
+        self.assertEqual(
+            resolved,
+            {"RGBX", "BGRX", "XRGB", "XBGR", "RGB", "BGR", "BGR;16", "RGB;16", "BGR;15", "RGB;15", "RGB;4B"},
+        )
 
     def test_rgb565_is_red_in_the_high_bits(self):
         """0x00F8 little-endian through BGR;16 is pure red."""

--- a/vncdotool/pixelformat.py
+++ b/vncdotool/pixelformat.py
@@ -73,24 +73,24 @@ def raw_mode(pixel_format: rfb.PixelFormat) -> str:
     if pixel_format.bpp == 16:
         if pixel_format.bigendian:
             raise UnsupportedPixelFormat("big-endian 16bpp is not supported")
-        blue_high = pixel_format.blueshift > pixel_format.redshift
-        red_high = pixel_format.redshift > pixel_format.blueshift
-        if widths == (5, 6, 5):
-            if red_high:
-                return "BGR;16"
-            if blue_high:
-                return "RGB;16"
-        elif widths == (5, 5, 5):
-            if red_high:
-                return "BGR;15"
-            if blue_high:
-                return "RGB;15"
-        elif widths == (4, 4, 4):
-            # Pillow has no mirror of RGB;4B: a 444 format with red in the
-            # high nibble and blue in the low one has no raw mode at all.
-            if blue_high:
-                return "RGB;4B"
-        raise UnsupportedPixelFormat(f"16bpp layout widths={widths} has no Pillow mode")
+        shifts = (pixel_format.redshift, pixel_format.greenshift, pixel_format.blueshift)
+        # Matched as whole triples, not by asking which of red and blue sits
+        # higher: the channels have unequal widths, so an arrangement that
+        # passes that test can still overlap.
+        try:
+            # Pillow has no mirror of RGB;4B, so 444 with red in the high
+            # nibble is absent here and raises.
+            return {
+                ((5, 6, 5), (11, 5, 0)): "BGR;16",
+                ((5, 6, 5), (0, 5, 11)): "RGB;16",
+                ((5, 5, 5), (10, 5, 0)): "BGR;15",
+                ((5, 5, 5), (0, 5, 10)): "RGB;15",
+                ((4, 4, 4), (0, 4, 8)): "RGB;4B",
+            }[(widths, shifts)]
+        except KeyError:
+            raise UnsupportedPixelFormat(
+                f"16bpp layout widths={widths} shifts={shifts} has no Pillow mode"
+            ) from None
 
     raise UnsupportedPixelFormat(f"bpp={pixel_format.bpp} is not supported")
 

--- a/vncdotool/pixelformat.py
+++ b/vncdotool/pixelformat.py
@@ -134,7 +134,6 @@ def cpixel_offset(pixel_format: rfb.PixelFormat) -> int:
     return 0 if low != pixel_format.bigendian else pixel_format.bypp - 3
 
 
-# Names the ``--pixel-format`` CLI flag will accept.
 PIXEL_FORMATS: dict[str, rfb.PixelFormat] = {
     "bgrx8888": rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 16, 8, 0),
     "rgbx8888": rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 0, 8, 16),

--- a/vncdotool/pixelformat.py
+++ b/vncdotool/pixelformat.py
@@ -1,0 +1,142 @@
+"""
+Pixel format resolution: :class:`rfb.PixelFormat` -> Pillow raw mode, and the
+CPIXEL width/offset rules ZRLE depends on.
+
+Reference:
+https://www.rfc-editor.org/rfc/rfc6143#section-7.7.5
+https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst (ZRLE Encoding)
+"""
+from __future__ import annotations
+
+from . import rfb
+
+_32BPP_MODES = {"RGBX", "BGRX", "XRGB", "XBGR"}
+_24BPP_MODES = {"RGB", "BGR"}
+
+
+class UnsupportedPixelFormat(Exception):
+    """No Pillow raw mode exists for this :class:`rfb.PixelFormat`."""
+
+
+def _channel_widths(pixel_format: rfb.PixelFormat) -> tuple[int, int, int]:
+    return (
+        pixel_format.redmax.bit_length(),
+        pixel_format.greenmax.bit_length(),
+        pixel_format.bluemax.bit_length(),
+    )
+
+
+def _byte_positions(
+    pixel_format: rfb.PixelFormat, nbytes: int
+) -> dict[int, str]:
+    positions: dict[int, str] = {}
+    for shift, channel in (
+        (pixel_format.redshift, "R"),
+        (pixel_format.greenshift, "G"),
+        (pixel_format.blueshift, "B"),
+    ):
+        if shift % 8:
+            raise UnsupportedPixelFormat(f"shift={shift} is not byte-aligned")
+        pos = shift // 8
+        pos = pos if not pixel_format.bigendian else nbytes - 1 - pos
+        if pos in positions:
+            raise UnsupportedPixelFormat(f"two channels share byte {pos}")
+        positions[pos] = channel
+    return positions
+
+
+def raw_mode(pixel_format: rfb.PixelFormat) -> str:
+    """The Pillow raw mode that reads bytes in this layout, ignoring depth."""
+    if not pixel_format.truecolor:
+        raise UnsupportedPixelFormat("colour-mapped pixel formats are not supported")
+
+    widths = _channel_widths(pixel_format)
+
+    if pixel_format.bpp == 32:
+        if widths != (8, 8, 8):
+            raise UnsupportedPixelFormat(f"32bpp channel widths {widths} unsupported")
+        positions = _byte_positions(pixel_format, 4)
+        mode = "".join(positions.get(i, "X") for i in range(4))
+        if mode not in _32BPP_MODES:
+            raise UnsupportedPixelFormat(f"32bpp layout {mode!r} has no Pillow mode")
+        return mode
+
+    if pixel_format.bpp == 24:
+        if widths != (8, 8, 8):
+            raise UnsupportedPixelFormat(f"24bpp channel widths {widths} unsupported")
+        positions = _byte_positions(pixel_format, 3)
+        mode = "".join(positions.get(i, "X") for i in range(3))
+        if mode not in _24BPP_MODES:
+            raise UnsupportedPixelFormat(f"24bpp layout {mode!r} has no Pillow mode")
+        return mode
+
+    if pixel_format.bpp == 16:
+        if pixel_format.bigendian:
+            raise UnsupportedPixelFormat("big-endian 16bpp is not supported")
+        blue_high = pixel_format.blueshift > pixel_format.redshift
+        red_high = pixel_format.redshift > pixel_format.blueshift
+        if widths == (5, 6, 5):
+            if red_high:
+                return "BGR;16"
+            if blue_high:
+                return "RGB;16"
+        elif widths == (5, 5, 5):
+            if red_high:
+                return "BGR;15"
+            if blue_high:
+                return "RGB;15"
+        elif widths == (4, 4, 4):
+            # Pillow has no mirror of RGB;4B: a 444 format with red in the
+            # high nibble and blue in the low one has no raw mode at all.
+            if blue_high:
+                return "RGB;4B"
+        raise UnsupportedPixelFormat(f"16bpp layout widths={widths} has no Pillow mode")
+
+    raise UnsupportedPixelFormat(f"bpp={pixel_format.bpp} is not supported")
+
+
+def _cpixel_placement(pixel_format: rfb.PixelFormat) -> str | None:
+    widths = _channel_widths(pixel_format)
+    shifts = (pixel_format.redshift, pixel_format.greenshift, pixel_format.blueshift)
+    fits_low = all(shift + width <= 24 for shift, width in zip(shifts, widths))
+    fits_high = all(shift >= 8 for shift in shifts)
+    if fits_low:
+        # rfbproto: when depth <= 16 both placements fit, and the low three
+        # bytes are used by convention.
+        return "low"
+    if fits_high:
+        return "high"
+    return None
+
+
+def cpixel_bytes(pixel_format: rfb.PixelFormat) -> int:
+    """3 for a CPIXEL-eligible format, otherwise ``bypp`` (a PIXEL)."""
+    if (
+        pixel_format.truecolor
+        and pixel_format.bpp == 32
+        and pixel_format.depth <= 24
+        and _cpixel_placement(pixel_format) is not None
+    ):
+        return 3
+    return pixel_format.bypp
+
+
+def cpixel_offset(pixel_format: rfb.PixelFormat) -> int:
+    """Byte offset of the 3 CPIXEL bytes within a PIXEL: 0 or ``bypp - 3``.
+
+    The placement is in value space and the offset is in byte space, so
+    big-endian reverses it: the least significant three bytes of a
+    big-endian pixel are the *last* three on the wire.
+    """
+    if cpixel_bytes(pixel_format) != 3:
+        return 0
+    low = _cpixel_placement(pixel_format) == "low"
+    return 0 if low != pixel_format.bigendian else pixel_format.bypp - 3
+
+
+# Names the ``--pixel-format`` CLI flag will accept.
+PIXEL_FORMATS: dict[str, rfb.PixelFormat] = {
+    "bgrx8888": rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 16, 8, 0),
+    "rgbx8888": rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 0, 8, 16),
+    "rgb565": rfb.PixelFormat(16, 16, False, True, 31, 63, 31, 11, 5, 0),
+}


### PR DESCRIPTION
Phase 1 of `specs/pixel-format.md` (#377). New module and its tests only — no call sites, `PF2IM` and `setImageMode` still in place, nothing user-visible, so no CHANGELOG entry.

`raw_mode()` computes the Pillow mode from the format's fields instead of matching a whole dataclass against a table. That difference is the point: libvncserver-example announces the layout `PF2IM` calls `RGBX` but declares depth 32, so it misses the table and we renegotiate to a format byte-identical to the one already arriving. `raw_mode` ignores `depth`; `cpixel_bytes` obeys it, since the encoder used the same declaration.

Every mode string is a claim about Pillow's behaviour, so the tests pack a primary using the format's own shifts, decode through the resolved mode, and assert the pixel that comes back — asserting *which string we picked* would prove nothing. Two things fell out of testing that way: Pillow has `RGB;4B` and no mirror of it, so 444-with-red-high has no mode at all; and `cpixel_offset` is a byte offset while CPIXEL's placement rule is about value bits, so big-endian reverses which end the three bytes sit at. The first cut returned the same offset either way, which slices off a channel and reads the pad byte. Both are fixed here and corrected in the spec on #377.

Tested: 228 unit tests green, flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)