### PR TITLE
Fix VMWareClient raising AttributeError on any 20-byte packet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@
   - ``vncdo`` failures print to stderr as plain messages (@sibson, #395)
   - ``vncdo -v`` logs the pixel format it requests, beside the native format it already logged (@sibson, #394)
   - Fix screenshots shifted against any server whose first rectangle does not start at (0, 0) (@sibson)
+  - Fix ``VMWareClient`` raising ``AttributeError`` instead of detecting the VMware single-pixel update it exists to filter (@sibson, #400)
   - Local development moves from Makefile.venv + pip to uv; ``make`` targets run under ``uv run`` (@sibson, #383)
   - Fix ``make release`` tagging an empty version (@sibson, #382)
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -388,3 +388,30 @@ class TestImageMode(TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("error", FutureWarning)
             cli.updateCursor(0, 0, 4, 4, b"\x00" * (4 * 4 * 4), b"\x00" * 4)
+
+
+class TestVMWareClient(TestCase):
+
+    def setUp(self) -> None:
+        self.client = client.VMWareClient()
+        self.client.transport = mock.Mock()
+        self.client.factory = mock.Mock()
+        self.client.framebufferUpdateRequest = mock.Mock()  # type: ignore[assignment]
+        self.client._handler = mock.Mock()
+
+    def test_dataReceived_recognizes_single_pixel_update(self) -> None:
+        payload = struct.pack(
+            "!BxHHHHHixxxx",
+            client.rfb.MsgS2C.FRAMEBUFFER_UPDATE,
+            1,  # number-of-rectangles
+            0,  # x-position
+            0,  # y-position
+            1,  # width
+            1,  # height
+            client.rfb.Encoding.RAW,
+        )
+
+        self.client.dataReceived(payload)
+
+        self.client.framebufferUpdateRequest.assert_called_once_with()
+        self.client._handler.assert_called_once_with()

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -453,7 +453,7 @@ class VNCDoToolClient(rfb.RFBClient):
 
 
 class VMWareClient(VNCDoToolClient):
-    SINGLE_PIXLE_UPDATE = pack(
+    SINGLE_PIXEL_UPDATE = pack(
         "!BxHHHHHixxxx",
         rfb.MsgS2C.FRAMEBUFFER_UPDATE,  # message-type
         # padding


### PR DESCRIPTION
`VMWareClient` defines the class attribute as `SINGLE_PIXLE_UPDATE`, but its own `dataReceived` reads `self.SINGLE_PIXEL_UPDATE`. Any 20-byte packet reaching it raises `AttributeError` instead of being matched against the single-pixel-update signature the class exists to filter. Reachable through the public API via `VMWareFactory`, broken since 0a49cdc (2023-01-17).

Renames the definition to match the two use sites, and adds `TestVMWareClient` to `tests/unit/test_client.py`. The test builds its 20-byte payload with `struct.pack` rather than reusing the class constant, so it exercises the wire layout independently of the attribute it is checking.

Found by running mypy over the package for the first time — `flake8` cannot see attribute cross-references. Wiring mypy up is a separate PR.

Tested: `make test` 229 pass (2 expected failures), `flake8` clean. Verified the new test fails with the reported `AttributeError` before the rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
