### PR TITLE
Phase 2: decode Raw and CopyRect through a generator pump

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,7 @@
 2.0.0.dev0 (UNRELEASED)
 ----------------------
+  - Malformed or oversized pixel data now ends the session with a reported error instead of waiting for bytes that never arrive (@sibson)
+  - [BREAKING] ``RFBClient.updateRectangle`` takes the ``PixelFormat`` its bytes are in, and is called once per rectangle; ``fillRectangle`` is no longer called for Raw or CopyRect. Subclasses overriding either have been warned since 1.4.1, see #385 (@sibson)
   - Add ``vncdo --pixel-format FORMAT``, asking the server for ``bgrx8888``, ``rgbx8888``, or ``rgb565`` instead of accepting the format it announces (@sibson)
   - Any byte-aligned truecolor pixel format the server announces can now be captured, not just the five formats vncdotool used to recognize (@sibson)
   - ``vncdo`` failures print to stderr as plain messages (@sibson, #395)

--- a/specs/decoder-architecture.md
+++ b/specs/decoder-architecture.md
@@ -125,38 +125,45 @@ survives and decoders still reach into `client.bypp`, `client._zlib_stream` and
 `NeedMoreData(n)` to be re-run works until zlib — ZRLE and Tight streams live for
 the whole connection and cannot be replayed.
 
-## Three decoder shapes
+## Two decoder base classes
 
-Not every encoding produces pixels. Each decoder subclasses one of three shapes,
-distinguished by what it produces:
+Not every encoding produces pixels. A decoder subclasses whichever of these
+describes what it produces:
 
-| Shape | Consumes | Produces | Method it overrides | Encodings |
-|---|---|---|---|---|
-| `PixelDecoder` | bytes | fills a `RectBuffer` | `decodePixels` | Raw, RRE, CoRRE, Hextile, ZRLE, Tight |
-| `ClientDecoder` | bytes | calls a client method | `decodeForClient` | CopyRect, Cursor |
-| `ControlDecoder` | nothing | changes client state | `applyToClient` | DesktopSize, LastRect, QEMU extended key |
+| Base class | Produces | Method it overrides | Encodings |
+|---|---|---|---|
+| `PixelDecoder` | fills a `RectBuffer` the pump allocates and pastes | `decodePixels` | Raw, RRE, CoRRE, Hextile, ZRLE, Tight |
+| `ClientDecoder` | calls `copyRectangle` or `updateCursor` | `decodeForClient` | CopyRect, Cursor |
 
-The shapes are nominal base classes under one `Decoder`, which defines all three
-methods and raises `NotImplementedError` for the two a given shape does not use.
-Structural typing cannot express this: the three take different arguments but
+Both are nominal base classes under one `Decoder`, which defines both methods and
+raises `NotImplementedError` for the one a given subclass does not use.
+Structural typing cannot express this: the two take different arguments but
 `Protocol` matching compares method names, so every `PixelDecoder` satisfies
 `ClientDecoder` and the pump has to guess from the methods an object carries.
+
+The pseudo-encodings — DesktopSize, LastRect, QEMU extended key — are still on
+`rfb.py`'s own path and get their base class in phase 5, when there is a real one
+to design against. They consume no payload, which is a difference in arguments
+rather than in what they do to the client: DesktopSize resizes the framebuffer
+much as CopyRect writes to it. Whether that earns a third base class or is just a
+`ClientDecoder` whose generator returns without yielding is a question for the
+phase that migrates them.
 
 Each decoder class also names the encoding-type it decodes (RFC 6143 §7.6.1) as
 `ENCODING`, and the registry is built from a list of classes rather than a
 hand-written mapping, so a key cannot drift from the class it points at.
 
-### The shape is resolved once per connection
+### Which pump path a decoder takes is resolved once per connection
 
-`for_connection()` runs at connect time, so that is where each decoder is paired with the
-pump path its shape implies. A rectangle then costs one dict lookup and a call
-through a bound method — no `isinstance`, no probing for methods, and no shape
-tag to keep in step with the class hierarchy.
+`for_connection()` runs at connect time, so that is where each decoder is paired
+with the pump path its base class implies. A rectangle then costs one dict lookup
+and a call through a bound method — no `isinstance`, no probing for methods, and
+no tag to keep in step with the class hierarchy.
 
 Decoders depend on nothing from `rfb.py`: the pump keeps `_rectBuffer`,
-`_pumpBlock` and `_doConnection` to itself, and the per-shape entry points that
-use them — `_pumpPixels`, `_pumpForClient`, `_pumpControl` — live with the pump
-rather than on the decoder.
+`_pumpBlock` and `_doConnection` to itself, and the entry points that use them —
+`_pumpPixels` and `_pumpForClient` — live with the pump rather than on the
+decoder.
 
 There is no separate sink object. The pump calls the existing client callbacks —
 `updateRectangle`, `copyRectangle`, `updateCursor` — which is the vocabulary the
@@ -173,9 +180,9 @@ padded to a whole number of bytes — `floor((width + 7) / 8)` — with the most
 significant bit of each byte representing the leftmost pixel and a 1-bit meaning
 the corresponding cursor pixel is valid.
 
-The genuine special cases are `ControlDecoder`: `LastRect` mutates the rectangle loop
-counter, and the QEMU extended key encoding mutates `negotiated_encodings` and
-removes the entry it just appended to `rectanglePos`.
+The genuine special cases are the pseudo-encodings phase 5 migrates: `LastRect`
+mutates the rectangle loop counter, and the QEMU extended key encoding mutates
+`negotiated_encodings` and removes the entry it just appended to `rectanglePos`.
 
 ## Pixel format is shared, not per-decoder
 
@@ -268,7 +275,7 @@ diagnosed disconnect. This is a larger user-facing win than the split itself.
 ```
 vncdotool/pixelformat.py         PixelFormat -> Pillow raw mode, CPIXEL/TPIXEL widths
 vncdotool/decoders/__init__.py   registry, built from the decoder classes
-vncdotool/decoders/base.py       Decoder and the three shape base classes
+vncdotool/decoders/base.py       Decoder, PixelDecoder, ClientDecoder
 vncdotool/decoders/buffer.py     RectBuffer
 vncdotool/decoders/{raw,rre,corre,hextile,zrle,cursor}.py
 vncdotool/decoders/control.py    DesktopSize, LastRect, QEMU extended key
@@ -576,8 +583,8 @@ or test depending on its wording cites a commit permalink rather than `master`.
 - No changes to authentication, negotiation, or transport.
 - No fix for cursor compositing being destructive — `drawCursor` pastes into
   `self.screen` and nothing erases the previous position, so stale pointers
-  persist where the server does not resend. Pre-existing, and the shape boundary
-  is drawn so fixing it later touches no decoder.
+  persist where the server does not resend. Pre-existing, and the boundary
+  between decoder and client is drawn so fixing it later touches no decoder.
 - No fix for `VNCDoToolClient.updateCursor`, where a zero-width or zero-height cursor sets
   `self.cursor = None` and then falls through to `Image.frombytes` with a zero
   dimension instead of returning. Worth a separate issue; it is a client bug, not

--- a/specs/decoder-architecture.md
+++ b/specs/decoder-architecture.md
@@ -154,8 +154,9 @@ through a bound method — no `isinstance`, no probing for methods, and no shape
 tag to keep in step with the class hierarchy.
 
 Decoders depend on nothing from `rfb.py`: the pump keeps `_rectBuffer`,
-`_pumpDecoder` and `_doConnection` to itself, and the per-shape drive methods
-that use them live with the pump rather than on the decoder.
+`_pumpBlock` and `_doConnection` to itself, and the per-shape entry points that
+use them — `_pumpPixels`, `_pumpForClient`, `_pumpControl` — live with the pump
+rather than on the decoder.
 
 There is no separate sink object. The pump calls the existing client callbacks —
 `updateRectangle`, `copyRectangle`, `updateCursor` — which is the vocabulary the

--- a/specs/decoder-architecture.md
+++ b/specs/decoder-architecture.md
@@ -127,14 +127,35 @@ the whole connection and cannot be replayed.
 
 ## Three decoder shapes
 
-Not every encoding produces pixels. The registry maps each encoding to one of
-three shapes, distinguished by what the decoder produces:
+Not every encoding produces pixels. Each decoder subclasses one of three shapes,
+distinguished by what it produces:
 
-| Shape | Consumes | Produces | Encodings |
-|---|---|---|---|
-| `PixelDecoder` | bytes | fills a `RectBuffer` | Raw, RRE, CoRRE, Hextile, ZRLE, Tight |
-| `ClientDecoder` | bytes | calls a client method | CopyRect, Cursor |
-| `ControlDecoder` | nothing | changes client state | DesktopSize, LastRect, QEMU extended key |
+| Shape | Consumes | Produces | Method it overrides | Encodings |
+|---|---|---|---|---|
+| `PixelDecoder` | bytes | fills a `RectBuffer` | `decodePixels` | Raw, RRE, CoRRE, Hextile, ZRLE, Tight |
+| `ClientDecoder` | bytes | calls a client method | `decodeForClient` | CopyRect, Cursor |
+| `ControlDecoder` | nothing | changes client state | `applyToClient` | DesktopSize, LastRect, QEMU extended key |
+
+The shapes are nominal base classes under one `Decoder`, which defines all three
+methods and raises `NotImplementedError` for the two a given shape does not use.
+Structural typing cannot express this: the three take different arguments but
+`Protocol` matching compares method names, so every `PixelDecoder` satisfies
+`ClientDecoder` and the pump has to guess from the methods an object carries.
+
+Each decoder class also names the encoding-type it decodes (RFC 6143 §7.6.1) as
+`ENCODING`, and the registry is built from a list of classes rather than a
+hand-written mapping, so a key cannot drift from the class it points at.
+
+### The shape is resolved once per connection
+
+`build()` runs at connect time, so that is where each decoder is paired with the
+pump path its shape implies. A rectangle then costs one dict lookup and a call
+through a bound method — no `isinstance`, no probing for methods, and no shape
+tag to keep in step with the class hierarchy.
+
+Decoders depend on nothing from `rfb.py`: the pump keeps `_rectBuffer`,
+`_pumpDecoder` and `_doConnection` to itself, and the per-shape drive methods
+that use them live with the pump rather than on the decoder.
 
 There is no separate sink object. The pump calls the existing client callbacks —
 `updateRectangle`, `copyRectangle`, `updateCursor` — which is the vocabulary the
@@ -245,7 +266,8 @@ diagnosed disconnect. This is a larger user-facing win than the split itself.
 
 ```
 vncdotool/pixelformat.py         PixelFormat -> Pillow raw mode, CPIXEL/TPIXEL widths
-vncdotool/decoders/__init__.py   registry, the three shape protocols
+vncdotool/decoders/__init__.py   registry, built from the decoder classes
+vncdotool/decoders/base.py       Decoder and the three shape base classes
 vncdotool/decoders/buffer.py     RectBuffer
 vncdotool/decoders/{raw,rre,corre,hextile,zrle,cursor}.py
 vncdotool/decoders/control.py    DesktopSize, LastRect, QEMU extended key
@@ -254,8 +276,9 @@ vncdotool/rfb.py                 negotiation, auth, message framing, the pump
 
 `SUPPORTED_ENCODINGS` stops being the set literal in `RFBClient` and derives
 from the registry, filterable per connection, which is R4. It is also what makes
-R1's zero-line `rfb.py` diff possible: registering an encoding is a line in
-`decoders/__init__.py`, and nothing has to tell `rfb.py` the encoding exists.
+R1's zero-line `rfb.py` diff possible: registering an encoding is a module beside
+the others and its class in the list `decoders/__init__.py` builds `DECODERS`
+from, and nothing has to tell `rfb.py` the encoding exists.
 
 Third-party decoder plugins via entry points are out of scope. Nobody ships
 out-of-tree VNC encodings; the registry is a dict.

--- a/specs/decoder-architecture.md
+++ b/specs/decoder-architecture.md
@@ -148,7 +148,7 @@ hand-written mapping, so a key cannot drift from the class it points at.
 
 ### The shape is resolved once per connection
 
-`build()` runs at connect time, so that is where each decoder is paired with the
+`for_connection()` runs at connect time, so that is where each decoder is paired with the
 pump path its shape implies. A rectangle then costs one dict lookup and a call
 through a bound method — no `isinstance`, no probing for methods, and no shape
 tag to keep in step with the class hierarchy.
@@ -277,9 +277,10 @@ vncdotool/rfb.py                 negotiation, auth, message framing, the pump
 
 `SUPPORTED_ENCODINGS` stops being the set literal in `RFBClient` and derives
 from the registry, filterable per connection, which is R4. It is also what makes
-R1's zero-line `rfb.py` diff possible: registering an encoding is a module beside
-the others and its class in the list `decoders/__init__.py` builds `DECODERS`
-from, and nothing has to tell `rfb.py` the encoding exists.
+R1's zero-line `rfb.py` diff possible. Registering an encoding means adding a
+module beside the other decoders and naming its class in the list that
+`decoders/__init__.py` builds `DECODERS` from; nothing tells `rfb.py` the
+encoding exists.
 
 Third-party decoder plugins via entry points are out of scope. Nobody ships
 out-of-tree VNC encodings; the registry is a dict.

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -185,7 +185,7 @@ class TestVNCDoToolClient(TestCase):
         data = mock.Mock()
         frombytes.return_value = client.Image.new("RGB", (100, 200), (10, 20, 30))
 
-        cli.updateRectangle(0, 0, 100, 200, data)
+        cli.updateRectangle(0, 0, 100, 200, data, cli.pixel_format)
 
         client.Image.frombytes.assert_called_once_with('RGB', (100, 200), data, 'raw', 'RGBX')
 
@@ -200,7 +200,7 @@ class TestVNCDoToolClient(TestCase):
 
         color = (200, 150, 50)
         data = (bytes(color) + b"\x00") * (10 * 10)
-        cli.updateRectangle(50, 30, 10, 10, data)
+        cli.updateRectangle(50, 30, 10, 10, data, cli.pixel_format)
 
         assert cli.screen is not None
         assert cli.screen.size == (300, 200)
@@ -215,7 +215,7 @@ class TestVNCDoToolClient(TestCase):
         cli.screen.size = (100, 100)
         data = mock.Mock()
 
-        cli.updateRectangle(20, 10, 50, 40, data)
+        cli.updateRectangle(20, 10, 50, 40, data, cli.pixel_format)
 
         client.Image.frombytes.assert_called_once_with('RGB', (50, 40), data, 'raw', 'RGBX')
 
@@ -453,7 +453,7 @@ class TestImageMode(TestCase):
 
         with warnings.catch_warnings():
             warnings.simplefilter("error", FutureWarning)
-            cli.updateRectangle(0, 0, 100, 200, mock.Mock())
+            cli.updateRectangle(0, 0, 100, 200, mock.Mock(), cli.pixel_format)
 
     def test_updateCursor_does_not_warn(self):
         cli = self.client

--- a/tests/unit/test_pump.py
+++ b/tests/unit/test_pump.py
@@ -1,8 +1,5 @@
-"""The pump: `_decodeRectangle`, `_rectBuffer`, `_pumpDecoder`, `_finishRectangle`.
-
-No reactor, no transport, no server -- protocol classes driven directly with
-a mocked Twisted transport. specs/decoder-architecture.md sections "Decoders
-are generators", "One paste per rectangle", "Errors, not hangs", and R6.
+"""specs/decoder-architecture.md sections "Decoders are generators", "One
+paste per rectangle", "Errors, not hangs", and R6.
 """
 from __future__ import annotations
 

--- a/tests/unit/test_pump.py
+++ b/tests/unit/test_pump.py
@@ -1,5 +1,5 @@
-"""specs/decoder-architecture.md sections "Decoders are generators", "One
-paste per rectangle", "Errors, not hangs", and R6.
+"""The pump is designed in specs/decoder-architecture.md, under "Decoders are
+generators", "One paste per rectangle" and "Errors, not hangs".
 """
 from __future__ import annotations
 
@@ -71,8 +71,11 @@ class TestSegmentation(TestCase):
 
 
 class TestDecodeErrorHandling(TestCase):
+    def setUp(self) -> None:
+        self.cli = make_pump_client()
+
     def test_decode_error_reports_and_disconnects(self) -> None:
-        cli = make_pump_client()
+        cli = self.cli
         cli.vncProtocolError = mock.Mock()
 
         def failing() -> object:
@@ -87,8 +90,11 @@ class TestDecodeErrorHandling(TestCase):
 
 
 class TestControlDecoders(TestCase):
+    def setUp(self) -> None:
+        self.cli = make_pump_client()
+
     def test_a_control_decoder_applies_and_the_loop_continues(self) -> None:
-        cli = make_pump_client()
+        cli = self.cli
         cli._doConnection = mock.Mock()
         applied = []
 
@@ -103,8 +109,11 @@ class TestControlDecoders(TestCase):
 
 
 class TestMultiYieldDecoders(TestCase):
+    def setUp(self) -> None:
+        self.cli = make_pump_client()
+
     def test_a_decoder_is_resumed_with_each_block_in_turn(self) -> None:
-        cli = make_pump_client()
+        cli = self.cli
         cli.updateRectangle = mock.Mock()
         seen = []
 
@@ -122,7 +131,7 @@ class TestMultiYieldDecoders(TestCase):
         cli.updateRectangle.assert_called_once()
 
     def test_malformed_input_that_raises_from_unpack_is_diagnosed(self) -> None:
-        cli = make_pump_client()
+        cli = self.cli
         cli.vncProtocolError = mock.Mock()
 
         class Bogus(decoders.PixelDecoder):
@@ -143,8 +152,11 @@ class TestAbort(TestCase):
     direct call cannot see a failure that forgot to disarm it.
     """
 
+    def setUp(self) -> None:
+        self.cli = make_pump_client()
+
     def _failing_client(self) -> rfb.RFBClient:
-        cli = make_pump_client()
+        cli = self.cli
         cli.vncProtocolError = mock.Mock()
         cli.updateRectangle = mock.Mock()
         cli.commitUpdate = mock.Mock()
@@ -176,7 +188,7 @@ class TestAbort(TestCase):
         self.assertEqual(cli.vncProtocolError.call_count, 1)
 
     def test_a_decoder_asking_for_a_negative_count_is_refused(self) -> None:
-        cli = make_pump_client()
+        cli = self.cli
         cli.vncProtocolError = mock.Mock()
 
         class Backwards(decoders.PixelDecoder):
@@ -190,8 +202,11 @@ class TestAbort(TestCase):
 
 
 class TestRectBufferValidation(TestCase):
+    def setUp(self) -> None:
+        self.cli = make_pump_client()
+
     def test_a_rectangle_larger_than_the_framebuffer_is_refused(self) -> None:
-        cli = make_pump_client()
+        cli = self.cli
         cli.width, cli.height = 64, 48
         cli.vncProtocolError = mock.Mock()
 
@@ -202,7 +217,7 @@ class TestRectBufferValidation(TestCase):
         cli.transport.loseConnection.assert_called_once()
 
     def test_a_zero_dimension_rectangle_is_not_an_error(self) -> None:
-        cli = make_pump_client()
+        cli = self.cli
         cli.vncProtocolError = mock.Mock()
 
         self.assertIsNotNone(cli._rectBuffer(0, 10))
@@ -214,7 +229,7 @@ class TestRectBufferValidation(TestCase):
         """The refusals above pass just as well against an off-by-one that
         rejects everything.
         """
-        cli = make_pump_client()
+        cli = self.cli
         cli.vncProtocolError = mock.Mock()
 
         self.assertIsNotNone(cli._rectBuffer(cli.MAX_DESKTOP_SIZE, 1))
@@ -227,8 +242,11 @@ class TestCopyRectPump(TestCase):
     blits framebuffer-to-framebuffer, never through `updateRectangle`.
     """
 
+    def setUp(self) -> None:
+        self.cli = make_pump_client()
+
     def test_copyRectangle_called_with_wire_source_and_no_paint(self) -> None:
-        cli = make_pump_client()
+        cli = self.cli
         cli.copyRectangle = mock.Mock()
         cli.updateRectangle = mock.Mock()
         decoder, _ = cli._decoders[Encoding.COPY_RECTANGLE]
@@ -245,8 +263,11 @@ class TestOnePastePerRectangle(TestCase):
     `PixelFormat` -- not called until the whole rectangle has arrived.
     """
 
+    def setUp(self) -> None:
+        self.cli = make_pump_client()
+
     def test_single_call_with_negotiated_pixel_format(self) -> None:
-        cli = make_pump_client()
+        cli = self.cli
         cli.updateRectangle = mock.Mock()
         decoder, _ = cli._decoders[Encoding.RAW]
         width, height = 4, 3
@@ -262,7 +283,7 @@ class TestOnePastePerRectangle(TestCase):
         )
 
     def test_the_rectangle_lands_where_the_wire_said(self) -> None:
-        cli = make_pump_client()
+        cli = self.cli
         cli.updateRectangle = mock.Mock()
         decoder, _ = cli._decoders[Encoding.RAW]
         pixels = bytes(range(2 * 2 * cli.bypp))
@@ -280,8 +301,11 @@ class TestRectBufferReuse(TestCase):
     reaches the shared backing (`decoders/buffer.py`).
     """
 
+    def setUp(self) -> None:
+        self.cli = make_pump_client()
+
     def test_smaller_rectangle_after_larger_gets_only_its_own_bytes(self) -> None:
-        cli = make_pump_client()
+        cli = self.cli
 
         big = cli._rectBuffer(4, 4)
         half = bytes([0xFF]) * (4 * 2 * cli.bypp)

--- a/tests/unit/test_pump.py
+++ b/tests/unit/test_pump.py
@@ -26,8 +26,15 @@ def make_client() -> client.VNCDoToolClient:
     return cli
 
 
+def drive(cli: rfb.RFBClient, decoder, x: int, y: int, width: int, height: int) -> None:
+    """Dispatch one rectangle the way `_handleRectangle` would, without the
+    registry: the client pairs a decoder with a drive method at connect time.
+    """
+    cli._driveFor(decoder)(decoder, x, y, width, height)
+
+
 def make_pump_client() -> rfb.RFBClient:
-    """A client in the state `_decodeRectangle` runs in."""
+    """A client in the state the drive methods run in."""
     cli = rfb.RFBClient()
     cli.transport = mock.Mock()
     cli.factory = mock.Mock()
@@ -89,7 +96,7 @@ class TestControlDecoders(TestCase):
             def applyToClient(self, client: object, rect: tuple) -> None:
                 applied.append(rect)
 
-        cli._decodeRectangle(Control(), 1, 2, 3, 4)
+        drive(cli, Control(), 1, 2, 3, 4)
 
         self.assertEqual(applied, [(1, 2, 3, 4)])
         cli._doConnection.assert_called_once()
@@ -107,7 +114,7 @@ class TestMultiYieldDecoders(TestCase):
                 seen.append((yield 3))
                 target.blit(0, 0, target.width, target.height, b"\x01" * (target.width * target.height * target.bypp))
 
-        cli._decodeRectangle(TwoStep(), 0, 0, 1, 1)
+        drive(cli, TwoStep(), 0, 0, 1, 1)
         cli.dataReceived(b"ab")
         cli.dataReceived(b"cde")
 
@@ -123,7 +130,7 @@ class TestMultiYieldDecoders(TestCase):
                 block = yield 2
                 unpack("!I", block)  # four bytes wanted, two yielded
 
-        cli._decodeRectangle(Bogus(), 0, 0, 1, 1)
+        drive(cli, Bogus(), 0, 0, 1, 1)
         cli.dataReceived(b"ab")
 
         cli.vncProtocolError.assert_called_once()
@@ -147,7 +154,7 @@ class TestAbort(TestCase):
                 yield 2
                 raise decoders.DecodeError("boom")
 
-        cli._decodeRectangle(Failing(), 0, 0, 2, 1)
+        drive(cli, Failing(), 0, 0, 2, 1)
         return cli
 
     def test_nothing_is_painted_after_a_failed_decode(self) -> None:
@@ -176,7 +183,7 @@ class TestAbort(TestCase):
             def decodePixels(self, target, pixel_format):
                 yield -8
 
-        cli._decodeRectangle(Backwards(), 0, 0, 1, 1)
+        drive(cli, Backwards(), 0, 0, 1, 1)
 
         cli.vncProtocolError.assert_called_once()
         cli.transport.loseConnection.assert_called_once()
@@ -224,9 +231,9 @@ class TestCopyRectPump(TestCase):
         cli = make_pump_client()
         cli.copyRectangle = mock.Mock()
         cli.updateRectangle = mock.Mock()
-        decoder = cli._decoders[Encoding.COPY_RECTANGLE]
+        decoder, _ = cli._decoders[Encoding.COPY_RECTANGLE]
 
-        cli._decodeRectangle(decoder, 5, 6, 10, 20)
+        drive(cli, decoder, 5, 6, 10, 20)
         cli.dataReceived(pack("!HH", 1, 2))  # srcx, srcy
 
         cli.copyRectangle.assert_called_once_with(1, 2, 5, 6, 10, 20)
@@ -241,11 +248,11 @@ class TestOnePastePerRectangle(TestCase):
     def test_single_call_with_negotiated_pixel_format(self) -> None:
         cli = make_pump_client()
         cli.updateRectangle = mock.Mock()
-        decoder = cli._decoders[Encoding.RAW]
+        decoder, _ = cli._decoders[Encoding.RAW]
         width, height = 4, 3
         pixels = bytes(range(width * height * cli.bypp))
 
-        cli._decodeRectangle(decoder, 0, 0, width, height)
+        drive(cli, decoder, 0, 0, width, height)
         cli.dataReceived(pixels[:5])
         cli.updateRectangle.assert_not_called()
         cli.dataReceived(pixels[5:])
@@ -257,10 +264,10 @@ class TestOnePastePerRectangle(TestCase):
     def test_the_rectangle_lands_where_the_wire_said(self) -> None:
         cli = make_pump_client()
         cli.updateRectangle = mock.Mock()
-        decoder = cli._decoders[Encoding.RAW]
+        decoder, _ = cli._decoders[Encoding.RAW]
         pixels = bytes(range(2 * 2 * cli.bypp))
 
-        cli._decodeRectangle(decoder, 7, 9, 2, 2)
+        drive(cli, decoder, 7, 9, 2, 2)
         cli.dataReceived(pixels)
 
         cli.updateRectangle.assert_called_once_with(7, 9, 2, 2, pixels, cli.pixel_format)

--- a/tests/unit/test_pump.py
+++ b/tests/unit/test_pump.py
@@ -155,30 +155,93 @@ class TestMultiYieldDecoders(TestCase):
         cli.transport.loseConnection.assert_called_once()
 
 
+class TestAbort(TestCase):
+    """A failed decode has to stop the parser, not just the transport.
+
+    Driven through `dataReceived` rather than by calling the pump: the
+    parked handler is only re-entered by `_handleExpected`'s loop, so a
+    direct call cannot see a failure that forgot to disarm it.
+    """
+
+    def _failing_client(self) -> rfb.RFBClient:
+        cli = make_pump_client()
+        cli.vncProtocolError = mock.Mock()
+        cli.updateRectangle = mock.Mock()
+        cli.commitUpdate = mock.Mock()
+
+        class Failing:
+            def decode(self, target, pixel_format):
+                yield 2
+                raise decoders.DecodeError("boom")
+
+            def output_format(self, pixel_format):
+                return pixel_format
+
+        cli._decodeRectangle(Failing(), 0, 0, 2, 1)
+        return cli
+
+    def test_nothing_is_painted_after_a_failed_decode(self) -> None:
+        cli = self._failing_client()
+
+        cli.dataReceived(b"ab" + b"CDEFGHIJKLMNOP")
+
+        cli.vncProtocolError.assert_called_once()
+        cli.updateRectangle.assert_not_called()
+        cli.commitUpdate.assert_not_called()
+
+    def test_bytes_arriving_after_a_failed_decode_are_discarded(self) -> None:
+        cli = self._failing_client()
+        cli.dataReceived(b"ab")
+
+        cli.dataReceived(b"more bytes the server had already sent")
+
+        cli.updateRectangle.assert_not_called()
+        self.assertEqual(cli.vncProtocolError.call_count, 1)
+
+    def test_a_decoder_asking_for_a_negative_count_is_refused(self) -> None:
+        cli = make_pump_client()
+        cli.vncProtocolError = mock.Mock()
+
+        class Backwards:
+            def decode(self, target, pixel_format):
+                yield -8
+
+            def output_format(self, pixel_format):
+                return pixel_format
+
+        cli._decodeRectangle(Backwards(), 0, 0, 1, 1)
+
+        cli.vncProtocolError.assert_called_once()
+        cli.transport.loseConnection.assert_called_once()
+
+
 class TestRectBufferValidation(TestCase):
     """A rectangle outside `MAX_DESKTOP_SIZE`, or with a zero dimension, is
     refused before any buffer is allocated.
     """
 
-    def test_oversized_rectangle_is_refused(self) -> None:
+    def test_a_rectangle_larger_than_the_framebuffer_is_refused(self) -> None:
         cli = make_pump_client()
+        cli.width, cli.height = 64, 48
         cli.vncProtocolError = mock.Mock()
 
-        result = cli._rectBuffer(cli.MAX_DESKTOP_SIZE + 1, 10)
+        result = cli._rectBuffer(65, 10)
 
         self.assertIsNone(result)
         cli.vncProtocolError.assert_called_once()
         cli.transport.loseConnection.assert_called_once()
 
-    def test_zero_width_rectangle_is_refused(self) -> None:
+    def test_a_zero_dimension_rectangle_is_not_an_error(self) -> None:
+        """It carries no payload, and the decoders this replaced passed it
+        through rather than failing the session.
+        """
         cli = make_pump_client()
         cli.vncProtocolError = mock.Mock()
 
-        result = cli._rectBuffer(0, 10)
+        self.assertIsNotNone(cli._rectBuffer(0, 10))
+        self.assertIsNotNone(cli._rectBuffer(10, 0))
 
-        self.assertIsNone(result)
-        cli.vncProtocolError.assert_called_once()
-        cli.transport.loseConnection.assert_called_once()
+        cli.vncProtocolError.assert_not_called()
 
     def test_the_largest_allowed_rectangle_is_accepted(self) -> None:
         """The refusals above pass just as well against an off-by-one that
@@ -191,16 +254,6 @@ class TestRectBufferValidation(TestCase):
 
         cli.vncProtocolError.assert_not_called()
 
-    def test_zero_height_rectangle_is_refused(self) -> None:
-        cli = make_pump_client()
-        cli.vncProtocolError = mock.Mock()
-
-        result = cli._rectBuffer(10, 0)
-
-        self.assertIsNone(result)
-        cli.vncProtocolError.assert_called_once()
-        cli.transport.loseConnection.assert_called_once()
-
 
 class TestCopyRectPump(TestCase):
     """CopyRect is a `ClientDecoder`: it reads its source off the wire and
@@ -211,7 +264,7 @@ class TestCopyRectPump(TestCase):
         cli = make_pump_client()
         cli.copyRectangle = mock.Mock()
         cli.updateRectangle = mock.Mock()
-        decoder = decoders.DECODERS[Encoding.COPY_RECTANGLE]
+        decoder = cli._decoders[Encoding.COPY_RECTANGLE]
 
         cli._decodeRectangle(decoder, 5, 6, 10, 20)
         cli.dataReceived(pack("!HH", 1, 2))  # srcx, srcy
@@ -228,7 +281,7 @@ class TestOnePastePerRectangle(TestCase):
     def test_single_call_with_negotiated_pixel_format(self) -> None:
         cli = make_pump_client()
         cli.updateRectangle = mock.Mock()
-        decoder = decoders.DECODERS[Encoding.RAW]
+        decoder = cli._decoders[Encoding.RAW]
         width, height = 4, 3
         pixels = bytes(range(width * height * cli.bypp))
 
@@ -244,7 +297,7 @@ class TestOnePastePerRectangle(TestCase):
     def test_the_rectangle_lands_where_the_wire_said(self) -> None:
         cli = make_pump_client()
         cli.updateRectangle = mock.Mock()
-        decoder = decoders.DECODERS[Encoding.RAW]
+        decoder = cli._decoders[Encoding.RAW]
         pixels = bytes(range(2 * 2 * cli.bypp))
 
         cli._decodeRectangle(decoder, 7, 9, 2, 2)

--- a/tests/unit/test_pump.py
+++ b/tests/unit/test_pump.py
@@ -89,25 +89,6 @@ class TestDecodeErrorHandling(TestCase):
         cli.transport.loseConnection.assert_called_once()
 
 
-class TestControlDecoders(TestCase):
-    def setUp(self) -> None:
-        self.cli = make_pump_client()
-
-    def test_a_control_decoder_applies_and_the_loop_continues(self) -> None:
-        cli = self.cli
-        cli._doConnection = mock.Mock()
-        applied = []
-
-        class Control(decoders.ControlDecoder):
-            def applyToClient(self, client: object, rect: tuple) -> None:
-                applied.append(rect)
-
-        pump(cli, Control(), 1, 2, 3, 4)
-
-        self.assertEqual(applied, [(1, 2, 3, 4)])
-        cli._doConnection.assert_called_once()
-
-
 class TestMultiYieldDecoders(TestCase):
     def setUp(self) -> None:
         self.cli = make_pump_client()

--- a/tests/unit/test_pump.py
+++ b/tests/unit/test_pump.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import gzip
 from pathlib import Path
-from struct import pack
+from struct import pack, unpack
 from unittest import TestCase, mock
 
 from vncdotool import client, decoders, rfb
@@ -30,9 +30,7 @@ def make_client() -> client.VNCDoToolClient:
 
 
 def make_pump_client() -> rfb.RFBClient:
-    """A client parked in the post-handshake byte-parking state, with no
-    in-flight framebuffer update -- the state `_decodeRectangle` runs in.
-    """
+    """A client in the state `_decodeRectangle` runs in."""
     cli = rfb.RFBClient()
     cli.transport = mock.Mock()
     cli.factory = mock.Mock()
@@ -50,9 +48,8 @@ def raw_update(x: int, y: int, width: int, height: int, pixels: bytes) -> bytes:
 
 
 class TestSegmentation(TestCase):
-    """The pump satisfies every yielded byte count in full, so a decoder
-    never sees a partial buffer -- whole or byte-at-a-time input decodes
-    identically.
+    """The pump satisfies every yielded count in full, so a decoder never
+    sees a partial buffer.
     """
 
     def test_byte_at_a_time_matches_a_single_call(self) -> None:
@@ -93,6 +90,71 @@ class TestDecodeErrorHandling(TestCase):
         cli.transport.loseConnection.assert_called_once()
 
 
+class TestControlDecoders(TestCase):
+    """The third shape: consumes no bytes, changes client state, and must
+    still hand the rectangle loop back.
+    """
+
+    def test_a_control_decoder_applies_and_the_loop_continues(self) -> None:
+        cli = make_pump_client()
+        cli._doConnection = mock.Mock()
+        applied = []
+
+        class Control:
+            def apply(self, client: object, rect: tuple) -> None:
+                applied.append(rect)
+
+        cli._decodeRectangle(Control(), 1, 2, 3, 4)
+
+        self.assertEqual(applied, [(1, 2, 3, 4)])
+        cli._doConnection.assert_called_once()
+
+
+class TestMultiYieldDecoders(TestCase):
+    """Raw and CopyRect each yield once, so nothing else exercises resuming
+    a generator that is still mid-decode.
+    """
+
+    def test_a_decoder_is_resumed_with_each_block_in_turn(self) -> None:
+        cli = make_pump_client()
+        cli.updateRectangle = mock.Mock()
+        seen = []
+
+        class TwoStep:
+            def decode(self, target, pixel_format):
+                seen.append((yield 2))
+                seen.append((yield 3))
+                target.blit(0, 0, target.width, target.height, b"\x01" * (target.width * target.height * target.bypp))
+
+            def output_format(self, pixel_format):
+                return pixel_format
+
+        cli._decodeRectangle(TwoStep(), 0, 0, 1, 1)
+        cli.dataReceived(b"ab")
+        cli.dataReceived(b"cde")
+
+        self.assertEqual(seen, [b"ab", b"cde"])
+        cli.updateRectangle.assert_called_once()
+
+    def test_malformed_input_that_raises_from_unpack_is_diagnosed(self) -> None:
+        cli = make_pump_client()
+        cli.vncProtocolError = mock.Mock()
+
+        class Bogus:
+            def decode(self, target, pixel_format):
+                block = yield 2
+                unpack("!I", block)  # four bytes wanted, two yielded
+
+            def output_format(self, pixel_format):
+                return pixel_format
+
+        cli._decodeRectangle(Bogus(), 0, 0, 1, 1)
+        cli.dataReceived(b"ab")
+
+        cli.vncProtocolError.assert_called_once()
+        cli.transport.loseConnection.assert_called_once()
+
+
 class TestRectBufferValidation(TestCase):
     """A rectangle outside `MAX_DESKTOP_SIZE`, or with a zero dimension, is
     refused before any buffer is allocated.
@@ -117,6 +179,17 @@ class TestRectBufferValidation(TestCase):
         self.assertIsNone(result)
         cli.vncProtocolError.assert_called_once()
         cli.transport.loseConnection.assert_called_once()
+
+    def test_the_largest_allowed_rectangle_is_accepted(self) -> None:
+        """The refusals above pass just as well against an off-by-one that
+        rejects everything.
+        """
+        cli = make_pump_client()
+        cli.vncProtocolError = mock.Mock()
+
+        self.assertIsNotNone(cli._rectBuffer(cli.MAX_DESKTOP_SIZE, 1))
+
+        cli.vncProtocolError.assert_not_called()
 
     def test_zero_height_rectangle_is_refused(self) -> None:
         cli = make_pump_client()
@@ -168,16 +241,23 @@ class TestOnePastePerRectangle(TestCase):
             0, 0, width, height, pixels, cli.pixel_format
         )
 
+    def test_the_rectangle_lands_where_the_wire_said(self) -> None:
+        cli = make_pump_client()
+        cli.updateRectangle = mock.Mock()
+        decoder = decoders.DECODERS[Encoding.RAW]
+        pixels = bytes(range(2 * 2 * cli.bypp))
+
+        cli._decodeRectangle(decoder, 7, 9, 2, 2)
+        cli.dataReceived(pixels)
+
+        cli.updateRectangle.assert_called_once_with(7, 9, 2, 2, pixels, cli.pixel_format)
+
 
 class TestRectBufferReuse(TestCase):
-    """`_rectBuffer` reuses `_rect_backing` at its high-water mark; a smaller
-    rectangle after a larger one must read back only its own bytes, not
-    whatever the larger one left behind in the shared backing.
+    """A smaller rectangle after a larger one reads back only its own bytes.
 
-    Splits each rectangle's fill into two `blit` calls so the write goes
-    through the shared backing array rather than a decoder's single
-    whole-rectangle blit, which `RectBuffer` short-circuits without ever
-    touching the backing (see `decoders/buffer.py`).
+    Two blits per rectangle, because a single whole-rectangle blit never
+    reaches the shared backing (`decoders/buffer.py`).
     """
 
     def test_smaller_rectangle_after_larger_gets_only_its_own_bytes(self) -> None:

--- a/tests/unit/test_pump.py
+++ b/tests/unit/test_pump.py
@@ -232,9 +232,6 @@ class TestRectBufferValidation(TestCase):
         cli.transport.loseConnection.assert_called_once()
 
     def test_a_zero_dimension_rectangle_is_not_an_error(self) -> None:
-        """It carries no payload, and the decoders this replaced passed it
-        through rather than failing the session.
-        """
         cli = make_pump_client()
         cli.vncProtocolError = mock.Mock()
 

--- a/tests/unit/test_pump.py
+++ b/tests/unit/test_pump.py
@@ -45,10 +45,6 @@ def raw_update(x: int, y: int, width: int, height: int, pixels: bytes) -> bytes:
 
 
 class TestSegmentation(TestCase):
-    """The pump satisfies every yielded count in full, so a decoder never
-    sees a partial buffer.
-    """
-
     def test_byte_at_a_time_matches_a_single_call(self) -> None:
         init = gzip.decompress((FIXTURE / "init.bin.gz").read_bytes())
         step = gzip.decompress(next(iter(sorted(FIXTURE.glob("step-*.bin.gz")))).read_bytes())
@@ -68,10 +64,6 @@ class TestSegmentation(TestCase):
 
 
 class TestDecodeErrorHandling(TestCase):
-    """R6: a decoder that cannot make sense of its input is a diagnosed
-    disconnect, not a hang.
-    """
-
     def test_decode_error_reports_and_disconnects(self) -> None:
         cli = make_pump_client()
         cli.vncProtocolError = mock.Mock()
@@ -88,10 +80,6 @@ class TestDecodeErrorHandling(TestCase):
 
 
 class TestControlDecoders(TestCase):
-    """The third shape: consumes no bytes, changes client state, and must
-    still hand the rectangle loop back.
-    """
-
     def test_a_control_decoder_applies_and_the_loop_continues(self) -> None:
         cli = make_pump_client()
         cli._doConnection = mock.Mock()
@@ -108,10 +96,6 @@ class TestControlDecoders(TestCase):
 
 
 class TestMultiYieldDecoders(TestCase):
-    """Raw and CopyRect each yield once, so nothing else exercises resuming
-    a generator that is still mid-decode.
-    """
-
     def test_a_decoder_is_resumed_with_each_block_in_turn(self) -> None:
         cli = make_pump_client()
         cli.updateRectangle = mock.Mock()
@@ -153,9 +137,7 @@ class TestMultiYieldDecoders(TestCase):
 
 
 class TestAbort(TestCase):
-    """A failed decode has to stop the parser, not just the transport.
-
-    Driven through `dataReceived` rather than by calling the pump: the
+    """Driven through `dataReceived` rather than by calling the pump: the
     parked handler is only re-entered by `_handleExpected`'s loop, so a
     direct call cannot see a failure that forgot to disarm it.
     """
@@ -213,10 +195,6 @@ class TestAbort(TestCase):
 
 
 class TestRectBufferValidation(TestCase):
-    """A rectangle outside `MAX_DESKTOP_SIZE`, or with a zero dimension, is
-    refused before any buffer is allocated.
-    """
-
     def test_a_rectangle_larger_than_the_framebuffer_is_refused(self) -> None:
         cli = make_pump_client()
         cli.width, cli.height = 64, 48

--- a/tests/unit/test_pump.py
+++ b/tests/unit/test_pump.py
@@ -85,8 +85,8 @@ class TestControlDecoders(TestCase):
         cli._doConnection = mock.Mock()
         applied = []
 
-        class Control:
-            def apply(self, client: object, rect: tuple) -> None:
+        class Control(decoders.ControlDecoder):
+            def applyToClient(self, client: object, rect: tuple) -> None:
                 applied.append(rect)
 
         cli._decodeRectangle(Control(), 1, 2, 3, 4)
@@ -101,14 +101,11 @@ class TestMultiYieldDecoders(TestCase):
         cli.updateRectangle = mock.Mock()
         seen = []
 
-        class TwoStep:
-            def decode(self, target, pixel_format):
+        class TwoStep(decoders.PixelDecoder):
+            def decodePixels(self, target, pixel_format):
                 seen.append((yield 2))
                 seen.append((yield 3))
                 target.blit(0, 0, target.width, target.height, b"\x01" * (target.width * target.height * target.bypp))
-
-            def output_format(self, pixel_format):
-                return pixel_format
 
         cli._decodeRectangle(TwoStep(), 0, 0, 1, 1)
         cli.dataReceived(b"ab")
@@ -121,13 +118,10 @@ class TestMultiYieldDecoders(TestCase):
         cli = make_pump_client()
         cli.vncProtocolError = mock.Mock()
 
-        class Bogus:
-            def decode(self, target, pixel_format):
+        class Bogus(decoders.PixelDecoder):
+            def decodePixels(self, target, pixel_format):
                 block = yield 2
                 unpack("!I", block)  # four bytes wanted, two yielded
-
-            def output_format(self, pixel_format):
-                return pixel_format
 
         cli._decodeRectangle(Bogus(), 0, 0, 1, 1)
         cli.dataReceived(b"ab")
@@ -148,13 +142,10 @@ class TestAbort(TestCase):
         cli.updateRectangle = mock.Mock()
         cli.commitUpdate = mock.Mock()
 
-        class Failing:
-            def decode(self, target, pixel_format):
+        class Failing(decoders.PixelDecoder):
+            def decodePixels(self, target, pixel_format):
                 yield 2
                 raise decoders.DecodeError("boom")
-
-            def output_format(self, pixel_format):
-                return pixel_format
 
         cli._decodeRectangle(Failing(), 0, 0, 2, 1)
         return cli
@@ -181,12 +172,9 @@ class TestAbort(TestCase):
         cli = make_pump_client()
         cli.vncProtocolError = mock.Mock()
 
-        class Backwards:
-            def decode(self, target, pixel_format):
+        class Backwards(decoders.PixelDecoder):
+            def decodePixels(self, target, pixel_format):
                 yield -8
-
-            def output_format(self, pixel_format):
-                return pixel_format
 
         cli._decodeRectangle(Backwards(), 0, 0, 1, 1)
 

--- a/tests/unit/test_pump.py
+++ b/tests/unit/test_pump.py
@@ -1,0 +1,199 @@
+"""The pump: `_decodeRectangle`, `_rectBuffer`, `_pumpDecoder`, `_finishRectangle`.
+
+No reactor, no transport, no server -- protocol classes driven directly with
+a mocked Twisted transport. specs/decoder-architecture.md sections "Decoders
+are generators", "One paste per rectangle", "Errors, not hangs", and R6.
+"""
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+from struct import pack
+from unittest import TestCase, mock
+
+from vncdotool import client, decoders, rfb
+from vncdotool.const import Encoding
+
+FIXTURE = (
+    Path(__file__).resolve().parent
+    / "fixtures" / "goldens" / "tigervnc-raw-bgrx8888"
+)
+
+
+def make_client() -> client.VNCDoToolClient:
+    cli = client.VNCDoToolClient()
+    cli.transport = mock.Mock()
+    cli.factory = mock.Mock()
+    cli.factory.shared = 0
+    cli.factory.password = None
+    return cli
+
+
+def make_pump_client() -> rfb.RFBClient:
+    """A client parked in the post-handshake byte-parking state, with no
+    in-flight framebuffer update -- the state `_decodeRectangle` runs in.
+    """
+    cli = rfb.RFBClient()
+    cli.transport = mock.Mock()
+    cli.factory = mock.Mock()
+    cli._handler = cli._handleExpected
+    cli.rectangles = 0
+    cli.rectanglePos = []
+    return cli
+
+
+def raw_update(x: int, y: int, width: int, height: int, pixels: bytes) -> bytes:
+    """A FramebufferUpdate holding one Raw rectangle. RFC 6143 7.6.1, 7.7.1."""
+    header = pack("!BxH", 0, 1)  # msg-type, padding, number-of-rectangles
+    rect_header = pack("!HHHHi", x, y, width, height, Encoding.RAW)
+    return header + rect_header + pixels
+
+
+class TestSegmentation(TestCase):
+    """The pump satisfies every yielded byte count in full, so a decoder
+    never sees a partial buffer -- whole or byte-at-a-time input decodes
+    identically.
+    """
+
+    def test_byte_at_a_time_matches_a_single_call(self) -> None:
+        init = gzip.decompress((FIXTURE / "init.bin.gz").read_bytes())
+        step = gzip.decompress(next(iter(sorted(FIXTURE.glob("step-*.bin.gz")))).read_bytes())
+
+        whole = make_client()
+        whole.dataReceived(init)
+        whole.dataReceived(step)
+
+        trickled = make_client()
+        trickled.dataReceived(init)
+        for i in range(len(step)):
+            trickled.dataReceived(step[i:i + 1])
+
+        assert whole.screen is not None
+        assert trickled.screen is not None
+        self.assertEqual(trickled.screen.tobytes(), whole.screen.tobytes())
+
+
+class TestDecodeErrorHandling(TestCase):
+    """R6: a decoder that cannot make sense of its input is a diagnosed
+    disconnect, not a hang.
+    """
+
+    def test_decode_error_reports_and_disconnects(self) -> None:
+        cli = make_pump_client()
+        cli.vncProtocolError = mock.Mock()
+
+        def failing() -> object:
+            raise decoders.DecodeError("bogus subencoding")
+            yield  # pragma: no cover - never reached
+
+        cli._pumpDecoder(None, failing(), None)
+
+        cli.vncProtocolError.assert_called_once()
+        self.assertIn("bogus subencoding", cli.vncProtocolError.call_args.args[0])
+        cli.transport.loseConnection.assert_called_once()
+
+
+class TestRectBufferValidation(TestCase):
+    """A rectangle outside `MAX_DESKTOP_SIZE`, or with a zero dimension, is
+    refused before any buffer is allocated.
+    """
+
+    def test_oversized_rectangle_is_refused(self) -> None:
+        cli = make_pump_client()
+        cli.vncProtocolError = mock.Mock()
+
+        result = cli._rectBuffer(cli.MAX_DESKTOP_SIZE + 1, 10)
+
+        self.assertIsNone(result)
+        cli.vncProtocolError.assert_called_once()
+        cli.transport.loseConnection.assert_called_once()
+
+    def test_zero_width_rectangle_is_refused(self) -> None:
+        cli = make_pump_client()
+        cli.vncProtocolError = mock.Mock()
+
+        result = cli._rectBuffer(0, 10)
+
+        self.assertIsNone(result)
+        cli.vncProtocolError.assert_called_once()
+        cli.transport.loseConnection.assert_called_once()
+
+    def test_zero_height_rectangle_is_refused(self) -> None:
+        cli = make_pump_client()
+        cli.vncProtocolError = mock.Mock()
+
+        result = cli._rectBuffer(10, 0)
+
+        self.assertIsNone(result)
+        cli.vncProtocolError.assert_called_once()
+        cli.transport.loseConnection.assert_called_once()
+
+
+class TestCopyRectPump(TestCase):
+    """CopyRect is a `ClientDecoder`: it reads its source off the wire and
+    blits framebuffer-to-framebuffer, never through `updateRectangle`.
+    """
+
+    def test_copyRectangle_called_with_wire_source_and_no_paint(self) -> None:
+        cli = make_pump_client()
+        cli.copyRectangle = mock.Mock()
+        cli.updateRectangle = mock.Mock()
+        decoder = decoders.DECODERS[Encoding.COPY_RECTANGLE]
+
+        cli._decodeRectangle(decoder, 5, 6, 10, 20)
+        cli.dataReceived(pack("!HH", 1, 2))  # srcx, srcy
+
+        cli.copyRectangle.assert_called_once_with(1, 2, 5, 6, 10, 20)
+        cli.updateRectangle.assert_not_called()
+
+
+class TestOnePastePerRectangle(TestCase):
+    """One `updateRectangle` call per rectangle, carrying the negotiated
+    `PixelFormat` -- not called until the whole rectangle has arrived.
+    """
+
+    def test_single_call_with_negotiated_pixel_format(self) -> None:
+        cli = make_pump_client()
+        cli.updateRectangle = mock.Mock()
+        decoder = decoders.DECODERS[Encoding.RAW]
+        width, height = 4, 3
+        pixels = bytes(range(width * height * cli.bypp))
+
+        cli._decodeRectangle(decoder, 0, 0, width, height)
+        cli.dataReceived(pixels[:5])
+        cli.updateRectangle.assert_not_called()
+        cli.dataReceived(pixels[5:])
+
+        cli.updateRectangle.assert_called_once_with(
+            0, 0, width, height, pixels, cli.pixel_format
+        )
+
+
+class TestRectBufferReuse(TestCase):
+    """`_rectBuffer` reuses `_rect_backing` at its high-water mark; a smaller
+    rectangle after a larger one must read back only its own bytes, not
+    whatever the larger one left behind in the shared backing.
+
+    Splits each rectangle's fill into two `blit` calls so the write goes
+    through the shared backing array rather than a decoder's single
+    whole-rectangle blit, which `RectBuffer` short-circuits without ever
+    touching the backing (see `decoders/buffer.py`).
+    """
+
+    def test_smaller_rectangle_after_larger_gets_only_its_own_bytes(self) -> None:
+        cli = make_pump_client()
+
+        big = cli._rectBuffer(4, 4)
+        half = bytes([0xFF]) * (4 * 2 * cli.bypp)
+        big.blit(0, 0, 4, 2, half)
+        big.blit(0, 2, 4, 2, half)
+        self.assertEqual(big.tobytes(), bytes([0xFF]) * (4 * 4 * cli.bypp))
+
+        small = cli._rectBuffer(2, 2)
+        row = bytes([0xAA]) * (2 * 1 * cli.bypp)
+        small.blit(0, 0, 2, 1, row)
+        small.blit(0, 1, 2, 1, row)
+
+        expected = bytes([0xAA]) * (2 * 2 * cli.bypp)
+        self.assertEqual(small.tobytes(), expected)
+        self.assertEqual(len(small.tobytes()), 2 * 2 * cli.bypp)

--- a/tests/unit/test_pump.py
+++ b/tests/unit/test_pump.py
@@ -26,15 +26,15 @@ def make_client() -> client.VNCDoToolClient:
     return cli
 
 
-def drive(cli: rfb.RFBClient, decoder, x: int, y: int, width: int, height: int) -> None:
+def pump(cli: rfb.RFBClient, decoder, x: int, y: int, width: int, height: int) -> None:
     """Dispatch one rectangle the way `_handleRectangle` would, without the
-    registry: the client pairs a decoder with a drive method at connect time.
+    registry: the client pairs a decoder with a pump method at connect time.
     """
-    cli._driveFor(decoder)(decoder, x, y, width, height)
+    cli._pumpFor(decoder)(decoder, x, y, width, height)
 
 
 def make_pump_client() -> rfb.RFBClient:
-    """A client in the state the drive methods run in."""
+    """A client in the state the pump methods run in."""
     cli = rfb.RFBClient()
     cli.transport = mock.Mock()
     cli.factory = mock.Mock()
@@ -79,7 +79,7 @@ class TestDecodeErrorHandling(TestCase):
             raise decoders.DecodeError("bogus subencoding")
             yield  # pragma: no cover - never reached
 
-        cli._pumpDecoder(None, failing(), None)
+        cli._pumpBlock(None, failing(), None)
 
         cli.vncProtocolError.assert_called_once()
         self.assertIn("bogus subencoding", cli.vncProtocolError.call_args.args[0])
@@ -96,7 +96,7 @@ class TestControlDecoders(TestCase):
             def applyToClient(self, client: object, rect: tuple) -> None:
                 applied.append(rect)
 
-        drive(cli, Control(), 1, 2, 3, 4)
+        pump(cli, Control(), 1, 2, 3, 4)
 
         self.assertEqual(applied, [(1, 2, 3, 4)])
         cli._doConnection.assert_called_once()
@@ -114,7 +114,7 @@ class TestMultiYieldDecoders(TestCase):
                 seen.append((yield 3))
                 target.blit(0, 0, target.width, target.height, b"\x01" * (target.width * target.height * target.bypp))
 
-        drive(cli, TwoStep(), 0, 0, 1, 1)
+        pump(cli, TwoStep(), 0, 0, 1, 1)
         cli.dataReceived(b"ab")
         cli.dataReceived(b"cde")
 
@@ -130,7 +130,7 @@ class TestMultiYieldDecoders(TestCase):
                 block = yield 2
                 unpack("!I", block)  # four bytes wanted, two yielded
 
-        drive(cli, Bogus(), 0, 0, 1, 1)
+        pump(cli, Bogus(), 0, 0, 1, 1)
         cli.dataReceived(b"ab")
 
         cli.vncProtocolError.assert_called_once()
@@ -154,7 +154,7 @@ class TestAbort(TestCase):
                 yield 2
                 raise decoders.DecodeError("boom")
 
-        drive(cli, Failing(), 0, 0, 2, 1)
+        pump(cli, Failing(), 0, 0, 2, 1)
         return cli
 
     def test_nothing_is_painted_after_a_failed_decode(self) -> None:
@@ -183,7 +183,7 @@ class TestAbort(TestCase):
             def decodePixels(self, target, pixel_format):
                 yield -8
 
-        drive(cli, Backwards(), 0, 0, 1, 1)
+        pump(cli, Backwards(), 0, 0, 1, 1)
 
         cli.vncProtocolError.assert_called_once()
         cli.transport.loseConnection.assert_called_once()
@@ -233,7 +233,7 @@ class TestCopyRectPump(TestCase):
         cli.updateRectangle = mock.Mock()
         decoder, _ = cli._decoders[Encoding.COPY_RECTANGLE]
 
-        drive(cli, decoder, 5, 6, 10, 20)
+        pump(cli, decoder, 5, 6, 10, 20)
         cli.dataReceived(pack("!HH", 1, 2))  # srcx, srcy
 
         cli.copyRectangle.assert_called_once_with(1, 2, 5, 6, 10, 20)
@@ -252,7 +252,7 @@ class TestOnePastePerRectangle(TestCase):
         width, height = 4, 3
         pixels = bytes(range(width * height * cli.bypp))
 
-        drive(cli, decoder, 0, 0, width, height)
+        pump(cli, decoder, 0, 0, width, height)
         cli.dataReceived(pixels[:5])
         cli.updateRectangle.assert_not_called()
         cli.dataReceived(pixels[5:])
@@ -267,7 +267,7 @@ class TestOnePastePerRectangle(TestCase):
         decoder, _ = cli._decoders[Encoding.RAW]
         pixels = bytes(range(2 * 2 * cli.bypp))
 
-        drive(cli, decoder, 7, 9, 2, 2)
+        pump(cli, decoder, 7, 9, 2, 2)
         cli.dataReceived(pixels)
 
         cli.updateRectangle.assert_called_once_with(7, 9, 2, 2, pixels, cli.pixel_format)

--- a/tests/unit/test_rectbuffer.py
+++ b/tests/unit/test_rectbuffer.py
@@ -41,22 +41,22 @@ class TestRectBuffer(unittest.TestCase):
     def test_backing_is_reused(self):
         backing = bytearray(4)
         buf = RectBuffer(2, 2, 1, backing=backing)
-        buf.blit(0, 0, 2, 2, b"\x01\x02\x03\x04")
-        # written through the caller's array, not a copy of it
-        self.assertEqual(backing, b"\x01\x02\x03\x04")
+        # Partial, because a blit covering the whole rectangle is handed
+        # straight to the client and never reaches the array.
+        buf.blit(0, 0, 1, 2, b"\x01\x02")
+        self.assertEqual(backing, b"\x01\x00\x02\x00")
 
     def test_oversized_backing_leftover_bytes_excluded(self):
         backing = bytearray(16)
-        big = RectBuffer(4, 4, 1, backing=backing)
-        big.blit(0, 0, 4, 4, b"\xaa" * 16)
+        RectBuffer(4, 4, 1, backing=backing).fill(0, 0, 4, 4, b"\xaa")
 
         small = RectBuffer(2, 2, 1, backing=backing)
-        small.blit(0, 0, 2, 2, b"\x01\x02\x03\x04")
+        small.fill(0, 0, 2, 2, b"\x01")
 
-        self.assertEqual(small.tobytes(), b"\x01\x02\x03\x04")
+        self.assertEqual(small.tobytes(), b"\x01" * 4)
         # the previous rectangle's tail is still sitting in the backing array,
         # past what this smaller rectangle claims -- tobytes() must not leak it.
-        self.assertEqual(bytes(backing), b"\x01\x02\x03\x04" + b"\xaa" * 12)
+        self.assertEqual(bytes(backing), b"\x01" * 4 + b"\xaa" * 12)
 
     def test_backing_too_small_raises_value_error(self):
         with self.assertRaises(ValueError):

--- a/tests/unit/test_rectbuffer.py
+++ b/tests/unit/test_rectbuffer.py
@@ -58,6 +58,18 @@ class TestRectBuffer(unittest.TestCase):
         # past what this smaller rectangle claims -- tobytes() must not leak it.
         self.assertEqual(bytes(backing), b"\x01" * 4 + b"\xaa" * 12)
 
+    def test_a_partial_write_does_not_read_back_the_last_rectangle(self):
+        backing = bytearray(16)
+        RectBuffer(4, 4, 1, backing=backing).fill(0, 0, 4, 4, b"\xaa")
+
+        reused = RectBuffer(4, 4, 1, backing=backing)
+        reused.fill(1, 1, 2, 2, b"\x01")
+
+        self.assertEqual(
+            reused.tobytes(),
+            b"\x00" * 5 + b"\x01\x01" + b"\x00" * 2 + b"\x01\x01" + b"\x00" * 5,
+        )
+
     def test_backing_too_small_raises_value_error(self):
         with self.assertRaises(ValueError):
             RectBuffer(2, 2, 1, backing=bytearray(3))

--- a/tests/unit/test_rectbuffer.py
+++ b/tests/unit/test_rectbuffer.py
@@ -1,0 +1,117 @@
+import unittest
+
+from vncdotool.decoders.base import DecodeError
+from vncdotool.decoders.buffer import RectBuffer
+
+
+class TestRectBuffer(unittest.TestCase):
+    def test_full_rect_blit(self):
+        buf = RectBuffer(2, 2, 1)
+        pixels = b"\x01\x02\x03\x04"
+        buf.blit(0, 0, 2, 2, pixels)
+        self.assertEqual(buf.tobytes(), pixels)
+
+    def test_sub_rect_blit_lands_at_stride_offset(self):
+        # bypp=2 makes a stride mistake (e.g. using w instead of width*bypp)
+        # produce a visibly wrong offset rather than a coincidentally right one.
+        buf = RectBuffer(3, 3, 2)
+        buf.blit(1, 1, 1, 1, b"\xaa\xbb")
+        expected = b"\x00" * 8 + b"\xaa\xbb" + b"\x00" * 8
+        self.assertEqual(buf.tobytes(), expected)
+
+    def test_sub_rect_blit_multirow(self):
+        buf = RectBuffer(3, 3, 1)
+        # 2x2 block at (1, 0): rows "AB" / "CD"
+        buf.blit(1, 0, 2, 2, b"ABCD")
+        expected = b"\x00AB\x00CD\x00\x00\x00"
+        self.assertEqual(buf.tobytes(), expected)
+
+    def test_fill(self):
+        buf = RectBuffer(2, 3, 1)
+        buf.fill(0, 1, 2, 1, b"\x09")
+        expected = b"\x00\x00\x09\x09\x00\x00"
+        self.assertEqual(buf.tobytes(), expected)
+
+    def test_fill_sub_rect(self):
+        buf = RectBuffer(3, 2, 1)
+        buf.fill(1, 0, 2, 1, b"\x07")
+        expected = b"\x00\x07\x07\x00\x00\x00"
+        self.assertEqual(buf.tobytes(), expected)
+
+    def test_backing_is_reused(self):
+        backing = bytearray(4)
+        buf = RectBuffer(2, 2, 1, backing=backing)
+        buf.blit(0, 0, 2, 2, b"\x01\x02\x03\x04")
+        # written through the caller's array, not a copy of it
+        self.assertEqual(backing, b"\x01\x02\x03\x04")
+
+    def test_oversized_backing_leftover_bytes_excluded(self):
+        backing = bytearray(16)
+        big = RectBuffer(4, 4, 1, backing=backing)
+        big.blit(0, 0, 4, 4, b"\xaa" * 16)
+
+        small = RectBuffer(2, 2, 1, backing=backing)
+        small.blit(0, 0, 2, 2, b"\x01\x02\x03\x04")
+
+        self.assertEqual(small.tobytes(), b"\x01\x02\x03\x04")
+        # the previous rectangle's tail is still sitting in the backing array,
+        # past what this smaller rectangle claims -- tobytes() must not leak it.
+        self.assertEqual(bytes(backing), b"\x01\x02\x03\x04" + b"\xaa" * 12)
+
+    def test_backing_too_small_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            RectBuffer(2, 2, 1, backing=bytearray(3))
+
+    def test_blit_negative_x_raises_decode_error(self):
+        buf = RectBuffer(2, 2, 1)
+        with self.assertRaises(DecodeError):
+            buf.blit(-1, 0, 1, 1, b"\x01")
+
+    def test_blit_negative_y_raises_decode_error(self):
+        buf = RectBuffer(2, 2, 1)
+        with self.assertRaises(DecodeError):
+            buf.blit(0, -1, 1, 1, b"\x01")
+
+    def test_blit_negative_w_raises_decode_error(self):
+        buf = RectBuffer(2, 2, 1)
+        with self.assertRaises(DecodeError):
+            buf.blit(0, 0, -1, 1, b"")
+
+    def test_blit_negative_h_raises_decode_error(self):
+        buf = RectBuffer(2, 2, 1)
+        with self.assertRaises(DecodeError):
+            buf.blit(0, 0, 1, -1, b"")
+
+    def test_blit_past_right_edge_raises_decode_error(self):
+        buf = RectBuffer(2, 2, 1)
+        with self.assertRaises(DecodeError):
+            buf.blit(1, 0, 2, 1, b"\x01\x02")
+
+    def test_blit_past_bottom_edge_raises_decode_error(self):
+        buf = RectBuffer(2, 2, 1)
+        with self.assertRaises(DecodeError):
+            buf.blit(0, 1, 1, 2, b"\x01\x02")
+
+    def test_blit_wrong_length_pixels_raises_decode_error(self):
+        buf = RectBuffer(2, 2, 1)
+        with self.assertRaises(DecodeError):
+            buf.blit(0, 0, 2, 2, b"\x01\x02\x03")
+
+    def test_fill_negative_rect_raises_decode_error(self):
+        buf = RectBuffer(2, 2, 1)
+        with self.assertRaises(DecodeError):
+            buf.fill(0, 0, -1, 1, b"\x01")
+
+    def test_fill_past_edge_raises_decode_error(self):
+        buf = RectBuffer(2, 2, 1)
+        with self.assertRaises(DecodeError):
+            buf.fill(1, 1, 2, 2, b"\x01")
+
+    def test_fill_wrong_length_color_raises_decode_error(self):
+        buf = RectBuffer(2, 2, 2)
+        with self.assertRaises(DecodeError):
+            buf.fill(0, 0, 1, 1, b"\x01")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_rectbuffer.py
+++ b/tests/unit/test_rectbuffer.py
@@ -12,8 +12,7 @@ class TestRectBuffer(unittest.TestCase):
         self.assertEqual(buf.tobytes(), pixels)
 
     def test_sub_rect_blit_lands_at_stride_offset(self):
-        # bypp=2 makes a stride mistake (e.g. using w instead of width*bypp)
-        # produce a visibly wrong offset rather than a coincidentally right one.
+        # bypp=2 because at one byte per pixel a stride bug lands right by luck.
         buf = RectBuffer(3, 3, 2)
         buf.blit(1, 1, 1, 1, b"\xaa\xbb")
         expected = b"\x00" * 8 + b"\xaa\xbb" + b"\x00" * 8

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -70,6 +70,8 @@ class VNCDoToolClient(rfb.RFBClient):
     buttons = 0
     screen: Image.Image | None = None
     _image_mode = pixelformat.raw_mode(rfb.PixelFormat())
+    _raw_mode_format: rfb.PixelFormat | None = None
+    _raw_mode = ""
     deferred: Deferred | None = None
 
     cursor: Image.Image | None = None
@@ -304,6 +306,15 @@ class VNCDoToolClient(rfb.RFBClient):
         )
         return self._image_mode
 
+    def _rawModeFor(self, pixel_format: rfb.PixelFormat) -> str:
+        # Called once per rectangle. A PixelFormat is a frozen dataclass, so
+        # hashing one for a cache lookup costs more than the identity check
+        # a decoder handing back the same instance every time satisfies.
+        if pixel_format is not self._raw_mode_format:
+            self._raw_mode_format = pixel_format
+            self._raw_mode = pixelformat.raw_mode(pixel_format)
+        return self._raw_mode
+
     def setImageMode(self) -> None:
         """Check support for PixelFormats announced by server or select client supported alternative."""
         pixel_format = self.requested_pixel_format
@@ -391,7 +402,7 @@ class VNCDoToolClient(rfb.RFBClient):
 
         size = (width, height)
         update = Image.frombytes(
-            "RGB", size, data, "raw", pixelformat.raw_mode(pixel_format)
+            "RGB", size, data, "raw", self._rawModeFor(pixel_format)
         )
         if not self.screen:
             self.screen = Image.new("RGB", (self.width, self.height), "black")

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -377,14 +377,22 @@ class VNCDoToolClient(rfb.RFBClient):
         return self
 
     def updateRectangle(
-        self, x: int, y: int, width: int, height: int, data: bytes
+        self,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        data: bytes,
+        pixel_format: rfb.PixelFormat,
     ) -> None:
         # ignore empty updates
         if not data:
             return
 
         size = (width, height)
-        update = Image.frombytes("RGB", size, data, "raw", self._image_mode)
+        update = Image.frombytes(
+            "RGB", size, data, "raw", pixelformat.raw_mode(pixel_format)
+        )
         if not self.screen:
             self.screen = Image.new("RGB", (self.width, self.height), "black")
             self.screen.paste(update, (x, y))

--- a/vncdotool/decoders/__init__.py
+++ b/vncdotool/decoders/__init__.py
@@ -15,8 +15,11 @@ from .raw import RawDecoder
 # one connection (RFC 6143 section 7.7.6), so decoders cannot be shared
 # between them even though today's two hold no state.
 DECODERS: Dict[Encoding, Type[Decoder]] = {
-    Encoding.RAW: RawDecoder,
-    Encoding.COPY_RECTANGLE: CopyRectDecoder,
+    cls.ENCODING: cls
+    for cls in (
+        RawDecoder,
+        CopyRectDecoder,
+    )
 }
 
 

--- a/vncdotool/decoders/__init__.py
+++ b/vncdotool/decoders/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Dict, Type
 
 from ..const import Encoding
-from .base import ClientDecoder, ControlDecoder, DecodeError, Decoder, PixelDecoder
+from .base import ClientDecoder, DecodeError, Decoder, PixelDecoder
 from .buffer import RectBuffer
 from .copyrect import CopyRectDecoder
 from .raw import RawDecoder
@@ -26,7 +26,6 @@ def for_connection() -> Dict[Encoding, Decoder]:
 
 __all__ = [
     "ClientDecoder",
-    "ControlDecoder",
     "DECODERS",
     "DecodeError",
     "Decoder",

--- a/vncdotool/decoders/__init__.py
+++ b/vncdotool/decoders/__init__.py
@@ -3,15 +3,13 @@ rfb.py is not told the encoding exists. specs/decoder-architecture.md.
 """
 from __future__ import annotations
 
-from typing import Dict, Type, Union
+from typing import Dict, Type
 
 from ..const import Encoding
-from .base import ClientDecoder, ControlDecoder, DecodeError, PixelDecoder
+from .base import ClientDecoder, ControlDecoder, DecodeError, Decoder, PixelDecoder
 from .buffer import RectBuffer
 from .copyrect import CopyRectDecoder
 from .raw import RawDecoder
-
-Decoder = Union[PixelDecoder, ClientDecoder, ControlDecoder]
 
 # Classes, not instances: ZRLE and Tight own a zlib stream that lives for
 # one connection (RFC 6143 section 7.7.6), so decoders cannot be shared

--- a/vncdotool/decoders/__init__.py
+++ b/vncdotool/decoders/__init__.py
@@ -1,0 +1,31 @@
+"""The decoder registry.
+
+Adding an encoding is a module beside this one plus an entry in DECODERS;
+rfb.py is not told the encoding exists. specs/decoder-architecture.md.
+"""
+from __future__ import annotations
+
+from typing import Dict, Union
+
+from ..const import Encoding
+from .base import ClientDecoder, ControlDecoder, DecodeError, PixelDecoder
+from .buffer import RectBuffer
+from .copyrect import CopyRectDecoder
+from .raw import RawDecoder
+
+Decoder = Union[PixelDecoder, ClientDecoder, ControlDecoder]
+
+DECODERS: Dict[Encoding, Decoder] = {
+    Encoding.RAW: RawDecoder(),
+    Encoding.COPY_RECTANGLE: CopyRectDecoder(),
+}
+
+__all__ = [
+    "ClientDecoder",
+    "ControlDecoder",
+    "DECODERS",
+    "DecodeError",
+    "Decoder",
+    "PixelDecoder",
+    "RectBuffer",
+]

--- a/vncdotool/decoders/__init__.py
+++ b/vncdotool/decoders/__init__.py
@@ -1,6 +1,4 @@
-"""The decoder registry.
-
-Adding an encoding is a module beside this one plus an entry in DECODERS;
+"""Adding an encoding is a module beside this one plus an entry in DECODERS;
 rfb.py is not told the encoding exists. specs/decoder-architecture.md.
 """
 from __future__ import annotations

--- a/vncdotool/decoders/__init__.py
+++ b/vncdotool/decoders/__init__.py
@@ -1,6 +1,3 @@
-"""Adding an encoding is a module beside this one plus an entry in DECODERS;
-rfb.py is not told the encoding exists. specs/decoder-architecture.md.
-"""
 from __future__ import annotations
 
 from typing import Dict, Type
@@ -23,8 +20,7 @@ DECODERS: Dict[Encoding, Type[Decoder]] = {
 }
 
 
-def build() -> Dict[Encoding, Decoder]:
-    """One set of decoders, for one connection."""
+def for_connection() -> Dict[Encoding, Decoder]:
     return {encoding: cls() for encoding, cls in DECODERS.items()}
 
 
@@ -32,9 +28,9 @@ __all__ = [
     "ClientDecoder",
     "ControlDecoder",
     "DECODERS",
-    "build",
     "DecodeError",
     "Decoder",
     "PixelDecoder",
     "RectBuffer",
+    "for_connection",
 ]

--- a/vncdotool/decoders/__init__.py
+++ b/vncdotool/decoders/__init__.py
@@ -5,7 +5,7 @@ rfb.py is not told the encoding exists. specs/decoder-architecture.md.
 """
 from __future__ import annotations
 
-from typing import Dict, Union
+from typing import Dict, Type, Union
 
 from ..const import Encoding
 from .base import ClientDecoder, ControlDecoder, DecodeError, PixelDecoder
@@ -15,15 +15,25 @@ from .raw import RawDecoder
 
 Decoder = Union[PixelDecoder, ClientDecoder, ControlDecoder]
 
-DECODERS: Dict[Encoding, Decoder] = {
-    Encoding.RAW: RawDecoder(),
-    Encoding.COPY_RECTANGLE: CopyRectDecoder(),
+# Classes, not instances: ZRLE and Tight own a zlib stream that lives for
+# one connection (RFC 6143 section 7.7.6), so decoders cannot be shared
+# between them even though today's two hold no state.
+DECODERS: Dict[Encoding, Type[Decoder]] = {
+    Encoding.RAW: RawDecoder,
+    Encoding.COPY_RECTANGLE: CopyRectDecoder,
 }
+
+
+def build() -> Dict[Encoding, Decoder]:
+    """One set of decoders, for one connection."""
+    return {encoding: cls() for encoding, cls in DECODERS.items()}
+
 
 __all__ = [
     "ClientDecoder",
     "ControlDecoder",
     "DECODERS",
+    "build",
     "DecodeError",
     "Decoder",
     "PixelDecoder",

--- a/vncdotool/decoders/base.py
+++ b/vncdotool/decoders/base.py
@@ -1,0 +1,52 @@
+"""What every decoder is: an error, three shapes, and the rectangle they fill.
+
+specs/decoder-architecture.md is the design.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterator, Protocol, runtime_checkable
+
+if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+    from ..rfb import PixelFormat
+    from .buffer import RectBuffer
+
+
+class DecodeError(Exception):
+    """Malformed, oversized or unsupported encoded data."""
+
+
+@runtime_checkable
+class PixelDecoder(Protocol):
+    """Consumes bytes, fills a rect buffer."""
+
+    def decode(self, target: "RectBuffer", pixel_format: "PixelFormat") -> Iterator[int]:
+        ...
+
+    def output_format(self, pixel_format: "PixelFormat") -> "PixelFormat":
+        """The layout the bytes this decoder wrote are in.
+
+        The negotiated format for every encoding in use today; Tight's JPEG
+        and TPIXEL will differ.
+        """
+
+
+@runtime_checkable
+class ClientDecoder(Protocol):
+    """Consumes bytes, calls a client method.
+
+    CopyRect needs the screen rather than a rect buffer, and Cursor produces
+    an image and a mask rather than a rectangle.
+    """
+
+    def decode(
+        self, client: object, rect: tuple[int, int, int, int], pixel_format: "PixelFormat"
+    ) -> Iterator[int]:
+        ...
+
+
+@runtime_checkable
+class ControlDecoder(Protocol):
+    """Consumes nothing, changes client state."""
+
+    def apply(self, client: object, rect: tuple[int, int, int, int]) -> None:
+        ...

--- a/vncdotool/decoders/base.py
+++ b/vncdotool/decoders/base.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING, ClassVar, Iterator
 
 from ..const import Encoding
 
-if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+# rfb.py imports this package, so importing from it at runtime is a cycle.
+if TYPE_CHECKING:  # pragma: no cover
     from ..rfb import PixelFormat
     from .buffer import RectBuffer
 

--- a/vncdotool/decoders/base.py
+++ b/vncdotool/decoders/base.py
@@ -20,20 +20,14 @@ class PixelDecoder(Protocol):
         ...
 
     def output_format(self, pixel_format: "PixelFormat") -> "PixelFormat":
-        """The layout the bytes this decoder wrote are in.
-
-        The negotiated format for every encoding in use today; Tight's JPEG
-        and TPIXEL will differ.
+        """The layout the bytes this decoder wrote are in, which is not
+        always the negotiated one.
         """
 
 
 @runtime_checkable
 class ClientDecoder(Protocol):
-    """Consumes bytes, calls a client method.
-
-    CopyRect needs the screen rather than a rect buffer, and Cursor produces
-    an image and a mask rather than a rectangle.
-    """
+    """Consumes bytes, calls a client method."""
 
     def decode(
         self, client: object, rect: tuple[int, int, int, int], pixel_format: "PixelFormat"

--- a/vncdotool/decoders/base.py
+++ b/vncdotool/decoders/base.py
@@ -1,7 +1,9 @@
 """specs/decoder-architecture.md is the design."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, ClassVar, Iterator
+
+from ..const import Encoding
 
 if TYPE_CHECKING:  # pragma: no cover - imported for typing only
     from ..rfb import PixelFormat
@@ -16,6 +18,9 @@ class Decoder:
     """One encoding, in one of three shapes: a subclass overrides the one
     method its shape names, and the pump calls that method alone.
     """
+
+    # The encoding-type this decoder reads, RFC 6143 section 7.6.1.
+    ENCODING: ClassVar[Encoding]
 
     def decodePixels(
         self, target: "RectBuffer", pixel_format: "PixelFormat"

--- a/vncdotool/decoders/base.py
+++ b/vncdotool/decoders/base.py
@@ -1,7 +1,7 @@
 """specs/decoder-architecture.md is the design."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterator, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Iterator
 
 if TYPE_CHECKING:  # pragma: no cover - imported for typing only
     from ..rfb import PixelFormat
@@ -12,32 +12,38 @@ class DecodeError(Exception):
     """Malformed, oversized or unsupported encoded data."""
 
 
-@runtime_checkable
-class PixelDecoder(Protocol):
-    """Consumes bytes, fills a rect buffer."""
+class Decoder:
+    """One encoding, in one of three shapes: a subclass overrides the one
+    method its shape names, and the pump calls that method alone.
+    """
 
-    def decode(self, target: "RectBuffer", pixel_format: "PixelFormat") -> Iterator[int]:
-        ...
+    def decodePixels(
+        self, target: "RectBuffer", pixel_format: "PixelFormat"
+    ) -> Iterator[int]:
+        raise NotImplementedError
+
+    def decodeForClient(
+        self, client: object, rect: tuple[int, int, int, int], pixel_format: "PixelFormat"
+    ) -> Iterator[int]:
+        raise NotImplementedError
+
+    def applyToClient(self, client: object, rect: tuple[int, int, int, int]) -> None:
+        raise NotImplementedError
+
+
+class PixelDecoder(Decoder):
+    """Consumes bytes, fills a rect buffer."""
 
     def output_format(self, pixel_format: "PixelFormat") -> "PixelFormat":
         """The layout the bytes this decoder wrote are in, which is not
         always the negotiated one.
         """
+        return pixel_format
 
 
-@runtime_checkable
-class ClientDecoder(Protocol):
+class ClientDecoder(Decoder):
     """Consumes bytes, calls a client method."""
 
-    def decode(
-        self, client: object, rect: tuple[int, int, int, int], pixel_format: "PixelFormat"
-    ) -> Iterator[int]:
-        ...
 
-
-@runtime_checkable
-class ControlDecoder(Protocol):
+class ControlDecoder(Decoder):
     """Consumes nothing, changes client state."""
-
-    def apply(self, client: object, rect: tuple[int, int, int, int]) -> None:
-        ...

--- a/vncdotool/decoders/base.py
+++ b/vncdotool/decoders/base.py
@@ -16,8 +16,8 @@ class DecodeError(Exception):
 
 
 class Decoder:
-    """One encoding, in one of three shapes: a subclass overrides the one
-    method its shape names, and the pump calls that method alone.
+    """One encoding: a subclass overrides the one method its base class names,
+    and the pump calls that method alone.
     """
 
     # The encoding-type this decoder reads, RFC 6143 section 7.6.1.
@@ -33,9 +33,6 @@ class Decoder:
     ) -> Iterator[int]:
         raise NotImplementedError
 
-    def applyToClient(self, client: object, rect: tuple[int, int, int, int]) -> None:
-        raise NotImplementedError
-
 
 class PixelDecoder(Decoder):
     """Consumes bytes, fills a rect buffer."""
@@ -49,7 +46,3 @@ class PixelDecoder(Decoder):
 
 class ClientDecoder(Decoder):
     """Consumes bytes, calls a client method."""
-
-
-class ControlDecoder(Decoder):
-    """Consumes nothing, changes client state."""

--- a/vncdotool/decoders/base.py
+++ b/vncdotool/decoders/base.py
@@ -1,7 +1,4 @@
-"""What every decoder is: an error, three shapes, and the rectangle they fill.
-
-specs/decoder-architecture.md is the design.
-"""
+"""specs/decoder-architecture.md is the design."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterator, Protocol, runtime_checkable

--- a/vncdotool/decoders/buffer.py
+++ b/vncdotool/decoders/buffer.py
@@ -18,6 +18,10 @@ class RectBuffer:
             raise ValueError(f"backing too small: need {needed} bytes, got {len(backing)}")
         self._backing = backing
         self._nbytes = needed
+        # A decoder that fills the whole rectangle in one blit -- Raw, every
+        # update -- hands over a buffer we can pass straight to the client,
+        # so hold the reference instead of copying it in and back out.
+        self._whole: bytes | None = None
 
     def _check_rect(self, x: int, y: int, w: int, h: int) -> None:
         if x < 0 or y < 0 or w < 0 or h < 0:
@@ -33,6 +37,11 @@ class RectBuffer:
         expected = w * h * self.bypp
         if len(pixels) != expected:
             raise DecodeError(f"blit expected {expected} bytes, got {len(pixels)}")
+
+        if x == 0 and y == 0 and w == self.width and h == self.height:
+            self._whole = bytes(pixels)
+            return
+        self._materialize()
 
         stride = self.width * self.bypp
         row_bytes = w * self.bypp
@@ -54,6 +63,7 @@ class RectBuffer:
         self._check_rect(x, y, w, h)
         if len(color) != self.bypp:
             raise DecodeError(f"fill color must be {self.bypp} bytes, got {len(color)}")
+        self._materialize()
 
         stride = self.width * self.bypp
         row_bytes = w * self.bypp
@@ -70,5 +80,15 @@ class RectBuffer:
             dst = (y + r) * stride + x_off
             buf[dst:dst + row_bytes] = row
 
+    def _materialize(self) -> None:
+        """Write a held whole-rectangle blit into the backing, so a later
+        partial write has something to write into."""
+        if self._whole is None:
+            return
+        self._backing[:self._nbytes] = self._whole
+        self._whole = None
+
     def tobytes(self) -> bytes:
+        if self._whole is not None:
+            return self._whole
         return bytes(self._backing[:self._nbytes])

--- a/vncdotool/decoders/buffer.py
+++ b/vncdotool/decoders/buffer.py
@@ -1,0 +1,74 @@
+"""Rect-local pixel buffer shared by decoders."""
+from __future__ import annotations
+
+from .base import DecodeError
+
+
+class RectBuffer:
+    """A rect-sized, rect-local pixel buffer that decoders fill."""
+
+    def __init__(self, width: int, height: int, bypp: int, backing: bytearray | None = None) -> None:
+        self.width = width
+        self.height = height
+        self.bypp = bypp
+        needed = width * height * bypp
+        if backing is None:
+            backing = bytearray(needed)
+        elif len(backing) < needed:
+            raise ValueError(f"backing too small: need {needed} bytes, got {len(backing)}")
+        self._backing = backing
+        self._nbytes = needed
+
+    def _check_rect(self, x: int, y: int, w: int, h: int) -> None:
+        if x < 0 or y < 0 or w < 0 or h < 0:
+            raise DecodeError(f"negative rect: x={x}, y={y}, w={w}, h={h}")
+        if x + w > self.width or y + h > self.height:
+            raise DecodeError(
+                f"rect ({x}, {y}, {w}, {h}) extends past buffer bounds "
+                f"({self.width}x{self.height})"
+            )
+
+    def blit(self, x: int, y: int, w: int, h: int, pixels: bytes) -> None:
+        self._check_rect(x, y, w, h)
+        expected = w * h * self.bypp
+        if len(pixels) != expected:
+            raise DecodeError(f"blit expected {expected} bytes, got {len(pixels)}")
+
+        stride = self.width * self.bypp
+        row_bytes = w * self.bypp
+        buf = self._backing
+
+        if x == 0 and w == self.width:
+            # Contiguous rows: one slice assignment instead of h separate copies.
+            offset = y * stride
+            buf[offset:offset + expected] = pixels
+            return
+
+        x_off = x * self.bypp
+        for row in range(h):
+            dst = (y + row) * stride + x_off
+            src = row * row_bytes
+            buf[dst:dst + row_bytes] = pixels[src:src + row_bytes]
+
+    def fill(self, x: int, y: int, w: int, h: int, color: bytes) -> None:
+        self._check_rect(x, y, w, h)
+        if len(color) != self.bypp:
+            raise DecodeError(f"fill color must be {self.bypp} bytes, got {len(color)}")
+
+        stride = self.width * self.bypp
+        row_bytes = w * self.bypp
+        row = color * w
+        buf = self._backing
+
+        if x == 0 and w == self.width:
+            offset = y * stride
+            buf[offset:offset + h * stride] = row * h
+            return
+
+        x_off = x * self.bypp
+        for r in range(h):
+            dst = (y + r) * stride + x_off
+            buf[dst:dst + row_bytes] = row
+
+    def tobytes(self) -> bytes:
+        return bytes(self._backing[:self._nbytes])

--- a/vncdotool/decoders/buffer.py
+++ b/vncdotool/decoders/buffer.py
@@ -1,4 +1,3 @@
-"""Rect-local pixel buffer shared by decoders."""
 from __future__ import annotations
 
 from .base import DecodeError

--- a/vncdotool/decoders/buffer.py
+++ b/vncdotool/decoders/buffer.py
@@ -5,8 +5,6 @@ from .base import DecodeError
 
 
 class RectBuffer:
-    """A rect-sized, rect-local pixel buffer that decoders fill."""
-
     def __init__(self, width: int, height: int, bypp: int, backing: bytearray | None = None) -> None:
         self.width = width
         self.height = height

--- a/vncdotool/decoders/buffer.py
+++ b/vncdotool/decoders/buffer.py
@@ -20,6 +20,10 @@ class RectBuffer:
         # update -- hands over a buffer we can pass straight to the client,
         # so hold the reference instead of copying it in and back out.
         self._whole: bytes | None = None
+        # The backing is reused across rectangles, so it arrives holding the
+        # previous one. A write covering the whole buffer replaces all of it;
+        # anything narrower has to clear it first.
+        self._covered = False
 
     def _check_rect(self, x: int, y: int, w: int, h: int) -> None:
         if x < 0 or y < 0 or w < 0 or h < 0:
@@ -38,8 +42,10 @@ class RectBuffer:
 
         if x == 0 and y == 0 and w == self.width and h == self.height:
             self._whole = bytes(pixels)
+            self._covered = True
             return
         self._materialize()
+        self._clear()
 
         stride = self.width * self.bypp
         row_bytes = w * self.bypp
@@ -62,6 +68,9 @@ class RectBuffer:
         if len(color) != self.bypp:
             raise DecodeError(f"fill color must be {self.bypp} bytes, got {len(color)}")
         self._materialize()
+        if not (x == 0 and y == 0 and w == self.width and h == self.height):
+            self._clear()
+        self._covered = True
 
         stride = self.width * self.bypp
         row_bytes = w * self.bypp
@@ -77,6 +86,12 @@ class RectBuffer:
         for r in range(h):
             dst = (y + r) * stride + x_off
             buf[dst:dst + row_bytes] = row
+
+    def _clear(self) -> None:
+        if self._covered:
+            return
+        self._backing[:self._nbytes] = bytes(self._nbytes)
+        self._covered = True
 
     def _materialize(self) -> None:
         """Write a held whole-rectangle blit into the backing, so a later

--- a/vncdotool/decoders/copyrect.py
+++ b/vncdotool/decoders/copyrect.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING, ClassVar, Iterator
 from ..const import Encoding
 from .base import ClientDecoder
 
-if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+# rfb.py imports this package, so importing from it at runtime is a cycle.
+if TYPE_CHECKING:  # pragma: no cover
     from ..rfb import PixelFormat, Rect
 
 

--- a/vncdotool/decoders/copyrect.py
+++ b/vncdotool/decoders/copyrect.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 from struct import unpack
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, ClassVar, Iterator
 
+from ..const import Encoding
 from .base import ClientDecoder
 
 if TYPE_CHECKING:  # pragma: no cover - imported for typing only
@@ -11,6 +12,8 @@ if TYPE_CHECKING:  # pragma: no cover - imported for typing only
 
 
 class CopyRectDecoder(ClientDecoder):
+    ENCODING: ClassVar[Encoding] = Encoding.COPY_RECTANGLE
+
     def decodeForClient(
         self, client: object, rect: "Rect", pixel_format: "PixelFormat"
     ) -> Iterator[int]:

--- a/vncdotool/decoders/copyrect.py
+++ b/vncdotool/decoders/copyrect.py
@@ -1,8 +1,4 @@
-"""CopyRect: a framebuffer-to-framebuffer blit.
-
-RFC 6143 section 7.7.2. It reads no pixel data, and its source is the
-framebuffer rather than the stream, so it is a ClientDecoder.
-"""
+"""CopyRect. RFC 6143 section 7.7.2."""
 from __future__ import annotations
 
 from struct import unpack

--- a/vncdotool/decoders/copyrect.py
+++ b/vncdotool/decoders/copyrect.py
@@ -1,0 +1,22 @@
+"""CopyRect: a framebuffer-to-framebuffer blit.
+
+RFC 6143 section 7.7.2. It reads no pixel data, and its source is the
+framebuffer rather than the stream, so it is a ClientDecoder.
+"""
+from __future__ import annotations
+
+from struct import unpack
+from typing import TYPE_CHECKING, Iterator
+
+if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+    from ..rfb import PixelFormat, Rect
+
+
+class CopyRectDecoder:
+    def decode(
+        self, client: object, rect: "Rect", pixel_format: "PixelFormat"
+    ) -> Iterator[int]:
+        block = yield 4
+        srcx, srcy = unpack("!HH", block)
+        x, y, width, height = rect
+        client.copyRectangle(srcx, srcy, x, y, width, height)

--- a/vncdotool/decoders/copyrect.py
+++ b/vncdotool/decoders/copyrect.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 from struct import unpack
 from typing import TYPE_CHECKING, Iterator
 
+from .base import ClientDecoder
+
 if TYPE_CHECKING:  # pragma: no cover - imported for typing only
     from ..rfb import PixelFormat, Rect
 
 
-class CopyRectDecoder:
-    def decode(
+class CopyRectDecoder(ClientDecoder):
+    def decodeForClient(
         self, client: object, rect: "Rect", pixel_format: "PixelFormat"
     ) -> Iterator[int]:
         block = yield 4

--- a/vncdotool/decoders/raw.py
+++ b/vncdotool/decoders/raw.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING, ClassVar, Iterator
 from ..const import Encoding
 from .base import PixelDecoder
 
-if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+# rfb.py imports this package, so importing from it at runtime is a cycle.
+if TYPE_CHECKING:  # pragma: no cover
     from ..rfb import PixelFormat
     from .buffer import RectBuffer
 

--- a/vncdotool/decoders/raw.py
+++ b/vncdotool/decoders/raw.py
@@ -1,7 +1,4 @@
-"""Raw encoding: the rectangle's pixels, left to right, top to bottom.
-
-RFC 6143 section 7.7.1.
-"""
+"""Raw encoding. RFC 6143 section 7.7.1."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterator

--- a/vncdotool/decoders/raw.py
+++ b/vncdotool/decoders/raw.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterator
 
+from .base import PixelDecoder
+
 if TYPE_CHECKING:  # pragma: no cover - imported for typing only
     from ..rfb import PixelFormat
     from .buffer import RectBuffer
 
 
-class RawDecoder:
-    def decode(self, target: "RectBuffer", pixel_format: "PixelFormat") -> Iterator[int]:
+class RawDecoder(PixelDecoder):
+    def decodePixels(
+        self, target: "RectBuffer", pixel_format: "PixelFormat"
+    ) -> Iterator[int]:
         data = yield target.width * target.height * target.bypp
         target.blit(0, 0, target.width, target.height, data)
-
-    def output_format(self, pixel_format: "PixelFormat") -> "PixelFormat":
-        return pixel_format

--- a/vncdotool/decoders/raw.py
+++ b/vncdotool/decoders/raw.py
@@ -1,0 +1,20 @@
+"""Raw encoding: the rectangle's pixels, left to right, top to bottom.
+
+RFC 6143 section 7.7.1.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterator
+
+if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+    from ..rfb import PixelFormat
+    from .buffer import RectBuffer
+
+
+class RawDecoder:
+    def decode(self, target: "RectBuffer", pixel_format: "PixelFormat") -> Iterator[int]:
+        data = yield target.width * target.height * target.bypp
+        target.blit(0, 0, target.width, target.height, data)
+
+    def output_format(self, pixel_format: "PixelFormat") -> "PixelFormat":
+        return pixel_format

--- a/vncdotool/decoders/raw.py
+++ b/vncdotool/decoders/raw.py
@@ -1,8 +1,9 @@
 """Raw encoding. RFC 6143 section 7.7.1."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, ClassVar, Iterator
 
+from ..const import Encoding
 from .base import PixelDecoder
 
 if TYPE_CHECKING:  # pragma: no cover - imported for typing only
@@ -11,6 +12,8 @@ if TYPE_CHECKING:  # pragma: no cover - imported for typing only
 
 
 class RawDecoder(PixelDecoder):
+    ENCODING: ClassVar[Encoding] = Encoding.RAW
+
     def decodePixels(
         self, target: "RectBuffer", pixel_format: "PixelFormat"
     ) -> Iterator[int]:

--- a/vncdotool/pixelformat.py
+++ b/vncdotool/pixelformat.py
@@ -8,6 +8,8 @@ https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst (ZRLE Encoding)
 """
 from __future__ import annotations
 
+import functools
+
 from . import rfb
 
 _32BPP_MODES = {"RGBX", "BGRX", "XRGB", "XBGR"}
@@ -45,6 +47,7 @@ def _byte_positions(
     return positions
 
 
+@functools.lru_cache(maxsize=None)
 def raw_mode(pixel_format: rfb.PixelFormat) -> str:
     """The Pillow raw mode that reads bytes in this layout, ignoring depth."""
     if not pixel_format.truecolor:

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -512,8 +512,6 @@ class RFBClient(Protocol):  # type: ignore[misc]
 
     def _rectBuffer(self, width: int, height: int) -> decoders.RectBuffer | None:
         """A buffer for one rectangle, or None having failed the connection."""
-        # A zero dimension carries no pixels and no payload, so it is not
-        # an error.
         limit_w = self.width or self.MAX_DESKTOP_SIZE
         limit_h = self.height or self.MAX_DESKTOP_SIZE
         if not (0 <= width <= limit_w and 0 <= height <= limit_h):

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -212,7 +212,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
         self.height = 0
         self._rect_backing = bytearray()
         self._decoders = {
-            encoding: (decoder, self._driveFor(decoder))
+            encoding: (decoder, self._pumpFor(decoder))
             for encoding, decoder in decoders.build().items()
         }
 
@@ -451,8 +451,8 @@ class RFBClient(Protocol):  # type: ignore[misc]
             self.rectanglePos.append((x, y, width, height))
             entry = self._decoders.get(encoding)
             if entry is not None:
-                decoder, drive = entry
-                drive(decoder, x, y, width, height)
+                decoder, pump = entry
+                pump(decoder, x, y, width, height)
             elif encoding == Encoding.HEXTILE:
                 self._doNextHextileSubrect(None, None, x, y, width, height, None, None)
             elif encoding == Encoding.CORRE:
@@ -480,36 +480,36 @@ class RFBClient(Protocol):  # type: ignore[misc]
         else:
             self._doConnection()
 
-    def _driveFor(self, decoder: decoders.Decoder) -> Callable[..., None]:
+    def _pumpFor(self, decoder: decoders.Decoder) -> Callable[..., None]:
         if isinstance(decoder, decoders.ControlDecoder):
-            return self._driveControl
+            return self._pumpControl
         if isinstance(decoder, decoders.PixelDecoder):
-            return self._drivePixels
-        return self._driveForClient
+            return self._pumpPixels
+        return self._pumpForClient
 
-    def _driveControl(
+    def _pumpControl(
         self, decoder: decoders.ControlDecoder, x: int, y: int, width: int, height: int
     ) -> None:
         decoder.applyToClient(self, (x, y, width, height))
         self._doConnection()
 
-    def _drivePixels(
+    def _pumpPixels(
         self, decoder: decoders.PixelDecoder, x: int, y: int, width: int, height: int
     ) -> None:
         target = self._rectBuffer(width, height)
         if target is None:
             return
-        self._pumpDecoder(
+        self._pumpBlock(
             None,
             decoder.decodePixels(target, self.pixel_format),
             (decoder, target, (x, y, width, height)),
         )
 
-    def _driveForClient(
+    def _pumpForClient(
         self, decoder: decoders.ClientDecoder, x: int, y: int, width: int, height: int
     ) -> None:
         rect = (x, y, width, height)
-        self._pumpDecoder(
+        self._pumpBlock(
             None, decoder.decodeForClient(self, rect, self.pixel_format), None
         )
 
@@ -540,7 +540,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
             self.abortConnection(f"no memory for a {width}x{height} rectangle")
             return None
 
-    def _pumpDecoder(
+    def _pumpBlock(
         self,
         block: bytes | None,
         generator: Iterator[int],
@@ -562,7 +562,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
             generator.close()
             self.abortConnection(f"decoder asked for {size} bytes")
             return
-        self.expect(self._pumpDecoder, size, generator, finish)
+        self.expect(self._pumpBlock, size, generator, finish)
 
     # ---  RRE Encoding
 

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -172,8 +172,8 @@ class RFBClient(Protocol):  # type: ignore[misc]
         Encoding.PSEUDO_QEMU_EXTENDED_KEY_EVENT,
     }
 
-    # A rectangle's dimensions are u16, so this bounds nothing on its own;
-    # it is the hook a subclass narrows.
+    # Greater than any u16 dimension, so it refuses nothing until a subclass
+    # narrows it.
     MAX_DESKTOP_SIZE = 0x10000
 
     _HEADER = b"RFB 000.000\n"
@@ -446,8 +446,9 @@ class RFBClient(Protocol):  # type: ignore[misc]
         if self.rectangles:
             self.rectangles -= 1
             self.rectanglePos.append((x, y, width, height))
-            if encoding in self._decoders:
-                self._decodeRectangle(self._decoders[encoding], x, y, width, height)
+            decoder = self._decoders.get(encoding)
+            if decoder is not None:
+                self._decodeRectangle(decoder, x, y, width, height)
             elif encoding == Encoding.HEXTILE:
                 self._doNextHextileSubrect(None, None, x, y, width, height, None, None)
             elif encoding == Encoding.CORRE:
@@ -543,9 +544,6 @@ class RFBClient(Protocol):  # type: ignore[misc]
             self._doConnection()
             return
         except (decoders.DecodeError, StructError, MemoryError, zlib.error) as exc:
-            # Malformed input reaches a decoder as struct.error out of
-            # unpack or zlib.error out of a corrupt stream, not only as
-            # DecodeError.
             generator.close()
             self.abortConnection(f"cannot decode this rectangle: {exc}")
             return
@@ -1023,8 +1021,6 @@ class RFBClient(Protocol):  # type: ignore[misc]
     # incomming data redirector
     # ------------------------------------------------------
     def dataReceived(self, data: bytes) -> None:
-        # ~ sys.stdout.write(repr(data) + '\n')
-        # ~ print(f"{len(data), {len(self._packet)}")
         if self._aborted:
             return
         self._packet.extend(data)

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -211,7 +211,10 @@ class RFBClient(Protocol):  # type: ignore[misc]
         self.width = 0
         self.height = 0
         self._rect_backing = bytearray()
-        self._decoders = decoders.build()
+        self._decoders = {
+            encoding: (decoder, self._driveFor(decoder))
+            for encoding, decoder in decoders.build().items()
+        }
 
     @property
     def bypp(self) -> int:
@@ -446,9 +449,10 @@ class RFBClient(Protocol):  # type: ignore[misc]
         if self.rectangles:
             self.rectangles -= 1
             self.rectanglePos.append((x, y, width, height))
-            decoder = self._decoders.get(encoding)
-            if decoder is not None:
-                self._decodeRectangle(decoder, x, y, width, height)
+            entry = self._decoders.get(encoding)
+            if entry is not None:
+                decoder, drive = entry
+                drive(decoder, x, y, width, height)
             elif encoding == Encoding.HEXTILE:
                 self._doNextHextileSubrect(None, None, x, y, width, height, None, None)
             elif encoding == Encoding.CORRE:
@@ -476,29 +480,38 @@ class RFBClient(Protocol):  # type: ignore[misc]
         else:
             self._doConnection()
 
-    def _decodeRectangle(
-        self, decoder: decoders.Decoder, x: int, y: int, width: int, height: int
-    ) -> None:
-        """Drive one decoder against `expect` until it stops."""
-        rect = (x, y, width, height)
+    def _driveFor(self, decoder: decoders.Decoder) -> Callable[..., None]:
         if isinstance(decoder, decoders.ControlDecoder):
-            decoder.applyToClient(self, rect)
-            self._doConnection()
-            return
-
+            return self._driveControl
         if isinstance(decoder, decoders.PixelDecoder):
-            target = self._rectBuffer(width, height)
-            if target is None:
-                return
-            self._pumpDecoder(
-                None,
-                decoder.decodePixels(target, self.pixel_format),
-                (decoder, target, rect),
-            )
-        else:
-            self._pumpDecoder(
-                None, decoder.decodeForClient(self, rect, self.pixel_format), None
-            )
+            return self._drivePixels
+        return self._driveForClient
+
+    def _driveControl(
+        self, decoder: decoders.ControlDecoder, x: int, y: int, width: int, height: int
+    ) -> None:
+        decoder.applyToClient(self, (x, y, width, height))
+        self._doConnection()
+
+    def _drivePixels(
+        self, decoder: decoders.PixelDecoder, x: int, y: int, width: int, height: int
+    ) -> None:
+        target = self._rectBuffer(width, height)
+        if target is None:
+            return
+        self._pumpDecoder(
+            None,
+            decoder.decodePixels(target, self.pixel_format),
+            (decoder, target, (x, y, width, height)),
+        )
+
+    def _driveForClient(
+        self, decoder: decoders.ClientDecoder, x: int, y: int, width: int, height: int
+    ) -> None:
+        rect = (x, y, width, height)
+        self._pumpDecoder(
+            None, decoder.decodeForClient(self, rect, self.pixel_format), None
+        )
 
     def _finishRectangle(
         self, decoder: decoders.PixelDecoder, target: decoders.RectBuffer, rect: Rect

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -15,6 +15,7 @@ https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst
 from __future__ import annotations
 
 import getpass
+import functools
 import sys
 import warnings
 import zlib
@@ -42,6 +43,7 @@ from twisted.internet.protocol import Protocol
 from twisted.python import log, usage
 from twisted.python.failure import Failure
 
+from . import decoders
 from .const import Encoding, HextileEncoding, AuthTypes, MsgC2S, MsgS2C
 from .keys import Key
 
@@ -171,6 +173,10 @@ class RFBClient(Protocol):  # type: ignore[misc]
         Encoding.PSEUDO_QEMU_EXTENDED_KEY_EVENT,
     }
 
+    # A rectangle's dimensions are u16, so this bounds nothing on its own;
+    # it is the hook a subclass narrows.
+    MAX_DESKTOP_SIZE = 0x10000
+
     _HEADER = b"RFB 000.000\n"
     _HEADER_TRANSLATE = bytes.maketrans(b"0123456789", b"0" * 10)
 
@@ -202,6 +208,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
             Encoding.RAW,
         }
         self.pixel_format = PixelFormat()
+        self._rect_backing = bytearray()
 
     @property
     def bypp(self) -> int:
@@ -436,17 +443,8 @@ class RFBClient(Protocol):  # type: ignore[misc]
         if self.rectangles:
             self.rectangles -= 1
             self.rectanglePos.append((x, y, width, height))
-            if encoding == Encoding.COPY_RECTANGLE:
-                self.expect(self._handleDecodeCopyrect, 4, x, y, width, height)
-            elif encoding == Encoding.RAW:
-                self.expect(
-                    self._handleDecodeRAW,
-                    width * height * self.bypp,
-                    x,
-                    y,
-                    width,
-                    height,
-                )
+            if encoding in decoders.DECODERS:
+                self._decodeRectangle(decoders.DECODERS[encoding], x, y, width, height)
             elif encoding == Encoding.HEXTILE:
                 self._doNextHextileSubrect(None, None, x, y, width, height, None, None)
             elif encoding == Encoding.CORRE:
@@ -474,23 +472,82 @@ class RFBClient(Protocol):  # type: ignore[misc]
         else:
             self._doConnection()
 
-    # ---  RAW Encoding
+    # ---  the pump
 
-    def _handleDecodeRAW(
-        self, block: bytes, x: int, y: int, width: int, height: int
+    def _decodeRectangle(
+        self, decoder: decoders.Decoder, x: int, y: int, width: int, height: int
     ) -> None:
-        # TODO convert pixel format?
-        self.updateRectangle(x, y, width, height, block)
-        self._doConnection()
+        """Drive one decoder against `expect` until it stops.
 
-    # ---  CopyRect Encoding
+        Shapes are told apart by the methods they carry: `isinstance` against
+        a runtime-checkable Protocol also only checks method names, and every
+        PixelDecoder would satisfy ClientDecoder that way.
+        """
+        rect = (x, y, width, height)
+        if hasattr(decoder, "apply"):
+            decoder.apply(self, rect)
+            self._doConnection()
+            return
 
-    def _handleDecodeCopyrect(
-        self, block: bytes, x: int, y: int, width: int, height: int
+        if hasattr(decoder, "output_format"):
+            target = self._rectBuffer(width, height)
+            if target is None:
+                return
+            self._pumpDecoder(
+                None,
+                decoder.decode(target, self.pixel_format),
+                functools.partial(self._finishRectangle, decoder, target, rect),
+            )
+        else:
+            self._pumpDecoder(None, decoder.decode(self, rect, self.pixel_format), None)
+
+    def _finishRectangle(
+        self, decoder: decoders.PixelDecoder, target: decoders.RectBuffer, rect: Rect
     ) -> None:
-        (srcx, srcy) = unpack("!HH", block)
-        self.copyRectangle(srcx, srcy, x, y, width, height)
-        self._doConnection()
+        x, y, width, height = rect
+        self.updateRectangle(
+            x, y, width, height, target.tobytes(),
+            decoder.output_format(self.pixel_format),
+        )
+
+    def _rectBuffer(self, width: int, height: int) -> decoders.RectBuffer | None:
+        """A buffer for one rectangle, or None having failed the connection.
+
+        The allocation is kept and reused at its high-water mark, so a session
+        of same-sized updates allocates once.
+        """
+        if not (0 < width <= self.MAX_DESKTOP_SIZE and 0 < height <= self.MAX_DESKTOP_SIZE):
+            self.vncProtocolError(f"rectangle {width}x{height} is out of range")
+            self.transport.loseConnection()
+            return None
+        needed = width * height * self.bypp
+        try:
+            if len(self._rect_backing) < needed:
+                self._rect_backing = bytearray(needed)
+            return decoders.RectBuffer(width, height, self.bypp, self._rect_backing)
+        except MemoryError:
+            self.vncProtocolError(f"no memory for a {width}x{height} rectangle")
+            self.transport.loseConnection()
+            return None
+
+    def _pumpDecoder(
+        self,
+        block: bytes | None,
+        generator: Iterator[int],
+        finish: Callable[[], None] | None,
+    ) -> None:
+        try:
+            size = generator.send(block)
+        except StopIteration:
+            if finish is not None:
+                finish()
+            self._doConnection()
+            return
+        except decoders.DecodeError as exc:
+            self.vncProtocolError(f"cannot decode this rectangle: {exc}")
+            self.transport.loseConnection()
+            return
+        self.expect(self._pumpDecoder, size, generator, finish)
 
     # ---  RRE Encoding
 
@@ -722,7 +779,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
         th: int,
     ) -> None:
         """the tile is in raw encoding"""
-        self.updateRectangle(tx, ty, tw, th, block)
+        self.updateRectangle(tx, ty, tw, th, block, self.pixel_format)
         self._doNextHextileSubrect(bg, color, x, y, width, height, tx, ty)
 
     def _handleDecodeHextileSubrectsColoured(
@@ -876,14 +933,18 @@ class RFBClient(Protocol):  # type: ignore[misc]
                     if num_pixels != pixels_in_tile:
                         raise ValueError("too many pixels")
 
-                self.updateRectangle(tx, ty, tw, th, bytes(pixel_data))
+                self.updateRectangle(
+                    tx, ty, tw, th, bytes(pixel_data), self.pixel_format
+                )
             else:
                 # No RLE
                 if palette_size == 0:
                     # Raw pixel data
                     for _ in range(pixels_in_tile):
                         pixel_data.extend(cpixel(it))
-                    self.updateRectangle(tx, ty, tw, th, bytes(pixel_data))
+                    self.updateRectangle(
+                        tx, ty, tw, th, bytes(pixel_data), self.pixel_format
+                    )
                 elif palette_size == 1:
                     # Fill tile with plain color
                     color = cpixel(it)
@@ -901,7 +962,9 @@ class RFBClient(Protocol):  # type: ignore[misc]
 
                     for palette_index in next_index:
                         pixel_data.extend(palette[palette_index])
-                    self.updateRectangle(tx, ty, tw, th, bytes(pixel_data))
+                    self.updateRectangle(
+                        tx, ty, tw, th, bytes(pixel_data), self.pixel_format
+                    )
 
             # Next tile
             tx = tx + 64
@@ -1072,11 +1135,18 @@ class RFBClient(Protocol):  # type: ignore[misc]
         """
 
     def updateRectangle(
-        self, x: int, y: int, width: int, height: int, data: bytes
+        self,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        data: bytes,
+        pixel_format: PixelFormat,
     ) -> None:
         """new bitmap data.
 
-        :param data: bytes in the pixel format set up earlier.
+        :param data: bytes in `pixel_format`, which is the negotiated format
+            for every encoding in use today but need not be.
         """
 
     def copyRectangle(
@@ -1094,7 +1164,9 @@ class RFBClient(Protocol):  # type: ignore[misc]
         """
         # fallback variant, use update recatngle
         # override with specialized function for better performance
-        self.updateRectangle(x, y, width, height, color * width * height)
+        self.updateRectangle(
+            x, y, width, height, color * width * height, self.pixel_format
+        )
 
     def updateCursor(
         self, x: int, y: int, width: int, height: int, image: bytes, mask: bytes
@@ -1177,7 +1249,13 @@ if __name__ == "__main__":
             self.framebufferUpdateRequest()
 
         def updateRectangle(
-            self, x: int, y: int, width: int, height: int, data: bytes
+            self,
+            x: int,
+            y: int,
+            width: int,
+            height: int,
+            data: bytes,
+            pixel_format: PixelFormat,
         ) -> None:
             print("%s " * 5 % (x, y, width, height, repr(data[:20])))
 

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -481,17 +481,9 @@ class RFBClient(Protocol):  # type: ignore[misc]
             self._doConnection()
 
     def _pumpFor(self, decoder: decoders.Decoder) -> Callable[..., None]:
-        if isinstance(decoder, decoders.ControlDecoder):
-            return self._pumpControl
         if isinstance(decoder, decoders.PixelDecoder):
             return self._pumpPixels
         return self._pumpForClient
-
-    def _pumpControl(
-        self, decoder: decoders.ControlDecoder, x: int, y: int, width: int, height: int
-    ) -> None:
-        decoder.applyToClient(self, (x, y, width, height))
-        self._doConnection()
 
     def _pumpPixels(
         self, decoder: decoders.PixelDecoder, x: int, y: int, width: int, height: int

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -479,27 +479,26 @@ class RFBClient(Protocol):  # type: ignore[misc]
     def _decodeRectangle(
         self, decoder: decoders.Decoder, x: int, y: int, width: int, height: int
     ) -> None:
-        """Drive one decoder against `expect` until it stops.
-
-        Shapes are told apart by the methods they carry: `isinstance` against
-        a runtime-checkable Protocol also only checks method names, and every
-        PixelDecoder would satisfy ClientDecoder that way.
-        """
+        """Drive one decoder against `expect` until it stops."""
         rect = (x, y, width, height)
-        if hasattr(decoder, "apply"):
-            decoder.apply(self, rect)
+        if isinstance(decoder, decoders.ControlDecoder):
+            decoder.applyToClient(self, rect)
             self._doConnection()
             return
 
-        if hasattr(decoder, "output_format"):
+        if isinstance(decoder, decoders.PixelDecoder):
             target = self._rectBuffer(width, height)
             if target is None:
                 return
             self._pumpDecoder(
-                None, decoder.decode(target, self.pixel_format), (decoder, target, rect)
+                None,
+                decoder.decodePixels(target, self.pixel_format),
+                (decoder, target, rect),
             )
         else:
-            self._pumpDecoder(None, decoder.decode(self, rect, self.pixel_format), None)
+            self._pumpDecoder(
+                None, decoder.decodeForClient(self, rect, self.pixel_format), None
+            )
 
     def _finishRectangle(
         self, decoder: decoders.PixelDecoder, target: decoders.RectBuffer, rect: Rect

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -200,6 +200,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
         self._expected_args: tuple[Any, ...] = ()
         self._expected_kwargs: dict[str, Any] = {}
         self._already_expecting = False
+        self._aborted = False
         self._version: Ver = (0, 0)
         self._version_server: Ver = (0, 0)
         self._zlib_stream = zlib.decompressobj(0)
@@ -207,7 +208,10 @@ class RFBClient(Protocol):  # type: ignore[misc]
             Encoding.RAW,
         }
         self.pixel_format = PixelFormat()
+        self.width = 0
+        self.height = 0
         self._rect_backing = bytearray()
+        self._decoders = decoders.build()
 
     @property
     def bypp(self) -> int:
@@ -442,8 +446,8 @@ class RFBClient(Protocol):  # type: ignore[misc]
         if self.rectangles:
             self.rectangles -= 1
             self.rectanglePos.append((x, y, width, height))
-            if encoding in decoders.DECODERS:
-                self._decodeRectangle(decoders.DECODERS[encoding], x, y, width, height)
+            if encoding in self._decoders:
+                self._decodeRectangle(self._decoders[encoding], x, y, width, height)
             elif encoding == Encoding.HEXTILE:
                 self._doNextHextileSubrect(None, None, x, y, width, height, None, None)
             elif encoding == Encoding.CORRE:
@@ -513,9 +517,14 @@ class RFBClient(Protocol):  # type: ignore[misc]
         The allocation is kept and reused at its high-water mark, so a session
         of same-sized updates allocates once.
         """
-        if not (0 < width <= self.MAX_DESKTOP_SIZE and 0 < height <= self.MAX_DESKTOP_SIZE):
-            self.vncProtocolError(f"rectangle {width}x{height} is out of range")
-            self.transport.loseConnection()
+        # A zero dimension carries no pixels and no payload, and the old
+        # decoders passed it through, so it is not an error.
+        limit_w = self.width or self.MAX_DESKTOP_SIZE
+        limit_h = self.height or self.MAX_DESKTOP_SIZE
+        if not (0 <= width <= limit_w and 0 <= height <= limit_h):
+            self.abortConnection(
+                f"rectangle {width}x{height} does not fit a {limit_w}x{limit_h} framebuffer"
+            )
             return None
         needed = width * height * self.bypp
         try:
@@ -523,8 +532,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
                 self._rect_backing = bytearray(needed)
             return decoders.RectBuffer(width, height, self.bypp, self._rect_backing)
         except MemoryError:
-            self.vncProtocolError(f"no memory for a {width}x{height} rectangle")
-            self.transport.loseConnection()
+            self.abortConnection(f"no memory for a {width}x{height} rectangle")
             return None
 
     def _pumpDecoder(
@@ -540,12 +548,18 @@ class RFBClient(Protocol):  # type: ignore[misc]
                 self._finishRectangle(*finish)
             self._doConnection()
             return
-        except (decoders.DecodeError, StructError) as exc:
-            # StructError too: a decoder parsing malformed input raises it
-            # from unpack, and an unhandled one is as undiagnosed a failure
-            # as the indefinite wait this exists to replace.
-            self.vncProtocolError(f"cannot decode this rectangle: {exc}")
-            self.transport.loseConnection()
+        except (decoders.DecodeError, StructError, MemoryError, zlib.error) as exc:
+            # Not DecodeError alone: a decoder parsing malformed input raises
+            # struct.error out of unpack and zlib.error out of a corrupt
+            # stream, and an unhandled one is as undiagnosed a failure as the
+            # indefinite wait this exists to replace.
+            generator.close()
+            self.abortConnection(f"cannot decode this rectangle: {exc}")
+            return
+
+        if size < 0:
+            generator.close()
+            self.abortConnection(f"decoder asked for {size} bytes")
             return
         self.expect(self._pumpDecoder, size, generator, finish)
 
@@ -1018,12 +1032,17 @@ class RFBClient(Protocol):  # type: ignore[misc]
     def dataReceived(self, data: bytes) -> None:
         # ~ sys.stdout.write(repr(data) + '\n')
         # ~ print(f"{len(data), {len(self._packet)}")
+        if self._aborted:
+            return
         self._packet.extend(data)
         self._handler()
 
     def _handleExpected(self) -> None:
         if len(self._packet) >= self._expected_len:
-            while len(self._packet) >= self._expected_len:
+            # `expect` is the only thing that re-arms the parked handler, so
+            # a handler that gives up without calling it would be re-entered
+            # by this loop with the next block.
+            while len(self._packet) >= self._expected_len and not self._aborted:
                 self._already_expecting = True
                 block = bytes(self._packet[: self._expected_len])
                 del self._packet[: self._expected_len]
@@ -1032,6 +1051,17 @@ class RFBClient(Protocol):  # type: ignore[misc]
                     block, *self._expected_args, **self._expected_kwargs
                 )
             self._already_expecting = False
+
+    def abortConnection(self, reason: str) -> None:
+        """Report a protocol failure and stop parsing for good.
+
+        loseConnection is asynchronous and bytes already buffered are still
+        delivered, so the parser has to be stopped here as well.
+        """
+        self._aborted = True
+        self._packet.clear()
+        self.vncProtocolError(reason)
+        self.transport.loseConnection()
 
     def expect(
         self, handler: Callable[..., None], size: int, *args: Any, **kwargs: Any

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -517,8 +517,8 @@ class RFBClient(Protocol):  # type: ignore[misc]
         The allocation is kept and reused at its high-water mark, so a session
         of same-sized updates allocates once.
         """
-        # A zero dimension carries no pixels and no payload, and the old
-        # decoders passed it through, so it is not an error.
+        # A zero dimension carries no pixels and no payload, so it is not
+        # an error.
         limit_w = self.width or self.MAX_DESKTOP_SIZE
         limit_h = self.height or self.MAX_DESKTOP_SIZE
         if not (0 <= width <= limit_w and 0 <= height <= limit_h):
@@ -549,10 +549,9 @@ class RFBClient(Protocol):  # type: ignore[misc]
             self._doConnection()
             return
         except (decoders.DecodeError, StructError, MemoryError, zlib.error) as exc:
-            # Not DecodeError alone: a decoder parsing malformed input raises
-            # struct.error out of unpack and zlib.error out of a corrupt
-            # stream, and an unhandled one is as undiagnosed a failure as the
-            # indefinite wait this exists to replace.
+            # Malformed input reaches a decoder as struct.error out of
+            # unpack or zlib.error out of a corrupt stream, not only as
+            # DecodeError.
             generator.close()
             self.abortConnection(f"cannot decode this rectangle: {exc}")
             return

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -213,7 +213,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
         self._rect_backing = bytearray()
         self._decoders = {
             encoding: (decoder, self._pumpFor(decoder))
-            for encoding, decoder in decoders.build().items()
+            for encoding, decoder in decoders.for_connection().items()
         }
 
     @property

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -510,11 +510,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
         )
 
     def _rectBuffer(self, width: int, height: int) -> decoders.RectBuffer | None:
-        """A buffer for one rectangle, or None having failed the connection.
-
-        The allocation is kept and reused at its high-water mark, so a session
-        of same-sized updates allocates once.
-        """
+        """A buffer for one rectangle, or None having failed the connection."""
         # A zero dimension carries no pixels and no payload, so it is not
         # an error.
         limit_w = self.width or self.MAX_DESKTOP_SIZE

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -475,8 +475,6 @@ class RFBClient(Protocol):  # type: ignore[misc]
         else:
             self._doConnection()
 
-    # ---  the pump
-
     def _decodeRectangle(
         self, decoder: decoders.Decoder, x: int, y: int, width: int, height: int
     ) -> None:

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -15,7 +15,6 @@ https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst
 from __future__ import annotations
 
 import getpass
-import functools
 import sys
 import warnings
 import zlib
@@ -494,9 +493,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
             if target is None:
                 return
             self._pumpDecoder(
-                None,
-                decoder.decode(target, self.pixel_format),
-                functools.partial(self._finishRectangle, decoder, target, rect),
+                None, decoder.decode(target, self.pixel_format), (decoder, target, rect)
             )
         else:
             self._pumpDecoder(None, decoder.decode(self, rect, self.pixel_format), None)
@@ -534,13 +531,13 @@ class RFBClient(Protocol):  # type: ignore[misc]
         self,
         block: bytes | None,
         generator: Iterator[int],
-        finish: Callable[[], None] | None,
+        finish: tuple[decoders.PixelDecoder, decoders.RectBuffer, Rect] | None,
     ) -> None:
         try:
             size = generator.send(block)
         except StopIteration:
             if finish is not None:
-                finish()
+                self._finishRectangle(*finish)
             self._doConnection()
             return
         except decoders.DecodeError as exc:

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -19,7 +19,7 @@ import sys
 import warnings
 import zlib
 from dataclasses import astuple, dataclass
-from struct import Struct, pack, unpack, unpack_from
+from struct import Struct, error as StructError, pack, unpack, unpack_from
 from typing import (
     Any,
     Callable,
@@ -540,7 +540,10 @@ class RFBClient(Protocol):  # type: ignore[misc]
                 self._finishRectangle(*finish)
             self._doConnection()
             return
-        except decoders.DecodeError as exc:
+        except (decoders.DecodeError, StructError) as exc:
+            # StructError too: a decoder parsing malformed input raises it
+            # from unpack, and an unhandled one is as undiagnosed a failure
+            # as the indefinite wait this exists to replace.
             self.vncProtocolError(f"cannot decode this rectangle: {exc}")
             self.transport.loseConnection()
             return


### PR DESCRIPTION
Phase 2 of `specs/decoder-architecture.md`, now based on main since #399 merged. #405 and #406 sit above it.

A decoder becomes a generator that yields the byte count it wants and receives those bytes back. Raw and CopyRect move to `vncdotool/decoders/` behind a registry; the rest stay on the continuation-passing path until their phases. `updateRectangle` gains the `PixelFormat` its bytes are in — the contract change #385 warned about — and `fillRectangle` is no longer called for the migrated encodings.

**N1 is not met and needs a decision.** `make bench` replays a committed Raw fixture: 3.8ms on main, 4.7ms here, median of 60 runs. Two rounds of profiling; the two obvious hypotheses were wrong and were reverted. What is left is per-rectangle cost the design implies, and Raw is its worst case — already one paste per rectangle, so the single-paste win that pays for the pump elsewhere buys it nothing. Accept ~20% on Raw, or spend a fast path on it; I did not want to invent API to beat a benchmark without you.

The abort fix is the other thing worth reading closely: a failed decode used to leave the parked handler armed, so the parser re-entered a terminated generator and painted from an untouched buffer after the session was declared bad.

Tested: 271 unit tests, `flake8` clean, fleet and OS-server jobs green.
