### PR TITLE
Prune type: ignore comments mypy proves unnecessary

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -27,10 +27,10 @@ class TestVNCDoToolClient(TestCase):
         self.client.factory = mock.Mock()
 
         # mock out a bunch of base class functions
-        self.client.framebufferUpdateRequest = mock.Mock()  # type: ignore[assignment]
-        self.client.pointerEvent = mock.Mock()  # type: ignore[assignment]
-        self.client.keyEvent = mock.Mock()  # type: ignore[assignment]
-        self.client.setEncodings = mock.Mock()  # type: ignore[assignment]
+        self.client.framebufferUpdateRequest = mock.Mock()  # type: ignore[method-assign]
+        self.client.pointerEvent = mock.Mock()  # type: ignore[method-assign]
+        self.client.keyEvent = mock.Mock()  # type: ignore[method-assign]
+        self.client.setEncodings = mock.Mock()  # type: ignore[method-assign]
 
     def test_vncConnectionMade(self):
         cli = self.client
@@ -470,7 +470,7 @@ class TestVMWareClient(TestCase):
         self.client = client.VMWareClient()
         self.client.transport = mock.Mock()
         self.client.factory = mock.Mock()
-        self.client.framebufferUpdateRequest = mock.Mock()  # type: ignore[assignment]
+        self.client.framebufferUpdateRequest = mock.Mock()  # type: ignore[method-assign]
         self.client._handler = mock.Mock()
 
     def test_dataReceived_recognizes_single_pixel_update(self) -> None:

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -134,7 +134,7 @@ class VNCDoCLIFactory(VNCDoToolFactory):
         reactor.callLater(0.1, reactor.stop)
 
 
-class ExitingProcess(protocol.ProcessProtocol):  # type: ignore[misc]
+class ExitingProcess(protocol.ProcessProtocol):
     def processExited(self, reason: Failure) -> None:
         reactor.callLater(0.1, reactor.stop)
 

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -41,7 +41,7 @@ TYPE_LEN = {
 REVERSE_MAP = {v: n for (n, v) in KEYMAP.items()}
 
 
-class RFBServer(Protocol):  # type: ignore[misc]
+class RFBServer(Protocol):
     _handler: tuple[Callable[..., None], int] = (lambda data: None, 0)
 
     def connectionMade(self) -> None:
@@ -209,7 +209,7 @@ class VNCLoggingClient(VNCDoToolClient):
             self.capture_file = None
 
 
-class VNCLoggingClientProxy(portforward.ProxyClient):  # type: ignore[misc]
+class VNCLoggingClientProxy(portforward.ProxyClient):
     """Accept data from a server and forward to logger and downstream client.
 
     ::
@@ -259,11 +259,11 @@ class VNCLoggingClientProxy(portforward.ProxyClient):  # type: ignore[misc]
         super().dataReceived(data)
 
 
-class VNCLoggingClientFactory(portforward.ProxyClientFactory):  # type: ignore[misc]
+class VNCLoggingClientFactory(portforward.ProxyClientFactory):
     protocol = VNCLoggingClientProxy
 
 
-class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore[misc]
+class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):
     """Proxy in the middle, decodes and logs RFB messages before sending them upstream.
 
     ::
@@ -433,7 +433,7 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):  # type: ignore
         self.recorder(" ".join(cmds))
 
 
-class VNCLoggingServerFactory(portforward.ProxyFactory):  # type: ignore[misc]
+class VNCLoggingServerFactory(portforward.ProxyFactory):
     protocol = VNCLoggingServerProxy
     shared = True
 

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -93,7 +93,7 @@ def _zrle_next_nibble(it: Iterator[int], pixels_in_tile: int) -> Iterator[int]:
                 return
 
 
-class RFBClient(Protocol):  # type: ignore[misc]
+class RFBClient(Protocol):
     # https://www.rfc-editor.org/rfc/rfc6143#section-7.1.1
     SUPPORTED_SERVER_VERSIONS = {
         (3, 3),
@@ -860,7 +860,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
         (aka clipboard)"""
 
 
-class RFBFactory(protocol.ClientFactory):  # type: ignore[misc]
+class RFBFactory(protocol.ClientFactory):
     """A factory for remote frame buffer connections."""
 
     # the class of the protocol to build
@@ -932,7 +932,7 @@ if __name__ == "__main__":
         ) -> None:
             print("%s " * 5 % (x, y, width, height, repr(data[:20])))
 
-    class RFBTestFactory(protocol.ClientFactory):  # type: ignore[misc]
+    class RFBTestFactory(protocol.ClientFactory):
         """test factory"""
 
         protocol = RFBTest
@@ -952,7 +952,7 @@ if __name__ == "__main__":
 
             reactor.stop()
 
-    class Options(usage.Options):  # type: ignore[misc]
+    class Options(usage.Options):
         """command line options"""
 
         optParameters = [


### PR DESCRIPTION
`--warn-unused-ignores` flags 15 dead `# type: ignore[...]` comments — most were suppressing a `disallow_subclassing_any` complaint on Twisted subclasses that no longer applies now that Twisted ships `py.typed`. 10 come off entirely; 5 in `test_client.py` narrow from `[assignment]` to `[method-assign]` rather than disappearing. 4 ignores elsewhere are tested (by deletion) to still be needed and are left alone.

Error count unchanged at 298 — pruning dead ignores doesn't surface hidden errors, which is the point.

Tested: `--warn-unused-ignores` clean, `make test` 300 pass, `flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
