### PR TITLE
CI: report mypy results without gating on them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,50 @@ jobs:
       - name: Run flake8
         run: uv run flake8 --count --statistics vncdotool tests
 
+  mypy:
+    name: Type check (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run mypy
+        run: |
+          set +e
+          uv run mypy vncdotool | tee mypy.log
+          echo "MYPY_EXIT_CODE=${PIPESTATUS[0]}" >> "$GITHUB_ENV"
+          exit 0
+
+      - name: Summarize mypy results
+        if: always()
+        run: |
+          {
+            echo "## mypy (advisory, does not fail CI)"
+            echo
+            if [ "$MYPY_EXIT_CODE" = "0" ]; then
+              echo "No errors."
+            else
+              tail -n 1 mypy.log
+            fi
+            echo
+            echo "<details><summary>Full output</summary>"
+            echo
+            echo '```'
+            cat mypy.log
+            echo '```'
+            echo
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   servers:
     name: Test server functional tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a `Type check (advisory)` job so the mypy count is visible on every PR without gating merges on it. Separate job rather than a step in `lint`, because the checks list shows job names: a swallowed step inside `lint` would leave that check green with no sign mypy had run at all.

Scoped to `mypy vncdotool` (not `vncdotool tests`), matching #434's decision to drop `tests/` from `make typecheck` — unittest's dynamic patterns throw false positives there that swamp real findings.

Non-blocking via capturing mypy's exit status in the run step (`set +e`, read `PIPESTATUS[0]`, `exit 0`) rather than `continue-on-error`, which still renders as failed-but-ignored in some views. `set +e` matters here specifically: Actions runs steps under `-eo pipefail`, so without it the mypy|tee pipeline's nonzero exit would abort the step before `PIPESTATUS` could be read. The check reports green; the job name is what marks it advisory. Count and full output go to `$GITHUB_STEP_SUMMARY`, folded in `<details>`, matching the `coverage` job.

It becomes a gate once the count is near zero — not merely once it runs.

Tested: workflow YAML parses; ran the step's exact script under Actions' shell flags (`bash --noprofile --norc -eo pipefail`) — mypy exits 1, the step exits 0, `MYPY_EXIT_CODE=1` lands in `$GITHUB_ENV` for the summary step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
