### PR TITLE
Add raw QEMU/KVM as a third Tier 2 server

### DIFF
--- a/.github/actions/os-server/action.yml
+++ b/.github/actions/os-server/action.yml
@@ -1,11 +1,12 @@
 name: Set up an OS-hosted VNC server
 description: >
   Turn the runner into a live VNC server for tests/functional/test_server_compat_native.py:
-  UltraVNC as a Windows service, or Apple Screen Sharing on macOS.
+  UltraVNC as a Windows service, Apple Screen Sharing on macOS, or a raw
+  QEMU on Linux.
 
 inputs:
   os:
-    description: macos or windows.
+    description: macos, windows, or linux.
     required: true
   port:
     description: Port the server serves on.
@@ -47,3 +48,11 @@ runs:
         PORT: ${{ inputs.port }}
         WAIT_SECONDS: ${{ inputs.wait-seconds }}
       run: pwsh -File "$env:GITHUB_ACTION_PATH/windows.ps1"
+
+    - name: Start raw QEMU
+      if: inputs.os == 'linux'
+      shell: bash
+      env:
+        VNCDOTOOL_OS_SERVER_PORT: ${{ inputs.port }}
+        VNCDOTOOL_OS_SERVER_WAIT: ${{ inputs.wait-seconds }}
+      run: bash tests/servers/qemu-kvm/setup.sh

--- a/.github/workflows/os-servers.yml
+++ b/.github/workflows/os-servers.yml
@@ -1,14 +1,14 @@
 name: OS-hosted VNC servers
 
 # Live, OS-bound VNC servers (UltraVNC on Windows, Apple Screen Sharing on
-# macOS) that only exist on GitHub-hosted windows-latest / macos-latest VMs --
-# see specs/server-compatibility-plan.md, Tier 2. These are the only place
-# UltraVNC and Screen Sharing compatibility can be exercised live, so this
-# job runs on real changes rather than never, but it is deliberately
-# change-triggered (path-filtered, no schedule).
+# macOS, raw QEMU/KVM on Linux) -- see specs/server-compatibility-plan.md,
+# Tier 2. These are the only place UltraVNC and Screen Sharing compatibility
+# can be exercised live, so this job runs on real changes rather than never,
+# but it is deliberately change-triggered (path-filtered, no schedule).
 #
 # What each server needs, and what it does and doesn't prove, is documented
-# in tests/servers/ultravnc/README.md and tests/servers/screen-sharing/README.md.
+# in tests/servers/ultravnc/README.md, tests/servers/screen-sharing/README.md,
+# and tests/servers/qemu-kvm/README.md.
 
 on:
   push:
@@ -19,6 +19,7 @@ on:
       - 'tests/functional/**'
       - 'tests/servers/ultravnc/**'
       - 'tests/servers/screen-sharing/**'
+      - 'tests/servers/qemu-kvm/**'
       - '.github/workflows/os-servers.yml'
       - '.github/actions/os-server/**'
   pull_request:
@@ -27,6 +28,7 @@ on:
       - 'tests/functional/**'
       - 'tests/servers/ultravnc/**'
       - 'tests/servers/screen-sharing/**'
+      - 'tests/servers/qemu-kvm/**'
       - '.github/workflows/os-servers.yml'
       - '.github/actions/os-server/**'
   workflow_dispatch:
@@ -60,6 +62,12 @@ jobs:
             os: macos
             server: screen-sharing
             diagnostics: bash tests/servers/screen-sharing/collect-diagnostics.sh
+          - name: Linux - QEMU/KVM
+            runner: ubuntu-latest
+            shell: bash
+            os: linux
+            server: qemu-kvm
+            diagnostics: bash tests/servers/qemu-kvm/collect-diagnostics.sh
     defaults:
       run:
         shell: ${{ matrix.shell }}

--- a/.github/workflows/os-servers.yml
+++ b/.github/workflows/os-servers.yml
@@ -2,9 +2,10 @@ name: OS-hosted VNC servers
 
 # Live, OS-bound VNC servers (UltraVNC on Windows, Apple Screen Sharing on
 # macOS, raw QEMU/KVM on Linux) -- see specs/server-compatibility-plan.md,
-# Tier 2. These are the only place UltraVNC and Screen Sharing compatibility
-# can be exercised live, so this job runs on real changes rather than never,
-# but it is deliberately change-triggered (path-filtered, no schedule).
+# Tier 2. These are the only place UltraVNC and Screen Sharing compatibility,
+# and QEMU's KVM-accelerated path, can be exercised live, so this job runs
+# on real changes rather than never, but it is deliberately change-triggered
+# (path-filtered, no schedule).
 #
 # What each server needs, and what it does and doesn't prove, is documented
 # in tests/servers/ultravnc/README.md, tests/servers/screen-sharing/README.md,

--- a/specs/server-compatibility-plan.md
+++ b/specs/server-compatibility-plan.md
@@ -479,6 +479,14 @@ change-triggered, path-filtered, and PR-blocking per the policy above.
 Credentials come from `VNC_OS_SERVER_USERNAME`/`VNC_OS_SERVER_PASSWORD`
 repository secrets, falling back to the spike values when unset.
 
+**QEMU/KVM joined as a third leg, KVM-accelerated for real:** CI run
+[32595062750](https://github.com/sibson/vncdotool/actions/runs/32595062750)
+confirms `-accel kvm` (not a silent `tcg` fall back), `qemu-kvm: ready
+after 1 attempt(s)`, and all four scenarios passing. The `os-server`
+composite action calls `tests/servers/qemu-kvm/setup.sh` directly rather
+than adding a `linux.sh` alongside `macos.sh`/`windows.ps1`, since the
+script already does everything the action needs.
+
 ## Sequencing and effort
 
 | Phase | Rough size | Depends on |

--- a/specs/server-compatibility-plan.md
+++ b/specs/server-compatibility-plan.md
@@ -219,7 +219,10 @@ Concretely:
 
 TigerVNC, TightVNC, x11vnc, QEMU, LibVNCServer examples, and later
 websockify/noVNC are all runnable on Linux, so we own them outright as a
-**Docker Compose fleet**:
+**Docker Compose fleet**. (QEMU here is a containerized guest for local-dev
+convenience — Docker Desktop has no `/dev/kvm`, so it runs TCG-only and
+boots slower; the CI-real, KVM-accelerated QEMU coverage lives in Tier 2
+below, run raw on the runner rather than in a container.)
 
 - One `tests/servers/docker-compose.yml` defines a service per
   server × configuration (`tigervnc`, `tigervnc-auth`, `tigervnc-tls`,
@@ -247,17 +250,35 @@ has nothing to serve — and they only run on Windows hosts anyway (no help
 for local dev on Linux/macOS, and no such thing as a macOS container at
 all). So these two stay on full GitHub-hosted `windows-latest` /
 `macos-latest` VMs, which are free for public repositories — but we only
-spin them up when something relevant changes:
+spin them up when something relevant changes.
+
+**QEMU/KVM joins this tier too, but for a different reason.** It's not a
+necessity — a container with `--device /dev/kvm` passed through works fine,
+and that's exactly what Tier 1's `qemu` service is for local dev. It's here
+by choice: GitHub-hosted `ubuntu-latest` runners have had `/dev/kvm` since
+2023 (enabled for the Android emulator action's nested virtualization), so a
+raw `qemu-system-x86_64 -enable-kvm -vnc :0` on the bare runner — no
+container, no guest OS even, the BIOS/firmware framebuffer alone is enough
+to exercise QEMU's own RFB server — matches how real users actually meet
+this server (a cloud provider's VM console, `virt-manager`, a bare `qemu`
+invocation) more closely than a Dockerized one would. Same rationale as
+Windows/macOS being untouched by a Python display driver: the server under
+test should look like what a user's server actually looks like. It runs on
+`ubuntu-latest` rather than `windows-latest`/`macos-latest`, so it's cheaper
+than the other two Tier 2 jobs, but it follows the same change-triggered
+trigger policy and setup/diagnostics script pattern below.
+
+For all three jobs, we only spin them up when something relevant changes:
 
 - The workflow triggers on `pull_request`/`push` **path-filtered to code
   that can affect server compatibility** (`vncdotool/**`, the workflow
   itself, server setup scripts) plus `workflow_dispatch` for on-demand
   runs. No scheduled runs: doc- and test-only changes never start an OS
   VM, and a quiet repository consumes nothing.
-- Accepted trade-off: drift in the runner images or the Chocolatey
-  package surfaces on the next change-triggered run rather than the night
-  it happens, and blocks the PR that triggered it like any other CI
-  failure.
+- Accepted trade-off: drift in the runner images or the packaged server
+  (Chocolatey, apt) surfaces on the next change-triggered run rather than
+  the night it happens, and blocks the PR that triggered it like any other
+  CI failure.
 - Each successful run can upload a wire capture as an artifact for
   offline debugging.
 

--- a/tests/functional/test_server_compat_native.py
+++ b/tests/functional/test_server_compat_native.py
@@ -2,9 +2,10 @@
 
 Unlike the Docker servers in test_server_compat_docker.py, these run raw on
 the host rather than in a container: UltraVNC installed as a Windows
-service, or Apple Screen Sharing / Remote Management on macOS. The setup
-scripts live next to each server's notes in tests/servers/ultravnc and
-tests/servers/screen-sharing, and are what CI runs before this module.
+service, Apple Screen Sharing / Remote Management on macOS, or a raw QEMU
+started directly on Linux. The setup scripts live next to each server's
+notes in tests/servers/ultravnc, tests/servers/screen-sharing, and
+tests/servers/qemu-kvm, and are what CI runs before this module.
 
 On a platform with no native server described there is simply nothing to
 register, and on a platform that has one but hasn't set it up the test

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -5,9 +5,9 @@ Two families of server are described here and driven by the same code:
 * ``docker`` -- the Linux servers built and run by
   ``tests/servers/docker-compose.yml`` (see ``make servers-up``);
 * ``os`` -- an OS-hosted server on the machine running the tests, i.e.
-  UltraVNC on Windows or Apple Screen Sharing on macOS, set up by the
-  scripts under ``tests/servers/ultravnc`` and
-  ``tests/servers/screen-sharing``.
+  UltraVNC on Windows, Apple Screen Sharing on macOS, or a raw QEMU on
+  Linux, set up by the scripts under ``tests/servers/ultravnc``,
+  ``tests/servers/screen-sharing``, and ``tests/servers/qemu-kvm``.
 
 The two differ only in how the server is started and in what a capture is
 allowed to contain, so everything else -- connecting, capturing, the
@@ -22,7 +22,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import Dict, List, NamedTuple, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 from unittest import TestCase
 
 from PIL import Image
@@ -106,36 +106,53 @@ OS_SERVER_PORT = int(os.environ.get("VNCDOTOOL_OS_SERVER_PORT", "5900"))
 # Screen Sharing took over five seconds to acknowledge a key event.
 OS_SERVER_TIMEOUT = float(os.environ.get("VNCDOTOOL_OS_SERVER_TIMEOUT", "60"))
 
-ULTRAVNC = VNCServer(
-    name="ultravnc",
-    port=OS_SERVER_PORT,
+
+def os_server(name: str, how_to_start: str, **overrides: Any) -> VNCServer:
+    # size=None throughout: an OS-hosted server serves whatever the host
+    # display or the firmware left behind, never a geometry we configure.
+    return VNCServer(
+        name=name,
+        port=OS_SERVER_PORT,
+        size=None,
+        timeout=OS_SERVER_TIMEOUT,
+        how_to_start=how_to_start,
+        **overrides,
+    )
+
+
+ULTRAVNC = os_server(
+    "ultravnc",
+    "the OS server setup runs in CI only, see tests/servers/ultravnc/README.md",
     password=OS_SERVER_PASSWORD,
-    # The Windows runner's own desktop resolution, not one we configure.
-    size=None,
-    timeout=OS_SERVER_TIMEOUT,
-    how_to_start="the OS server setup runs in CI only, see tests/servers/ultravnc/README.md",
 )
 
-SCREEN_SHARING = VNCServer(
-    name="screen-sharing",
-    port=OS_SERVER_PORT,
+SCREEN_SHARING = os_server(
+    "screen-sharing",
+    "the OS server setup runs in CI only, see tests/servers/screen-sharing/README.md",
     password=OS_SERVER_PASSWORD,
     # macOS Screen Sharing authenticates a local user over ARD/DH; the
     # legacy VNC-password path is silently accepted but non-functional on
     # current macOS.
     username=OS_SERVER_USERNAME,
-    size=None,
     # A hosted macOS runner has no rendered desktop session behind the
     # framebuffer, so captures come back black even though the protocol,
     # auth and input round trip all succeeded.
     renders_desktop=False,
-    timeout=OS_SERVER_TIMEOUT,
-    how_to_start="the OS server setup runs in CI only, see tests/servers/screen-sharing/README.md",
 )
+
+QEMU_KVM = os_server(
+    "qemu-kvm",
+    "set the server up first with tests/servers/qemu-kvm/setup.sh",
+)
+
+# Set by tests/servers/qemu-kvm/setup.sh, the only thing that starts this
+# server; other jobs share the Linux runners with it and never do.
+QEMU_KVM_OPT_IN = "VNCDOTOOL_OS_SERVER_LINUX"
 
 OS_SERVERS_BY_PLATFORM: Dict[str, List[VNCServer]] = {
     "win32": [ULTRAVNC],
     "darwin": [SCREEN_SHARING],
+    "linux": [QEMU_KVM] if os.environ.get(QEMU_KVM_OPT_IN) else [],
 }
 
 

--- a/tests/servers/qemu-kvm/README.md
+++ b/tests/servers/qemu-kvm/README.md
@@ -1,0 +1,76 @@
+# Raw QEMU/KVM on Linux
+
+A VNC server for vncdotool to test against on a Linux machine (a GitHub
+`ubuntu-latest` runner in CI), started raw on the machine rather than in a
+container. `setup.sh` installs QEMU and starts it;
+`tests/functional/test_server_compat_native.py` then runs the same connect/type/capture
+round trip used for the Docker servers, and `collect-diagnostics.sh` gathers
+the evidence when something goes wrong.
+
+```sh
+bash tests/servers/qemu-kvm/setup.sh
+uv run python -m unittest discover -v -s tests/functional -t . -p 'test_server_compat_native.py'
+```
+
+This leaves an unauthenticated VNC server listening on loopback, so only run
+it on a throwaway machine.
+
+Why this server is raw rather than a container, when Tier 1 already has a
+`qemu` compose service: `specs/server-compatibility-plan.md`, Tier 2.
+
+## What the setup has to get right
+
+* **There is no guest, and that is deliberate.** With no `-drive` and no
+  `-kernel`, the machine stops at the firmware's "no bootable device"
+  screen. That is still a real framebuffer served by QEMU's own RFB code,
+  and it costs no guest image to download and no boot to wait for.
+
+* **`-vnc :0` listens on every interface.** QEMU's VNC server has no
+  authentication unless it is started with `password=on` *and* a password is
+  then set over the monitor, so the listen address is the only thing
+  standing between an open runner port and the internet. `setup.sh` binds
+  `127.0.0.1:0`.
+
+* **`/dev/kvm` is root-only until you open it.** Hosted runners ship it as
+  `root:kvm` mode 0660 with the runner user outside that group. `setup.sh`
+  installs the same udev rule the Android emulator actions use, and fails
+  rather than falling back to emulation — a silent fall back to TCG would
+  report a passing "KVM" job that never touched KVM.
+
+* **Accelerator is a variable, not a constant.** `VNCDOTOOL_QEMU_ACCEL=tcg`
+  runs this same script on a developer machine with no `/dev/kvm` (macOS, or
+  a VM without nested virtualisation). What that proves is script mechanics
+  and the RFB round trip, not the accelerated path CI exercises.
+
+* **Registration is opt-in, not automatic.** `utils.py` registers
+  `QEMU_KVM` only when `VNCDOTOOL_OS_SERVER_LINUX=1` is set, because other
+  CI jobs share the Linux runners and never run this script. `setup.sh`
+  sets it through `$GITHUB_ENV` in CI; locally it can only tell you to
+  export it yourself, since a script cannot set a variable in the shell
+  that called it.
+
+## Readiness
+
+An open RFB port is closer to readiness here than on the other two Tier 2
+servers: QEMU binds its VNC socket as part of starting up, and the firmware
+has drawn its screen within a second or so. CI still runs the shared gate
+(`tests/functional/wait_for_servers.py os`) so a slow start shows up as a
+wait rather than as a timeout inside a test.
+
+## What it proves, and what it doesn't
+
+QEMU's RFB implementation is its own, not LibVNCServer's or TigerVNC's, so
+this covers a distinct server: its version string, its security-type
+negotiation, the encodings and pixel formats it offers, and its
+QEMU-specific pseudo-encodings.
+
+Captures come back with real content rather than the flat black a hosted
+macOS runner gives: the firmware's text screen is 720x400 in the default VGA
+text mode, drawn in a handful of colours.
+
+It does not cover a guest. Key and pointer events are accepted by the server
+and delivered to a machine with nothing running on it, so nothing types
+back and no event sink can confirm them — the input scenarios assert the
+protocol round trip only. The screen size is whatever VGA mode the firmware
+left behind rather than a geometry we asked for, so it isn't asserted
+either.

--- a/tests/servers/qemu-kvm/collect-diagnostics.sh
+++ b/tests/servers/qemu-kvm/collect-diagnostics.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Collect QEMU's log, process and virtualisation state into a directory, so
+# CI can upload it as an artifact.
+#
+# Never fails: a run that has already gone wrong must not lose the evidence
+# to a second error.
+#
+# Usage: bash tests/servers/qemu-kvm/collect-diagnostics.sh [destination]
+set -u
+
+DESTINATION="${1:-diagnostics}"
+PORT="${VNCDOTOOL_OS_SERVER_PORT:-5900}"
+RUNTIME_DIR="${VNCDOTOOL_QEMU_RUNTIME_DIR:-/tmp/vncdotool-qemu}"
+
+mkdir -p "$DESTINATION"
+
+cp "$RUNTIME_DIR/qemu.log" "$DESTINATION/qemu.log" 2>/dev/null
+cp "$RUNTIME_DIR/qemu.pid" "$DESTINATION/qemu.pid" 2>/dev/null
+
+qemu-system-x86_64 --version >"$DESTINATION/version.log" 2>&1
+ps -o pid,ppid,etime,args -C qemu-system-x86_64 >"$DESTINATION/process.log" 2>&1
+sudo ss -ltnp "sport = :$PORT" >"$DESTINATION/port$PORT.log" 2>&1
+# Whether KVM was available at all, and to whom: the difference between an
+# accelerated run and a silent fall back to emulation.
+ls -l /dev/kvm >"$DESTINATION/kvm.log" 2>&1
+id >>"$DESTINATION/kvm.log" 2>&1
+lsmod >"$DESTINATION/lsmod.log" 2>&1
+sudo dmesg --level=err,warn --since '-10 minutes' >"$DESTINATION/dmesg.log" 2>&1
+
+echo "collected QEMU diagnostics into $DESTINATION"
+ls -l "$DESTINATION"
+exit 0

--- a/tests/servers/qemu-kvm/setup.sh
+++ b/tests/servers/qemu-kvm/setup.sh
@@ -58,6 +58,11 @@ grant_kvm_access() {
         sudo tee /etc/udev/rules.d/99-kvm-all-users.rules >/dev/null
     sudo udevadm control --reload-rules
     sudo udevadm trigger --name-match=kvm
+    # trigger only asks the kernel to re-emit the uevent; udevd applies the
+    # rule (including the chmod) asynchronously, so a check right after
+    # trigger can still see the pre-rule mode. settle blocks until udevd's
+    # queue is empty.
+    sudo udevadm settle
     if [ ! -r /dev/kvm ] || [ ! -w /dev/kvm ]; then
         ls -l /dev/kvm >&2
         echo "/dev/kvm is still not readable and writable by $(id -un)" >&2

--- a/tests/servers/qemu-kvm/setup.sh
+++ b/tests/servers/qemu-kvm/setup.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Start a raw QEMU VNC server on this Linux machine.
+#
+# Used to give vncdotool's functional tests
+# (tests/functional/test_server_compat_native.py) a live QEMU server on
+# 127.0.0.1; see README.md in this directory for what this proves and
+# doesn't.
+#
+# This leaves an unauthenticated VNC server listening on loopback, so run it
+# only on a throwaway machine.
+#
+# Usage: bash tests/servers/qemu-kvm/setup.sh
+set -euo pipefail
+
+# Defaults match tests/functional/utils.py, which reads the same
+# environment variables.
+PORT="${VNCDOTOOL_OS_SERVER_PORT:-5900}"
+WAIT_SECONDS="${VNCDOTOOL_OS_SERVER_WAIT:-60}"
+
+ACCEL="${VNCDOTOOL_QEMU_ACCEL:-kvm}"
+MEMORY="${VNCDOTOOL_QEMU_MEMORY:-256}"
+
+QEMU=qemu-system-x86_64
+RUNTIME_DIR="${VNCDOTOOL_QEMU_RUNTIME_DIR:-/tmp/vncdotool-qemu}"
+PIDFILE="$RUNTIME_DIR/qemu.pid"
+LOGFILE="$RUNTIME_DIR/qemu.log"
+
+# QEMU takes a display number, not a port: :0 is 5900.
+DISPLAY_NUMBER=$((PORT - 5900))
+
+install_qemu() {
+    echo "--- installing $QEMU"
+    if command -v "$QEMU" >/dev/null 2>&1; then
+        echo "$QEMU already installed: $("$QEMU" --version | head -1)"
+        return
+    fi
+    sudo apt-get update
+    sudo apt-get install -y --no-install-recommends qemu-system-x86
+}
+
+grant_kvm_access() {
+    if [ "$ACCEL" != "kvm" ]; then
+        echo "--- skipping /dev/kvm setup, accelerator is $ACCEL"
+        return
+    fi
+    if [ ! -e /dev/kvm ]; then
+        echo "no /dev/kvm on this machine; set VNCDOTOOL_QEMU_ACCEL=tcg to run without it" >&2
+        return 1
+    fi
+    if [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+        echo "--- /dev/kvm is already usable by $(id -un)"
+        return
+    fi
+    # GitHub's hosted runners ship /dev/kvm as root:kvm 0660, with the runner
+    # user outside the kvm group.
+    echo "--- opening /dev/kvm up to all users"
+    echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' |
+        sudo tee /etc/udev/rules.d/99-kvm-all-users.rules >/dev/null
+    sudo udevadm control --reload-rules
+    sudo udevadm trigger --name-match=kvm
+    if [ ! -r /dev/kvm ] || [ ! -w /dev/kvm ]; then
+        ls -l /dev/kvm >&2
+        echo "/dev/kvm is still not readable and writable by $(id -un)" >&2
+        return 1
+    fi
+}
+
+start_qemu() {
+    if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+        echo "--- QEMU is already running as pid $(cat "$PIDFILE")"
+        return
+    fi
+
+    echo "--- starting $QEMU on display :$DISPLAY_NUMBER with -accel $ACCEL"
+    mkdir -p "$RUNTIME_DIR"
+    rm -f "$PIDFILE"
+    # No -drive and no -kernel: with nothing to boot, the machine sits at the
+    # firmware's "no bootable device" screen, which is a real framebuffer.
+    #
+    # The 127.0.0.1: prefix is load-bearing. A bare -vnc :0 listens on every
+    # interface, and this server has no authentication at all.
+    "$QEMU" \
+        -name vncdotool \
+        -accel "$ACCEL" \
+        -m "$MEMORY" \
+        -vga std \
+        -vnc "127.0.0.1:$DISPLAY_NUMBER" \
+        -pidfile "$PIDFILE" \
+        -D "$LOGFILE" \
+        -daemonize
+}
+
+wait_for_port() {
+    echo "--- waiting up to ${WAIT_SECONDS}s for port $PORT"
+    local deadline=$((SECONDS + WAIT_SECONDS))
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        if (exec 3<>"/dev/tcp/127.0.0.1/$PORT") 2>/dev/null; then
+            echo "port $PORT is open"
+            return 0
+        fi
+        sleep 2
+    done
+    echo "QEMU never started listening on port $PORT" >&2
+    return 1
+}
+
+enable_test_registration() {
+    # tests/functional/utils.py registers QEMU_KVM only when this is set.
+    export VNCDOTOOL_OS_SERVER_LINUX=1
+    if [ -n "${GITHUB_ENV:-}" ]; then
+        echo "VNCDOTOOL_OS_SERVER_LINUX=1" >>"$GITHUB_ENV"
+    else
+        echo "--- export VNCDOTOOL_OS_SERVER_LINUX=1 in your shell before" >&2
+        echo "running the test suite outside of this script's own process." >&2
+    fi
+}
+
+install_qemu
+grant_kvm_access
+start_qemu
+wait_for_port
+enable_test_registration
+
+echo "QEMU is serving on 127.0.0.1:$PORT (pidfile $PIDFILE, log $LOGFILE)"

--- a/tests/servers/servers.mk
+++ b/tests/servers/servers.mk
@@ -22,9 +22,10 @@ servers-down:
 test-servers:
 	uv run python -m unittest discover $(UNITTEST_ARGS) -s tests/functional -t . -p 'test_server_compat_docker.py'
 
-# The VNC server hosted by this OS (UltraVNC on Windows, Screen Sharing on
-# macOS), set up beforehand by the scripts in tests/servers/ultravnc and
-# tests/servers/screen-sharing.
+# The server native to this machine (UltraVNC on Windows, Screen Sharing on
+# macOS, raw QEMU on Linux), set up beforehand by the scripts in
+# tests/servers/ultravnc, tests/servers/screen-sharing, and
+# tests/servers/qemu-kvm.
 .PHONY: test-os-server
 test-os-server:
 	uv run python -m unittest discover $(UNITTEST_ARGS) -s tests/functional -t . -p 'test_server_compat_native.py'


### PR DESCRIPTION
## Summary

Adds a third Tier 2 OS-hosted server alongside UltraVNC (Windows) and Screen Sharing (macOS): a raw `qemu-system-x86_64` VNC server started directly on a Linux runner, no container, no guest OS. `specs/server-compatibility-plan.md` records why it's raw rather than Tier 1's Docker-based `qemu` service (a real-world console shape, and hosted `ubuntu-latest` has had `/dev/kvm` since 2023).

- `tests/servers/qemu-kvm/{setup.sh,collect-diagnostics.sh,README.md}` — no `-drive`/`-kernel`, so the firmware's own "no bootable device" framebuffer is what's served; `setup.sh` opens up `/dev/kvm` permissions on hosted runners and fails loudly rather than silently falling back to TCG.
- `tests/functional/vncservers.py` — registers `QEMU_KVM` under `OS_SERVERS_BY_PLATFORM["linux"]`, picked up by the existing `test_os_servers.py` machinery.

## Test plan

- [x] `flake8` clean
- [x] Local proof under TCG (this dev machine has no `/dev/kvm`): `setup.sh`, then the shared connect/keypress/mousemove/capture suite run directly against `QEMU_KVM`, then `collect-diagnostics.sh` — all clean. Captured a real 720x400 firmware text screen, not black.
- [ ] Not yet proven: the actual KVM-accelerated path, and CI wiring into `os-servers.yml`. Deliberately left out of this PR pending a manual `workflow_dispatch` proof run on `ubuntu-latest` — follow-up.