### PR TITLE
Pause before retrying a readiness probe that raised

### DIFF
--- a/tests/functional/vncservers.py
+++ b/tests/functional/vncservers.py
@@ -230,6 +230,7 @@ def wait_until_ready(
                     colours = distinct_colours(image)
         except Exception as exc:  # noqa: BLE001 - any failure means try again
             print(f"{server.name}: not ready yet (attempt {attempt}: {exc})")
+            time.sleep(RETRY_DELAY)
             continue
         if not has_expected_content(server, colours):
             print(f"{server.name}: not ready yet (attempt {attempt}: capture is flat)")


### PR DESCRIPTION
`wait_until_ready`'s exception branch retried with no pause, unlike the port-closed and flat-capture branches beside it. A server that fails fast then burns the whole readiness budget in a burst.

Seen on the `macOS - Screen Sharing` job of #402 ([run 32543585243](https://github.com/sibson/vncdotool/actions/runs/32543585243)): attempt 1 stalled about three minutes and failed with `Authentication or authorization failure`, then attempts 2-9 fired inside 80ms and the loop hit its deadline. The log reads as nine attempts against a server that was given no time between them.

This does not fix that job — the deadline was already spent by the first attempt, and the auth failure is its own problem — it stops the retry count from lying about what was tried.

Tested: `flake8` clean, unit suite green. The changed path is functional-suite setup, exercised by the CI server jobs rather than by unit tests.
