### PR TITLE
Carry the comment policy in the repo, where a cloud session can find it

### DIFF
--- a/.claude/skills/writing-code-comments/.agent-skills.json
+++ b/.claude/skills/writing-code-comments/.agent-skills.json
@@ -1,0 +1,5 @@
+{
+  "source": "agent-skills",
+  "skill": "writing-code-comments",
+  "version": "e7dc57a969fcf0a37751bb24d4e30aa915805174"
+}

--- a/.claude/skills/writing-code-comments/.agent-skills.json
+++ b/.claude/skills/writing-code-comments/.agent-skills.json
@@ -1,5 +1,5 @@
 {
   "source": "agent-skills",
   "skill": "writing-code-comments",
-  "version": "362f0da32fcaf3754e41108e121067bd8d04c625"
+  "version": "fd05f7db90970f15b6eacee018c8cfb247db515d"
 }

--- a/.claude/skills/writing-code-comments/.agent-skills.json
+++ b/.claude/skills/writing-code-comments/.agent-skills.json
@@ -1,5 +1,5 @@
 {
   "source": "agent-skills",
   "skill": "writing-code-comments",
-  "version": "e7dc57a969fcf0a37751bb24d4e30aa915805174"
+  "version": "362f0da32fcaf3754e41108e121067bd8d04c625"
 }

--- a/.claude/skills/writing-code-comments/SKILL.md
+++ b/.claude/skills/writing-code-comments/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: writing-code-comments
+description: Use when about to write or edit a comment, docstring, module header, or CHANGELOG entry in any language, and when auditing a diff, branch, file, or changelog section for prose quality — including when review feedback calls comments or entries verbose, redundant, obvious, noisy, restating the code, or when a repo's conventions file has a comments policy to apply.
+---
+
+# Writing Code Comments
+
+## Overview
+
+A comment carries one fact the reader cannot get anywhere else: from the
+language, the library's docs, the specs, the identifier names, or the code
+itself. Everything else is noise the reader must still read.
+
+**The repo's own policy wins.** Before writing or auditing, read the comments
+section of the repo's conventions file (`CLAUDE.md`, `AGENTS.md`,
+`CONTRIBUTING`). This skill is how to apply such a policy, not a replacement
+for one.
+
+## Mode A — Author time
+
+Before writing any comment, name the fact it carries. Say it out loud in this
+shape:
+
+> "The reader cannot know that ___ from the code, and will be surprised later
+> if they don't."
+
+Fill the blank with something particular to *this* code: a server that ignores
+what it was asked, an ordering nothing enforces, an obvious approach that does
+not work here, a bound that comes from outside the file.
+
+Then check where that fact already lives. True and non-obvious is **not** the
+test — a sentence can be both and still be a paraphrase of the docstring above
+it, of the code it describes, or of a comment in the module it wraps. Look at
+the thing being described before you keep the comment: if the fact is already
+written within the reader's reach, delete.
+
+**Look outside the file too**, at the commit message introducing the change,
+the PR, and `docs/`. A fact you just wrote in a commit body is already housed;
+repeating it in a comment makes a second copy that drifts from the first. When
+the repo's policy routes rationale to commits or `docs/`, that routing decides
+the verdict — the comment goes, even where the fact is genuinely surprising and
+lives nowhere in the code. Before keeping any comment that explains *why*, ask
+what the commit message for this change says — or will say.
+
+Can't fill it? Write no comment. That is the finished, correct outcome — not a
+failure to be papered over with a shorter comment.
+
+The comment IS that one fact, in plain prose, one or two lines. Not a preamble
+plus the fact. Not the fact plus a restatement of the code.
+
+## Name the source, or write nothing
+
+A comment that survives Mode A still has to be *true*, and you have to know it
+is. Before writing, name the source of the fact to yourself:
+
+- **The spec or docs** — then cite which, so the reader can check.
+- **Observed behaviour** — then say what was observed and where
+  ("as observed on VMware ESXi"), not what the vendor supposedly does.
+- **The code elsewhere** — then it is probably redundant; re-run Mode A.
+
+Cite a source by naming it, not by its identifier. `R3` and `N2` are lookups,
+not citations — the reader cannot check one without opening something else and
+searching it. Name the constraint in the comment; if the document is worth
+pointing at, point at it by title. An issue or PR number is not a citation to
+fix but a comment to delete — that fact belongs in the commit message.
+
+No source? You are inferring a story from a shape in the code. Write nothing.
+
+This is the most damaging failure mode, because the output is indistinguishable
+from expertise: a confident sentence about what some server "always" does,
+inferred from a byte pattern. It cannot be checked, it never gets removed, and
+readers trust it more than the code. Hedged phrasing is not a fix — "some
+servers may" with no source is the same guess wearing a hat.
+
+## Mode B — Sweep
+
+Sweep the diff you are about to commit, not the branch you are about to open
+a PR on. A sweep deferred to PR time has to be applied across every commit
+that has landed since, and across a stack of PRs it means rebasing the stack
+to fix comments. Keep a final pass at PR time for what arrived by rebase.
+
+Auditing a diff, branch, or file:
+
+1. Enumerate **every** comment and docstring in scope — not only the ones
+   review flagged. Reviews catch samples; the pattern is repo-wide. Drop
+   vendored files and published API reference from scope first.
+
+   **File headers are in scope.** Module docstrings, script preambles, the
+   comment block at the top of a YAML file, the banner above a function:
+   these are where unearned prose collects, because "orientation" feels
+   exempt. It isn't. A header earns its place the same way a line comment
+   does — one fact the reader cannot get from the code below it. "What this
+   file is for" is usually its name; "what it reads from the environment" is
+   usually the next five lines.
+2. Classify each one. Judge **per sentence, not per block** — a block is not a
+   unit, and one load-bearing sentence does not carry the ones around it.
+   - **keep** — every sentence in it carries a fact that lives nowhere else.
+   - **rewrite** — the same facts, expressed better: a cryptic line opened
+     back up, or a claim cut back to what its source actually supports. A
+     rewrite carries *every* fact the original did.
+   - **delete** — anything else.
+
+   Dropping sentences and keeping the survivors is not a rewrite, whatever it
+   is called. That block is a **delete**. Then ask separately, as a fresh
+   Mode A decision, whether any surviving fact earns a new comment of its own —
+   usually its home is the commit message or `docs/` instead.
+3. Check every **kept** comment against the code as it stands now, not as it
+   stood when the comment was written. A sweep that runs after a few commits
+   of design change will find comments that were accurate when authored and
+   are now false — the file that no longer exists, the fallback that was
+   removed, the caller that stopped calling. A wrong comment is worse than
+   the verbose one next to it, and it survives sweeps because it reads as
+   considered.
+4. Apply. Re-read each rewrite against Mode A as if authoring it fresh.
+5. Report every verdict, and for each **keep**, the fact it carries in a
+   handful of words. Counts alone read as diligence; a list of kept facts
+   shows which ones are really "explains the design I just chose".
+
+**Shortening is not a fix.** A shortened unnecessary comment is still an
+unnecessary comment, now also cryptic.
+
+### Sweeping your own work
+
+Judging a comment you wrote an hour ago is not the same task. Reading it
+replays the reasoning that produced it, and it scores as load-bearing because
+you are supplying the load. Reviewers of that same branch come back with
+"describes the code", "verbose", "unnecessary context" — on comments the
+author's own sweep kept.
+
+So for anything authored in this session or branch, do not decide by reading
+it. Decide by naming, out loud, where the fact lives if the comment goes:
+
+> "Deleting this, the fact survives in ___."
+
+The commit body, the PR, the README, the code itself — any of those is a
+delete. Only "nowhere, and the next reader hits it at this line" is a keep.
+Anything written to explain a decision made *in this branch* starts as a
+delete: that is what the commit message is for, and you are about to write it.
+
+## Mode C — Changelog entries
+
+A `CHANGELOG` entry is read by someone scanning a release to decide whether it
+affects them. One line, one user-visible fact: what is different for them now.
+The mechanism, the old behaviour, the wording of the old output, and the
+reassurance that something *else* is unchanged are all commit-message and PR
+material — the same routing Mode A applies to comments.
+
+Write the change the way a user would notice it, then stop:
+
+> ``vncdo`` failures print to stderr as plain messages (@sibson, #395)
+
+The same entry before the cut:
+
+> ``vncdo`` failures now read as CLI errors: the message goes to stderr on its
+> own, instead of being rendered as ``CRITICAL:root:<message>`` by the logging
+> module. The failure's traceback moved to ``-vv``, and log records no longer
+> carry the ``:root:`` logger name. Exit statuses are unchanged.
+
+Both are accurate. The second makes every reader scanning the release parse
+three sentences to reach the one thing they needed, and two of its facts are
+invisible unless you already run `-v`.
+
+**The cut test.** Delete everything after the first clause. Does a reader still
+know whether this release affects them? If yes, the rest was never load-bearing.
+
+| In an entry | Verdict |
+|---|---|
+| The mechanism: how the bug worked, which call was wrong | delete — commit-message material |
+| What did *not* change ("exit codes are unchanged") | delete unless a reader would assume otherwise |
+| A detail only visible under a debug flag | delete |
+| The user-visible symptom, or what a user must now do differently | keep |
+| A break, migration, or flag whose meaning changed | keep, and add the second sentence saying what to do |
+
+## Mode D — Docs written alongside the code
+
+A README beside the code is not exempt because it is prose. It is read by
+someone who wants to run the thing and know what it does not prove, and it
+grows the same way comments do: by accumulating the investigation that
+produced the current design.
+
+Apply the same routing. Evidence — the error strings, the run URLs, the two
+tools that refused, what upstream shipped in 2022 — is what the commits that
+found it are for. The README carries the conclusion and the constraints a
+reader will hit.
+
+The test: **would this line still be worth reading by someone who never saw
+the branch that changed it?** A sentence that only makes sense as an answer
+to "why isn't it the other way" is journey, not documentation.
+
+Watch the line count across a branch. A doc that doubles while the code it
+describes gets simpler is recording the work, not the result.
+
+## Three things this does not reach
+
+**Published API reference.** If a module is pulled into generated docs
+(Sphinx `automodule`, godoc, rustdoc, javadoc), its public docstrings are the
+reference a caller reads *instead of* the code. "Restates the name" does not
+apply — the caller has nowhere else to look. Judge those for accuracy instead:
+a docstring naming a parameter that no longer exists is the defect. Check
+before sweeping: grep the docs directory for the module name.
+
+**Strings the tooling prints.** A test method's docstring is its label in
+verbose runners and CI logs (`unittest -v` prints the first line under the test
+name); the same goes for argparse help, `__doc__` used as CLI usage, and
+deprecation messages. Deleting one does not remove noise, it blanks a line in
+someone's report. Run the tool and look before sweeping these.
+
+**Vendored code.** Imported third-party files carry their original author's
+conventions and were never in this repo's style. Check provenance before
+sweeping one — a copyright line naming someone outside the project, or a first
+commit that adds the file whole. Leave them, and exclude them when sampling the
+repo for what good looks like: their idioms will read as defects and they are
+not evidence of anything about this codebase.
+
+## The delete test
+
+Delete the comment. Read the code. Would an intelligent reader who knows the
+language be surprised later? Restore it only then.
+
+## Quick reference
+
+| Candidate | Verdict |
+|---|---|
+| Restates the identifier name, the next line, or the docstring above it | delete |
+| Paraphrases the code, class, or module it describes — even accurately | delete |
+| Docstring opening that renames the function in prose | delete that sentence, keep the rest |
+| Anything in the language reference, library docs, or spec | delete |
+| Describes the change: "now watches", "no longer needs", "was previously" | delete — commit-message material |
+| Names the task, issue, PR, or an alternative you rejected | delete — commit-message and `docs/` material |
+| Cites a requirement by bare identifier: `R3`, `N2` | rewrite — name the constraint, or the document by title |
+| Explains why the design is *this* rather than something else | delete — that is the commit body |
+| File header saying what the file is for, or which env vars it reads | delete — the name says the first, the code says the second |
+| True when written, false now: names a deleted file, a removed path, a caller that stopped calling | delete, and check its neighbours — rot arrives in clusters |
+| Banner or section-divider comment | delete, or fold into prose |
+| Compressed until the reasoning is gone | rewrite at full length; clarity outranks brevity |
+| Asserts what an external system does, with no cited spec or stated observation | delete, or rewrite down to what was actually observed |
+| A behaviour nothing in the code enforces, or a constraint from outside the file | keep |
+
+## Red flags — stop
+
+- "I'll add a short comment for clarity" — clarity of *what*? Name the fact or write nothing.
+- "This byte pattern only makes sense if the server does X" — you are guessing X. Say what the code matches, not why you think it exists.
+- "Every sentence in it is true and non-obvious" — not the test. Ask where the fact already lives: the code below, the docstring above, the module it wraps.
+- "The reviewer said verbose, I'll trim it" — trimming preserves the defect. Delete or rewrite.
+- "Explaining what I changed helps the reviewer" — the diff does that. The comment must still read correctly on `main` a year later.
+- "This function is complex, it deserves a docstring" — complexity is a reason to fix the names first.
+- "That's the file header, it's orientation" — headers are in scope. Same test, same verdicts.
+- "I wrote this an hour ago and it still reads as necessary" — of course it does. Name where the fact lives without it, or delete.
+- "I deleted six and rewrote thirteen, the sweep was thorough" — counts are not evidence. List what you kept and why; the weak keeps show up immediately.
+
+## Rationalizations
+
+| Excuse | Reality |
+|---|---|
+| "Documenting is good practice" | Documenting a *surprise* is. Documenting the visible is subtraction. |
+| "Obvious to me, not to others" | Others read the same code. If names hide the intent, fix the names. |
+| "Better to over-explain than under-explain" | Both cost. Noise trains readers to skip comments, including the load-bearing one. |
+| "The limit says trim, so I compressed it" | Length was never the axis. A cryptic comment fails harder than a long one. |
+| "It documents why I picked this approach" | Only if it is still surprising *as it stands*. Rejected alternatives go in the commit. |
+| "A future AI reader might need it" | An AI reader already has every public document. Same test applies. |
+| "It's the most plausible explanation for this code" | Plausible is not known. An invented why outlives everyone who could correct it. |
+| "I hedged it, so it's honest" | An unsourced guess with "may" in front is still an unsourced guess. |
+| "The changelog entry should explain the fix" | It should name the symptom. The reader wants to know if it was *their* bug, not how it worked. |

--- a/.claude/skills/writing-code-comments/SKILL.md
+++ b/.claude/skills/writing-code-comments/SKILL.md
@@ -8,8 +8,9 @@ description: Use when about to write or edit a comment, docstring, module header
 ## Overview
 
 A comment carries one fact the reader cannot get anywhere else: from the
-language, the library's docs, the specs, the identifier names, or the code
-itself. Everything else is noise the reader must still read.
+language, the library's docs, the specs, the identifier names, the code
+itself, or from running it. Everything else is noise the reader must still
+read.
 
 **The repo's own policy wins.** Before writing or auditing, read the comments
 section of the repo's conventions file (`CLAUDE.md`, `AGENTS.md`,
@@ -63,6 +64,10 @@ not citations — the reader cannot check one without opening something else and
 searching it. Name the constraint in the comment; if the document is worth
 pointing at, point at it by title. An issue or PR number is not a citation to
 fix but a comment to delete — that fact belongs in the commit message.
+
+Point elsewhere only when what is there is surprising and too long to state
+here. A pointer to something unsurprising is a second thing to read on the way
+to learning nothing.
 
 No source? You are inferring a story from a shape in the code. Write nothing.
 
@@ -225,6 +230,7 @@ language be surprised later? Restore it only then.
 | Paraphrases the code, class, or module it describes — even accurately | delete |
 | Docstring opening that renames the function in prose | delete that sentence, keep the rest |
 | Anything in the language reference, library docs, or spec | delete |
+| Names who calls this, or where it is used from | delete — that is what a search finds, and it goes stale |
 | Describes the change: "now watches", "no longer needs", "was previously" | delete — commit-message material |
 | Names the task, issue, PR, or an alternative you rejected | delete — commit-message and `docs/` material |
 | Cites a requirement by bare identifier: `R3`, `N2` | rewrite — name the constraint, or the document by title |

--- a/.claude/skills/writing-code-comments/SKILL.md
+++ b/.claude/skills/writing-code-comments/SKILL.md
@@ -17,6 +17,14 @@ section of the repo's conventions file (`CLAUDE.md`, `AGENTS.md`,
 `CONTRIBUTING`). This skill is how to apply such a policy, not a replacement
 for one.
 
+**Say so if this repo does not carry a copy of this skill.** Check for
+`.claude/skills/writing-code-comments/` in the project being worked on. If it
+is missing, you are running from an install local to this machine, and a
+session on the same repo elsewhere — a cloud container, someone else's
+checkout — gets only what the repo commits, which is nothing. Nothing else
+reports that gap: the session that lacks the skill has no way to know it
+exists. Name it once, and carry on with the work.
+
 ## Mode A — Author time
 
 Before writing any comment, name the fact it carries. Say it out loud in this

--- a/.claude/skills/writing-code-comments/evals/evals.json
+++ b/.claude/skills/writing-code-comments/evals/evals.json
@@ -1,0 +1,30 @@
+{
+  "skill_name": "writing-code-comments",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Audit the comments in the attached fixture and follow its instructions exactly. Report a verdict of delete, rewrite, or keep for each block, with one line of reasoning, then counts by verdict.",
+      "expected_output": "All four blocks are deleted: delete=4 rewrite=0 keep=0. Each block either restates visible code or repeats a fact already housed in the commit body or specs/ quoted in the fixture. Block 1 is the trap for partial redundancy (two of its three paragraphs are redundant, one fact survives) and must come back as delete plus a separate decision about the surviving fact, never as a rewrite that keeps the favoured sentence. Block 3 is the trap for a genuinely surprising fact that is nonetheless verbatim in the commit body of a repo whose policy routes rationale to commits.",
+      "files": ["evals/files/sweep-redundant-blocks.md"],
+      "expectations": [
+        "Every one of the four blocks receives the verdict delete",
+        "The counts line reports delete=4, rewrite=0, keep=0",
+        "Block 1 is not classified as a rewrite on the grounds that one of its three paragraphs carries a surviving fact",
+        "The reasoning for block 3 cites that the fact is already in the commit message, rather than keeping it because it explains the magic value --timeout 2",
+        "No block is retained by dropping some of its sentences and keeping the remainder"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Audit the comments in the attached fixture and follow its instructions exactly. Report a verdict of delete, rewrite, or keep for each block, with one line of reasoning, then counts by verdict.",
+      "expected_output": "Discrimination, not uniform deletion: delete=1 keep=2, or delete=1 with one keep and one rewrite. Blocks 1 and 3 state external behaviour that nothing in the code enforces and that appears nowhere else, in a repo with no convention routing rationale to commits, so they survive. Block 2 paraphrases the single line beneath it and is deleted.",
+      "files": ["evals/files/sweep-mixed-keep-delete.md"],
+      "expectations": [
+        "Block 1 is kept, or rewritten while preserving both the may-ignore behaviour and the trust-the-rectangle instruction",
+        "Block 3 is kept, or rewritten while preserving both the 32bpp/depth-24/little-endian limitation and the silent-wrong-decode consequence",
+        "Block 2 is deleted",
+        "Not every block is deleted"
+      ]
+    }
+  ]
+}

--- a/.claude/skills/writing-code-comments/evals/files/sweep-mixed-keep-delete.md
+++ b/.claude/skills/writing-code-comments/evals/files/sweep-mixed-keep-delete.md
@@ -1,0 +1,58 @@
+# Task
+
+Audit the comments in this diff. Classify EACH comment block below:
+**delete**, **rewrite**, or **keep**.
+
+Give your verdict per block, one line of reasoning each. Then a count by verdict.
+
+## Repo conventions (from CONTRIBUTING)
+
+Comment what is surprising and particular to this code. Do not comment what the
+reader can look up, infer from a name, or learn by running it.
+
+## Context
+
+This project has no convention routing rationale to commit messages. The commits
+below are the entire history of these lines.
+
+Block 1 was introduced by commit `4f21a0c`, whose full message is:
+
+> proxy: forward SetEncodings to the upstream server
+>
+> Adds the passthrough so recorded sessions negotiate the same encodings the
+> real client asked for.
+
+Block 2 was introduced by commit `9ce77b1`, whose full message is:
+
+> capture: write frames to the session directory
+>
+> Uses the run id as the subdirectory name.
+
+## Block 1 --- loggingproxy.py
+
+```python
+    def handle_set_encodings(self, encodings):
+        # SetEncodings only says what the client asked for, and a server may
+        # ignore it. Trust the encoding on each rectangle, not this list.
+        self.requested_encodings = encodings
+        self.upstream.send_set_encodings(encodings)
+```
+
+## Block 2 --- capture.py
+
+```python
+    def frame_path(self, run_id, index):
+        # Build the path to the frame file from the run id and frame index.
+        return self.session_dir / run_id / f"frame-{index:05d}.png"
+```
+
+## Block 3 --- decoder.py
+
+```python
+    def decode_zrle(self, data, rect):
+        # ZRLE assumes 3-byte compressed pixels, so this only works for
+        # 32bpp/depth-24/little-endian. Anything else silently decodes wrong
+        # rather than raising.
+        pixels = self._unpack_cpixels(data)
+        return self._blit(pixels, rect)
+```

--- a/.claude/skills/writing-code-comments/evals/files/sweep-redundant-blocks.md
+++ b/.claude/skills/writing-code-comments/evals/files/sweep-redundant-blocks.md
@@ -1,0 +1,126 @@
+# Task
+
+You are auditing the comments in a pull request you yourself just wrote.
+Classify EACH comment block below: **delete**, **rewrite**, or **keep**.
+
+Give your verdict per block, one line of reasoning each. Then a count by verdict.
+
+## Repo conventions (from CLAUDE.md)
+
+A comment carries what the reader cannot get anywhere else: something
+surprising, particular to this code, and absent from the language, the
+library's documentation, the RFB specs and the code itself.
+
+The reader knows the tools and can read the code, and an AI reader has every
+public document already. Anything they could look up, infer from a name, or
+learn by running it is not worth writing, and neither is anything about the
+change rather than the code -- the alternative you rejected, what used to be
+here, who calls it, the issue or PR it came from. That is commit-message and
+`docs/` material. Point elsewhere only when there is something surprising
+there too long to state here.
+
+Test by deleting it: keep it only if an intelligent reader would still be
+surprised later. Shortening an unnecessary comment leaves an unnecessary
+comment. One or two lines is the norm.
+
+## Context
+
+The PR does two things: it publishes five Docker test-server images to a
+registry (GHCR) so CI pulls them instead of rebuilding, and it shortens the
+container teardown timeout.
+
+The commit that introduced the registry work has this in its message body:
+
+> The tag is that directory's git tree hash, so it changes exactly when the
+> fleet does. It covers more than the build inputs -- editing an UltraVNC
+> script rebuilds images it cannot affect -- which is the safe direction: a
+> hash over hand-listed inputs goes stale silently the first time someone
+> adds a COPY without updating the list.
+>
+> Pull failure falls back to building, so a PR that edits tests/servers (its
+> images do not exist until it lands) and a fork PR (no registry access)
+> behave as they did before.
+
+The commit that introduced the teardown change has this in its message body:
+
+> vncev and libvncserver-example run their upstream binary as PID 1 with no
+> SIGTERM handling, so they eat the full default 10s stop grace period before
+> Docker SIGKILLs them -- the other three services already exit in under a
+> second via their entrypoint traps. Saves ~8s off the servers job.
+
+A design document in the repo, `specs/server-compatibility-plan.md`, already
+carries an entry recording that `type=gha` layer caching was measured and came
+out slower than plain building, and that GHCR is the chosen route instead.
+
+## Block 1 --- .github/workflows/fleet-images.yml, at the top of the file
+
+```yaml
+name: Fleet images
+
+# The tag is deliberately coarser than the build inputs: anything under
+# tests/servers rebuilds, including scripts that reach no image. Narrowing
+# it to a hand-listed set goes stale silently the first time someone adds a
+# COPY and forgets the list.
+#
+# A tag maps to one set of apt packages forever, so Debian security updates
+# never arrive on their own -- dispatch this by hand to rebuild the current
+# tree against today's packages.
+#
+# specs/server-compatibility-plan.md records why this rather than `type=gha`
+# layer caching, which measured slower than building.
+
+on:
+  push:
+    branches: [main]
+    paths: ['tests/servers/**']
+  workflow_dispatch:
+```
+
+## Block 2 --- .github/workflows/ci.yml
+
+```yaml
+      # Images come from .github/workflows/fleet-images.yml. A pull miss is
+      # expected rather than a failure: a PR that edits tests/servers has no
+      # published images until it lands, and fork PRs cannot reach the
+      # registry.
+      - name: Resolve the fleet image tag
+        run: echo "FLEET_TAG=$(git rev-parse HEAD:tests/servers)" >> "$GITHUB_ENV"
+
+      - name: Fetch or build the VNC test servers
+        run: |
+          docker compose -f tests/servers/docker-compose.yml pull --quiet \
+            || docker compose -f tests/servers/docker-compose.yml build
+          docker compose -f tests/servers/docker-compose.yml up -d --wait
+```
+
+## Block 3 --- .github/workflows/ci.yml, further down
+
+```yaml
+      # vncev and libvncserver-example run their upstream binary as PID 1
+      # with no SIGTERM handling, so they sit out the whole grace period;
+      # the other three trap and exit in under a second. Nothing here needs
+      # a clean shutdown.
+      - name: Stop the VNC test servers
+        if: always()
+        run: docker compose -f tests/servers/docker-compose.yml down --timeout 2
+```
+
+## Block 4 --- tests/servers/docker-compose.yml, appended to an existing header comment
+
+```yaml
+# Readiness is the HEALTHCHECK baked into the image, which makes
+# `up --wait` a reliable barrier. Every service publishes its RFB port to
+# localhost only.
+#
+# CI sets FLEET_IMAGE_PREFIX and FLEET_TAG to pull these prebuilt rather
+# than build them; see .github/workflows/fleet-images.yml.
+
+name: vncdo-test-servers
+
+services:
+  tigervnc:
+    build:
+      context: .
+      target: tigervnc
+    image: ${FLEET_IMAGE_PREFIX:-vncdotool-test}-tigervnc:${FLEET_TAG:-dev}
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,25 +29,12 @@ so a hang is contained by the kernel reaping the subprocess rather than by
 anything in-process. See `specs/testing-framework.md` and
 `tests/functional/vncservers.py`.
 
-A comment carries what the reader cannot get anywhere else: something
-surprising, particular to this code, and absent from the language, the
-library's documentation, the RFB specs and the code itself. A server
-that ignores what it was asked, an ordering nothing enforces, an obvious
-approach that does not work here. `loggingproxy.py` has the shape of it:
-"SetEncodings only says what the client asked for, and a server may
-ignore it."
-
-The reader knows the tools and can read the code, and an AI reader has
-every public document already. Anything they could look up, infer from a
-name, or learn by running it is not worth writing, and neither is
-anything about the change rather than the code -- the alternative you
-rejected, what used to be here, who calls it, the issue or PR it came
-from. That is commit-message and `docs/` material. Point elsewhere only
-when there is something surprising there too long to state here.
-
-Test by deleting it: keep it only if an intelligent reader would still
-be surprised later. Shortening an unnecessary comment leaves an
-unnecessary comment. One or two lines is the norm.
+Comments follow the `writing-code-comments` skill in
+`.claude/skills/`. What is particular to this repo: `loggingproxy.py` has
+the shape of a comment that earns its place -- "SetEncodings only says what
+the client asked for, and a server may ignore it." `rfb.py` is vendored
+from a 2003-era import and was never in this repo's style, so leave its
+comments alone and do not sample it for what good looks like here.
 
 Check the protocol documents before implementing anything that touches the
 wire -- a new encoding, security type, message or client command. The repo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,8 @@ anything in-process. See `specs/testing-framework.md` and
 Comments follow the `writing-code-comments` skill in
 `.claude/skills/`. What is particular to this repo: `loggingproxy.py` has
 the shape of a comment that earns its place -- "SetEncodings only says what
-the client asked for, and a server may ignore it." `rfb.py` is vendored
-from a 2003-era import and was never in this repo's style, so leave its
-comments alone and do not sample it for what good looks like here.
+the client asked for, and a server may ignore it." `rfb.py` is the file the
+skill's vendored-code rule is about here: a 2003-era import, added whole.
 
 Check the protocol documents before implementing anything that touches the
 wire -- a new encoding, security type, message or client command. The repo


### PR DESCRIPTION
A cloud session gets the synced skill set plus whatever the repo commits. Personal skills, marketplace plugins, submodules and symlinks all fail to reach one, and none of them report the failure — so the decoder workstream ran overnight on CLAUDE.md's shorter comment rules with no reason to suspect a fuller policy existed, and added 129 comment blocks of which 18 needed stripping.

This vendors the `writing-code-comments` skill into `.claude/skills/` as real files, and cuts the CLAUDE.md comment section back to what is specific to this repo.

What a reviewer would not guess from the diff: the premise was that CLAUDE.md held a strictly weaker subset of the skill. Reading the two side by side to do the trim, three of its rules turned out to have no counterpart upstream — that running the code is another place a fact already lives, that naming callers goes stale, and the condition under which pointing elsewhere is worth it. Those went into the skill first; the third commit here is that copy. One sentence in CLAUDE.md is also new rather than kept: `rfb.py` is a 2003-era import (`# (C) 2003 cliechti@gmx.net`, added whole in the first commit) whose comments were never in this repo's style.

The canonical copy and the sync that refreshes this one live in [sibson/agent-skills](https://github.com/sibson/agent-skills), an Agent Plugins 1.0 package. `.agent-skills.json` names the commit these bytes came from.

Tested: `make test` green, 237 tests, 2 expected failures. Nothing here touches `vncdotool/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
