### PR TITLE
benchmark: drop the header paragraph the spec already carries

### DIFF
--- a/tests/goldens/benchmark.py
+++ b/tests/goldens/benchmark.py
@@ -1,9 +1,5 @@
 """Time a decoder against a committed golden fixture. No Twisted in the loop.
 
-Raw is the only encoding in live use, so it is the only one with a
-before-and-after to regress against. Run this on the commit before a change
-and on the change.
-
 ``--record`` appends a line to bench.jsonl per run: the timings, which are
 only comparable against other lines carrying the same ``machine`` digest,
 and the call counts, which are comparable against every line.


### PR DESCRIPTION
Review comment on #402 called the benchmark's header "restating what is known", and it is: why Raw is the baseline is N1 in `specs/decoder-architecture.md`, and "run this before and after your change" is what a benchmark is.

What is left is the part the file alone can tell you — that `--record` writes bench.jsonl, and that its timings only compare within one `machine` digest while its call counts compare everywhere.

The comment was raised against #402, but the file moved to main with #411, so the fix belongs here rather than on that branch.

Tested: unit suite green, `flake8` clean, `make bench` still runs.
