### PR TITLE
Move PixelFormat below rfb.py, drop the Rect alias

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,8 @@
   - ``vncdo -v`` logs the pixel format it requests, beside the native format it already logged (@sibson, #394)
   - Fix screenshots shifted against any server whose first rectangle does not start at (0, 0) (@sibson)
   - Fix ``VMWareClient`` raising ``AttributeError`` instead of detecting the VMware single-pixel update it exists to filter (@sibson, #400)
-  - ``PixelFormat`` is now defined in ``vncdotool.pixelformat`` and documented there; ``vncdotool.rfb.PixelFormat`` still imports it and is the same class (@sibson, #415)
+  - ``PixelFormat`` moves to ``vncdotool.pixelformat``; ``vncdotool.rfb.PixelFormat`` still imports (@sibson, #415)
+  - [BREAKING] ``vncdotool.rfb.Rect`` is gone; annotate rectangles as ``tuple[int, int, int, int]`` (@sibson, #415)
   - Local development moves from Makefile.venv + pip to uv; ``make`` targets run under ``uv run`` (@sibson, #383)
   - Fix ``make release`` tagging an empty version (@sibson, #382)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@
   - ``vncdo -v`` logs the pixel format it requests, beside the native format it already logged (@sibson, #394)
   - Fix screenshots shifted against any server whose first rectangle does not start at (0, 0) (@sibson)
   - Fix ``VMWareClient`` raising ``AttributeError`` instead of detecting the VMware single-pixel update it exists to filter (@sibson, #400)
+  - ``PixelFormat`` is now defined in ``vncdotool.pixelformat`` and documented there; ``vncdotool.rfb.PixelFormat`` still imports it and is the same class (@sibson, #415)
   - Local development moves from Makefile.venv + pip to uv; ``make`` targets run under ``uv run`` (@sibson, #383)
   - Fix ``make release`` tagging an empty version (@sibson, #382)
 

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -25,6 +25,14 @@ Code Documentation
     :undoc-members:
     :show-inheritance:
 
+:mod:`pixelformat` Module
+-------------------------
+
+.. automodule:: vncdotool.pixelformat
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 :mod:`command` Module
 ---------------------
 

--- a/specs/decoder-architecture.md
+++ b/specs/decoder-architecture.md
@@ -165,12 +165,6 @@ Decoders depend on nothing from `rfb.py`: the pump keeps `_rectBuffer`,
 `_pumpPixels` and `_pumpForClient` — live with the pump rather than on the
 decoder.
 
-That holds at import time too. The two types the pump and a decoder both name
-sit below both: `PixelFormat` in `pixelformat.py`, and `Rect` — the rectangle
-the pump hands to `decodeForClient` — beside the interface that receives it.
-`rfb.py` imports them and re-exports both, since `rfb.PixelFormat` and
-`rfb.Rect` are public API.
-
 There is no separate sink object. The pump calls the existing client callbacks —
 `updateRectangle`, `copyRectangle`, `updateCursor` — which is the vocabulary the
 codebase already uses.
@@ -281,8 +275,9 @@ diagnosed disconnect. This is a larger user-facing win than the split itself.
 ```
 vncdotool/pixelformat.py         PixelFormat, its Pillow raw mode, CPIXEL/TPIXEL widths
 vncdotool/decoders/__init__.py   registry, built from the decoder classes
-vncdotool/decoders/base.py       Decoder, PixelDecoder, ClientDecoder, Rect
+vncdotool/decoders/base.py       Decoder, PixelDecoder, ClientDecoder
 vncdotool/decoders/buffer.py     RectBuffer
+vncdotool/decoders/errors.py     DecodeError
 vncdotool/decoders/{raw,rre,corre,hextile,zrle,cursor}.py
 vncdotool/decoders/control.py    DesktopSize, LastRect, QEMU extended key
 vncdotool/rfb.py                 negotiation, auth, message framing, the pump

--- a/specs/decoder-architecture.md
+++ b/specs/decoder-architecture.md
@@ -165,6 +165,12 @@ Decoders depend on nothing from `rfb.py`: the pump keeps `_rectBuffer`,
 `_pumpPixels` and `_pumpForClient` — live with the pump rather than on the
 decoder.
 
+That holds at import time too. The two types the pump and a decoder both name
+sit below both: `PixelFormat` in `pixelformat.py`, and `Rect` — the rectangle
+the pump hands to `decodeForClient` — beside the interface that receives it.
+`rfb.py` imports them and re-exports both, since `rfb.PixelFormat` and
+`rfb.Rect` are public API.
+
 There is no separate sink object. The pump calls the existing client callbacks —
 `updateRectangle`, `copyRectangle`, `updateCursor` — which is the vocabulary the
 codebase already uses.
@@ -273,9 +279,9 @@ diagnosed disconnect. This is a larger user-facing win than the split itself.
 ## Module layout
 
 ```
-vncdotool/pixelformat.py         PixelFormat -> Pillow raw mode, CPIXEL/TPIXEL widths
+vncdotool/pixelformat.py         PixelFormat, its Pillow raw mode, CPIXEL/TPIXEL widths
 vncdotool/decoders/__init__.py   registry, built from the decoder classes
-vncdotool/decoders/base.py       Decoder, PixelDecoder, ClientDecoder
+vncdotool/decoders/base.py       Decoder, PixelDecoder, ClientDecoder, Rect
 vncdotool/decoders/buffer.py     RectBuffer
 vncdotool/decoders/{raw,rre,corre,hextile,zrle,cursor}.py
 vncdotool/decoders/control.py    DesktopSize, LastRect, QEMU extended key

--- a/specs/pixel-format.md
+++ b/specs/pixel-format.md
@@ -99,10 +99,16 @@ by the goldens' cross-format comparison.
 ## Surface
 
 ```python
-def raw_mode(pixel_format: rfb.PixelFormat) -> str: ...      # raises UnsupportedPixelFormat
-def cpixel_bytes(pixel_format: rfb.PixelFormat) -> int: ...  # 3 or bypp
-def cpixel_offset(pixel_format: rfb.PixelFormat) -> int: ... # 0 or bypp - 3
+class PixelFormat: ...                                   # RFC 6143 §7.4
+
+def raw_mode(pixel_format: PixelFormat) -> str: ...      # raises UnsupportedPixelFormat
+def cpixel_bytes(pixel_format: PixelFormat) -> int: ...  # 3 or bypp
+def cpixel_offset(pixel_format: PixelFormat) -> int: ... # 0 or bypp - 3
 ```
+
+`pixelformat.py` defines `PixelFormat` and imports nothing else from the
+package, so both `rfb.py` and the decoders can reach it. `rfb.PixelFormat`
+remains a name because it is public API.
 
 `raw_mode` ignores `depth` — it does not affect where the channels sit.
 `cpixel_bytes` must obey it, since the encoder used the same declaration.

--- a/specs/pixel-format.md
+++ b/specs/pixel-format.md
@@ -106,10 +106,6 @@ def cpixel_bytes(pixel_format: PixelFormat) -> int: ...  # 3 or bypp
 def cpixel_offset(pixel_format: PixelFormat) -> int: ... # 0 or bypp - 3
 ```
 
-`pixelformat.py` defines `PixelFormat` and imports nothing else from the
-package, so both `rfb.py` and the decoders can reach it. `rfb.PixelFormat`
-remains a name because it is public API.
-
 `raw_mode` ignores `depth` — it does not affect where the channels sit.
 `cpixel_bytes` must obey it, since the encoder used the same declaration.
 

--- a/tests/unit/test_rectbuffer.py
+++ b/tests/unit/test_rectbuffer.py
@@ -1,6 +1,6 @@
 import unittest
 
-from vncdotool.decoders.base import DecodeError
+from vncdotool.decoders import DecodeError
 from vncdotool.decoders.buffer import RectBuffer
 
 

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -251,7 +251,7 @@ class VNCDoToolClient(rfb.RFBClient):
 
         return self._expectCompare(None, (x, y, x + w, y + h), maxrms)
 
-    def _expectCompare(self, data: object, box: rfb.Rect, maxrms: float) -> Deferred:
+    def _expectCompare(self, data: object, box: tuple[int, int, int, int], maxrms: float) -> Deferred:
         incremental = False
         if self.screen:
             incremental = True
@@ -424,7 +424,7 @@ class VNCDoToolClient(rfb.RFBClient):
 
         self.drawCursor()
 
-    def commitUpdate(self, rectangles: list[rfb.Rect] | None = None) -> None:
+    def commitUpdate(self, rectangles: list[tuple[int, int, int, int]] | None = None) -> None:
         if self.deferred:
             if not rectangles:
                 # No rectangle in this update painted self.screen; wait for

--- a/vncdotool/decoders/__init__.py
+++ b/vncdotool/decoders/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Dict, Type
 
 from ..const import Encoding
-from .base import ClientDecoder, DecodeError, Decoder, PixelDecoder
+from .base import ClientDecoder, DecodeError, Decoder, PixelDecoder, Rect
 from .buffer import RectBuffer
 from .copyrect import CopyRectDecoder
 from .raw import RawDecoder
@@ -30,6 +30,7 @@ __all__ = [
     "DecodeError",
     "Decoder",
     "PixelDecoder",
+    "Rect",
     "RectBuffer",
     "for_connection",
 ]

--- a/vncdotool/decoders/__init__.py
+++ b/vncdotool/decoders/__init__.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from typing import Dict, Type
 
 from ..const import Encoding
-from .base import ClientDecoder, DecodeError, Decoder, PixelDecoder, Rect
+from .base import ClientDecoder, Decoder, PixelDecoder
 from .buffer import RectBuffer
 from .copyrect import CopyRectDecoder
+from .errors import DecodeError
 from .raw import RawDecoder
 
 # Classes, not instances: ZRLE and Tight own a zlib stream that lives for
@@ -30,7 +31,6 @@ __all__ = [
     "DecodeError",
     "Decoder",
     "PixelDecoder",
-    "Rect",
     "RectBuffer",
     "for_connection",
 ]

--- a/vncdotool/decoders/base.py
+++ b/vncdotool/decoders/base.py
@@ -1,14 +1,17 @@
 """specs/decoder-architecture.md is the design."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar, Iterator
+from typing import TYPE_CHECKING, ClassVar, Iterator, Tuple
 
 from ..const import Encoding
+from ..pixelformat import PixelFormat
 
-# rfb.py imports this package, so importing from it at runtime is a cycle.
+# buffer.py raises DecodeError, so it imports this module and cannot be
+# imported back from it at runtime.
 if TYPE_CHECKING:  # pragma: no cover
-    from ..rfb import PixelFormat
     from .buffer import RectBuffer
+
+Rect = Tuple[int, int, int, int]
 
 
 class DecodeError(Exception):
@@ -24,12 +27,12 @@ class Decoder:
     ENCODING: ClassVar[Encoding]
 
     def decodePixels(
-        self, target: "RectBuffer", pixel_format: "PixelFormat"
+        self, target: RectBuffer, pixel_format: PixelFormat
     ) -> Iterator[int]:
         raise NotImplementedError
 
     def decodeForClient(
-        self, client: object, rect: tuple[int, int, int, int], pixel_format: "PixelFormat"
+        self, client: object, rect: Rect, pixel_format: PixelFormat
     ) -> Iterator[int]:
         raise NotImplementedError
 
@@ -37,7 +40,7 @@ class Decoder:
 class PixelDecoder(Decoder):
     """Consumes bytes, fills a rect buffer."""
 
-    def output_format(self, pixel_format: "PixelFormat") -> "PixelFormat":
+    def output_format(self, pixel_format: PixelFormat) -> PixelFormat:
         """The layout the bytes this decoder wrote are in, which is not
         always the negotiated one.
         """

--- a/vncdotool/decoders/base.py
+++ b/vncdotool/decoders/base.py
@@ -1,21 +1,11 @@
 """specs/decoder-architecture.md is the design."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar, Iterator, Tuple
+from typing import ClassVar, Iterator
 
 from ..const import Encoding
 from ..pixelformat import PixelFormat
-
-# buffer.py raises DecodeError, so it imports this module and cannot be
-# imported back from it at runtime.
-if TYPE_CHECKING:  # pragma: no cover
-    from .buffer import RectBuffer
-
-Rect = Tuple[int, int, int, int]
-
-
-class DecodeError(Exception):
-    """Malformed, oversized or unsupported encoded data."""
+from .buffer import RectBuffer
 
 
 class Decoder:
@@ -32,7 +22,7 @@ class Decoder:
         raise NotImplementedError
 
     def decodeForClient(
-        self, client: object, rect: Rect, pixel_format: PixelFormat
+        self, client: object, rect: tuple[int, int, int, int], pixel_format: PixelFormat
     ) -> Iterator[int]:
         raise NotImplementedError
 

--- a/vncdotool/decoders/buffer.py
+++ b/vncdotool/decoders/buffer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .base import DecodeError
+from .errors import DecodeError
 
 
 class RectBuffer:

--- a/vncdotool/decoders/copyrect.py
+++ b/vncdotool/decoders/copyrect.py
@@ -6,14 +6,14 @@ from typing import ClassVar, Iterator
 
 from ..const import Encoding
 from ..pixelformat import PixelFormat
-from .base import ClientDecoder, Rect
+from .base import ClientDecoder
 
 
 class CopyRectDecoder(ClientDecoder):
     ENCODING: ClassVar[Encoding] = Encoding.COPY_RECTANGLE
 
     def decodeForClient(
-        self, client: object, rect: Rect, pixel_format: PixelFormat
+        self, client: object, rect: tuple[int, int, int, int], pixel_format: PixelFormat
     ) -> Iterator[int]:
         block = yield 4
         srcx, srcy = unpack("!HH", block)

--- a/vncdotool/decoders/copyrect.py
+++ b/vncdotool/decoders/copyrect.py
@@ -2,21 +2,18 @@
 from __future__ import annotations
 
 from struct import unpack
-from typing import TYPE_CHECKING, ClassVar, Iterator
+from typing import ClassVar, Iterator
 
 from ..const import Encoding
-from .base import ClientDecoder
-
-# rfb.py imports this package, so importing from it at runtime is a cycle.
-if TYPE_CHECKING:  # pragma: no cover
-    from ..rfb import PixelFormat, Rect
+from ..pixelformat import PixelFormat
+from .base import ClientDecoder, Rect
 
 
 class CopyRectDecoder(ClientDecoder):
     ENCODING: ClassVar[Encoding] = Encoding.COPY_RECTANGLE
 
     def decodeForClient(
-        self, client: object, rect: "Rect", pixel_format: "PixelFormat"
+        self, client: object, rect: Rect, pixel_format: PixelFormat
     ) -> Iterator[int]:
         block = yield 4
         srcx, srcy = unpack("!HH", block)

--- a/vncdotool/decoders/errors.py
+++ b/vncdotool/decoders/errors.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+class DecodeError(Exception):
+    """Malformed, oversized or unsupported encoded data."""

--- a/vncdotool/decoders/raw.py
+++ b/vncdotool/decoders/raw.py
@@ -1,22 +1,19 @@
 """Raw encoding. RFC 6143 section 7.7.1."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar, Iterator
+from typing import ClassVar, Iterator
 
 from ..const import Encoding
+from ..pixelformat import PixelFormat
 from .base import PixelDecoder
-
-# rfb.py imports this package, so importing from it at runtime is a cycle.
-if TYPE_CHECKING:  # pragma: no cover
-    from ..rfb import PixelFormat
-    from .buffer import RectBuffer
+from .buffer import RectBuffer
 
 
 class RawDecoder(PixelDecoder):
     ENCODING: ClassVar[Encoding] = Encoding.RAW
 
     def decodePixels(
-        self, target: "RectBuffer", pixel_format: "PixelFormat"
+        self, target: RectBuffer, pixel_format: PixelFormat
     ) -> Iterator[int]:
         data = yield target.width * target.height * target.bypp
         target.blit(0, 0, target.width, target.height, data)

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -20,7 +20,7 @@ from .capture import CaptureWriter, HandshakeScrubber
 from .const import AuthTypes, Encoding, MsgC2S, QemuClientMessage
 from .client import VNCDoToolClient
 from .keys import KEYMAP
-from .rfb import PixelFormat, Rect
+from .rfb import PixelFormat
 
 log = logging.getLogger(__name__)
 
@@ -201,7 +201,7 @@ class VNCLoggingClient(VNCDoToolClient):
             self.capture.note_encoding(encoding)
         super()._handleRectangle(block)
 
-    def commitUpdate(self, rectangles: list[Rect] | None = None) -> None:
+    def commitUpdate(self, rectangles: list[tuple[int, int, int, int]] | None = None) -> None:
         if self.capture_file:
             assert self.screen is not None
             self.screen.save(self.capture_file)

--- a/vncdotool/pixelformat.py
+++ b/vncdotool/pixelformat.py
@@ -1,26 +1,74 @@
 """
-Pixel format resolution: :class:`rfb.PixelFormat` -> Pillow raw mode, and the
-CPIXEL width/offset rules ZRLE depends on.
+The :class:`PixelFormat` wire structure, its resolution to a Pillow raw mode,
+and the CPIXEL width/offset rules ZRLE depends on.
 
 Reference:
+https://www.rfc-editor.org/rfc/rfc6143#section-7.4
 https://www.rfc-editor.org/rfc/rfc6143#section-7.7.5
 https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst (ZRLE Encoding)
 """
 from __future__ import annotations
 
 import functools
-
-from . import rfb
+from dataclasses import astuple, dataclass
+from struct import Struct
+from typing import ClassVar, cast
 
 _32BPP_MODES = {"RGBX", "BGRX", "XRGB", "XBGR"}
 _24BPP_MODES = {"RGB", "BGR"}
 
 
+@dataclass(frozen=True)
+class PixelFormat:
+    """:rfc:`6143` §7.4. Pixel Format Data Structure."""
+
+    bpp: int = 32  # u8: bits-per-pixel
+    depth: int = 24  # u8
+    bigendian: bool = False  # u8
+    truecolor: bool = True  # u8
+    redmax: int = 255  # u16
+    greenmax: int = 255  # u16
+    bluemax: int = 255  # u16
+    redshift: int = 0  # u8
+    greenshift: int = 8  # u8
+    blueshift: int = 16  # u8
+
+    STRUCT: ClassVar = Struct("!BB??HHHBBBxxx")
+    VALIDATE: ClassVar = False
+
+    def __post_init__(self) -> None:
+        if not self.VALIDATE:
+            return
+        assert self.bpp in {8, 16, 24, 32}, f"bpp={self.bpp}"
+        assert 1 <= self.depth <= self.bpp, f"depth={self.depth} <= bpp={self.bpp}"
+        if self.truecolor:
+            for max, shift in zip(
+                (self.redmax, self.greenmax, self.bluemax),
+                (self.redshift, self.greenshift, self.blueshift),
+            ):
+                assert 1 <= max <= 0xFFFF, f"1 <= max={max} <= 0xffff"
+                assert max & (max + 1) == 0, f"max={max} not a 2**n-1"
+                assert (
+                    0 <= shift <= self.bpp - max.bit_length()
+                ), f"shift={shift} not in bpp={self.bpp}"
+
+    @property
+    def bypp(self) -> int:  # bytes-per-pixel
+        return (7 + self.bpp) // 8
+
+    @classmethod
+    def from_bytes(cls, block: bytes) -> PixelFormat:
+        return cls(*cls.STRUCT.unpack(block))
+
+    def to_bytes(self) -> bytes:
+        return cast(bytes, self.STRUCT.pack(*astuple(self)))
+
+
 class UnsupportedPixelFormat(Exception):
-    """No Pillow raw mode exists for this :class:`rfb.PixelFormat`."""
+    """No Pillow raw mode exists for this :class:`PixelFormat`."""
 
 
-def _channel_widths(pixel_format: rfb.PixelFormat) -> tuple[int, int, int]:
+def _channel_widths(pixel_format: PixelFormat) -> tuple[int, int, int]:
     return (
         pixel_format.redmax.bit_length(),
         pixel_format.greenmax.bit_length(),
@@ -28,9 +76,7 @@ def _channel_widths(pixel_format: rfb.PixelFormat) -> tuple[int, int, int]:
     )
 
 
-def _byte_positions(
-    pixel_format: rfb.PixelFormat, nbytes: int
-) -> dict[int, str]:
+def _byte_positions(pixel_format: PixelFormat, nbytes: int) -> dict[int, str]:
     positions: dict[int, str] = {}
     for shift, channel in (
         (pixel_format.redshift, "R"),
@@ -48,7 +94,7 @@ def _byte_positions(
 
 
 @functools.lru_cache(maxsize=None)
-def raw_mode(pixel_format: rfb.PixelFormat) -> str:
+def raw_mode(pixel_format: PixelFormat) -> str:
     """The Pillow raw mode that reads bytes in this layout, ignoring depth."""
     if not pixel_format.truecolor:
         raise UnsupportedPixelFormat("colour-mapped pixel formats are not supported")
@@ -98,7 +144,7 @@ def raw_mode(pixel_format: rfb.PixelFormat) -> str:
     raise UnsupportedPixelFormat(f"bpp={pixel_format.bpp} is not supported")
 
 
-def _cpixel_placement(pixel_format: rfb.PixelFormat) -> str | None:
+def _cpixel_placement(pixel_format: PixelFormat) -> str | None:
     widths = _channel_widths(pixel_format)
     shifts = (pixel_format.redshift, pixel_format.greenshift, pixel_format.blueshift)
     fits_low = all(shift + width <= 24 for shift, width in zip(shifts, widths))
@@ -112,7 +158,7 @@ def _cpixel_placement(pixel_format: rfb.PixelFormat) -> str | None:
     return None
 
 
-def cpixel_bytes(pixel_format: rfb.PixelFormat) -> int:
+def cpixel_bytes(pixel_format: PixelFormat) -> int:
     """3 for a CPIXEL-eligible format, otherwise ``bypp`` (a PIXEL)."""
     if (
         pixel_format.truecolor
@@ -124,7 +170,7 @@ def cpixel_bytes(pixel_format: rfb.PixelFormat) -> int:
     return pixel_format.bypp
 
 
-def cpixel_offset(pixel_format: rfb.PixelFormat) -> int:
+def cpixel_offset(pixel_format: PixelFormat) -> int:
     """Byte offset of the 3 CPIXEL bytes within a PIXEL: 0 or ``bypp - 3``.
 
     The placement is in value space and the offset is in byte space, so
@@ -137,8 +183,8 @@ def cpixel_offset(pixel_format: rfb.PixelFormat) -> int:
     return 0 if low != pixel_format.bigendian else pixel_format.bypp - 3
 
 
-PIXEL_FORMATS: dict[str, rfb.PixelFormat] = {
-    "bgrx8888": rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 16, 8, 0),
-    "rgbx8888": rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 0, 8, 16),
-    "rgb565": rfb.PixelFormat(16, 16, False, True, 31, 63, 31, 11, 5, 0),
+PIXEL_FORMATS: dict[str, PixelFormat] = {
+    "bgrx8888": PixelFormat(32, 24, False, True, 255, 255, 255, 16, 8, 0),
+    "rgbx8888": PixelFormat(32, 24, False, True, 255, 255, 255, 0, 8, 16),
+    "rgb565": PixelFormat(16, 16, False, True, 31, 63, 31, 11, 5, 0),
 }

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -18,12 +18,10 @@ import getpass
 import sys
 import warnings
 import zlib
-from dataclasses import astuple, dataclass
-from struct import Struct, error as StructError, pack, unpack, unpack_from
+from struct import error as StructError, pack, unpack, unpack_from
 from typing import (
     Any,
     Callable,
-    ClassVar,
     Collection,
     Iterator,
     List,
@@ -44,58 +42,13 @@ from twisted.python.failure import Failure
 
 from . import decoders
 from .const import Encoding, HextileEncoding, AuthTypes, MsgC2S, MsgS2C
+from .decoders import Rect
 from .keys import Key
+from .pixelformat import PixelFormat
 
-Rect = Tuple[int, int, int, int]
 Ver = Tuple[int, int]
 
 # ~ from twisted.internet import reactor
-
-
-@dataclass(frozen=True)
-class PixelFormat:
-    """:rfc:`6143` §7.4. Pixel Format Data Structure."""
-
-    bpp: int = 32  # u8: bits-per-pixel
-    depth: int = 24  # u8
-    bigendian: bool = False  # u8
-    truecolor: bool = True  # u8
-    redmax: int = 255  # u16
-    greenmax: int = 255  # u16
-    bluemax: int = 255  # u16
-    redshift: int = 0  # u8
-    greenshift: int = 8  # u8
-    blueshift: int = 16  # u8
-
-    STRUCT: ClassVar = Struct("!BB??HHHBBBxxx")
-    VALIDATE: ClassVar = False
-
-    def __post_init__(self) -> None:
-        if not self.VALIDATE:
-            return
-        assert self.bpp in {8, 16, 24, 32}, f"bpp={self.bpp}"
-        assert 1 <= self.depth <= self.bpp, f"depth={self.depth} <= bpp={self.bpp}"
-        if self.truecolor:
-            for max, shift in zip(
-                (self.redmax, self.greenmax, self.bluemax),
-                (self.redshift, self.greenshift, self.blueshift),
-            ):
-                assert 1 <= max <= 0xFFFF, f"1 <= max={max} <= 0xffff"
-                assert max & (max + 1) == 0, f"max={max} not a 2**n-1"
-                assert (
-                    0 <= shift <= self.bpp - max.bit_length()
-                ), f"shift={shift} not in bpp={self.bpp}"
-
-    @property
-    def bypp(self) -> int:  # bytes-per-pixel
-        return (7 + self.bpp) // 8
-
-    @classmethod
-    def from_bytes(cls, block: bytes) -> PixelFormat:
-        return cls(*cls.STRUCT.unpack(block))
-
-    def to_bytes(self) -> bytes:
-        return cast(bytes, self.STRUCT.pack(*astuple(self)))
 
 
 # ZRLE helpers

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -42,7 +42,6 @@ from twisted.python.failure import Failure
 
 from . import decoders
 from .const import Encoding, HextileEncoding, AuthTypes, MsgC2S, MsgS2C
-from .decoders import Rect
 from .keys import Key
 from .pixelformat import PixelFormat
 
@@ -382,7 +381,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
 
     def _handleFramebufferUpdate(self, block: bytes) -> None:
         (self.rectangles,) = unpack("!xH", block)
-        self.rectanglePos: list[Rect] = []
+        self.rectanglePos: list[tuple[int, int, int, int]] = []
         self.beginUpdate()
         self._doConnection()
 
@@ -459,7 +458,10 @@ class RFBClient(Protocol):  # type: ignore[misc]
         )
 
     def _finishRectangle(
-        self, decoder: decoders.PixelDecoder, target: decoders.RectBuffer, rect: Rect
+        self,
+        decoder: decoders.PixelDecoder,
+        target: decoders.RectBuffer,
+        rect: tuple[int, int, int, int],
     ) -> None:
         x, y, width, height = rect
         self.updateRectangle(
@@ -489,7 +491,9 @@ class RFBClient(Protocol):  # type: ignore[misc]
         self,
         block: bytes | None,
         generator: Iterator[int],
-        finish: tuple[decoders.PixelDecoder, decoders.RectBuffer, Rect] | None,
+        finish: tuple[
+            decoders.PixelDecoder, decoders.RectBuffer, tuple[int, int, int, int]
+        ] | None,
     ) -> None:
         try:
             size = generator.send(block)
@@ -1098,7 +1102,7 @@ class RFBClient(Protocol):  # type: ignore[misc]
         """called before a series of :meth:`updateRectangle`,
         :meth:`copyRectangle` or :meth:`fillRectangle`."""
 
-    def commitUpdate(self, rectangles: list[Rect] | None = None) -> None:
+    def commitUpdate(self, rectangles: list[tuple[int, int, int, int]] | None = None) -> None:
         """called after a series of :meth:`updateRectangle`, :meth:`copyRectangle`
         or :meth:`fillRectangle` are finished.
 


### PR DESCRIPTION
`rfb.py` imports the decoders package, so it sits at the top of the graph — but it also defined `PixelFormat` and `Rect`, so everything below had to import back up. `pixelformat.py` imported `rfb` purely to name `rfb.PixelFormat`, and each decoder carried a `TYPE_CHECKING` block with string-literal annotations to dodge the cycle.

`PixelFormat` moves to `pixelformat.py`, which now imports nothing else from the package. `rfb.py` re-exports it, so `rfb.PixelFormat` is the same object as before; fields, `STRUCT` and behaviour are untouched, and nothing pickles or isinstance-checks it.

`Rect` is deleted rather than relocated: a bare four-tuple alias with seven annotation sites that every use site already destructures. **`rfb.Rect` is gone** — that is the one break, and it has a CHANGELOG line.

Every conditional import is gone too. `DecodeError` moves to a new `decoders/errors.py`, which is what let `base.py` import `RectBuffer` plainly: `buffer.py` raises `DecodeError`, so while that exception lived in `base.py` the two modules could not both import each other.

One thing a reviewer would not guess from the diff: `docs/modules.rst` gains a `pixelformat` section, because `automodule` documents only members a module defines and `PixelFormat` would otherwise have dropped out of the published docs.

Decoder phases 3 (#405) and 4 (#406) touch these same imports and will need a trivial rebase; neither branch was touched here.

Tested: `make test` 270 tests, OK (expected failures=2). `uv run flake8 --count --statistics vncdotool tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)