### PR TITLE
Drop redundant comment on the _dirty fix

### DIFF
--- a/tests/goldens/benchmark.py
+++ b/tests/goldens/benchmark.py
@@ -140,9 +140,6 @@ def _run(*args: str) -> Optional[str]:
         out = subprocess.run(args, capture_output=True, text=True, check=True)
     except (OSError, subprocess.CalledProcessError):
         return None
-    # Not .strip(): git status --porcelain's status column is a leading
-    # space for an unstaged change, and a blanket strip eats it only off
-    # the first line, misaligning _dirty's column slice on that line alone.
     return out.stdout.rstrip("\n")
 
 


### PR DESCRIPTION
Removes a comment on `_run()` in `benchmark.py` that only restated what #422's commit message already says.

Tested: `make test`, flake8 clean.