### PR TITLE
Drop the per-rectangle debug trace

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@
   - Any byte-aligned truecolor pixel format the server announces can now be captured, not just the five formats vncdotool used to recognize (@sibson)
   - ``vncdo`` failures print to stderr as plain messages (@sibson, #395)
   - ``vncdo -v`` logs the pixel format it requests, beside the native format it already logged (@sibson, #394)
+  - The per-rectangle trace moves from ``-v`` to ``-vv``, and costs nothing when it is off; decoding a full-screen update is 30% faster for it (@sibson)
   - Fix screenshots shifted against any server whose first rectangle does not start at (0, 0) (@sibson)
   - Fix ``VMWareClient`` raising ``AttributeError`` instead of detecting the VMware single-pixel update it exists to filter (@sibson, #400)
   - ``PixelFormat`` moves to ``vncdotool.pixelformat``; ``vncdotool.rfb.PixelFormat`` still imports (@sibson, #415)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@
   - Any byte-aligned truecolor pixel format the server announces can now be captured, not just the five formats vncdotool used to recognize (@sibson)
   - ``vncdo`` failures print to stderr as plain messages (@sibson, #395)
   - ``vncdo -v`` logs the pixel format it requests, beside the native format it already logged (@sibson, #394)
-  - The per-rectangle trace moves from ``-v`` to ``-vv``, and costs nothing when it is off; decoding a full-screen update is 30% faster for it (@sibson)
+  - Drop the per-rectangle debug trace: never used to diagnose anything, and decoding a full-screen update is 30% faster without it (@sibson)
   - Fix screenshots shifted against any server whose first rectangle does not start at (0, 0) (@sibson)
   - Fix ``VMWareClient`` raising ``AttributeError`` instead of detecting the VMware single-pixel update it exists to filter (@sibson, #400)
   - ``PixelFormat`` moves to ``vncdotool.pixelformat``; ``vncdotool.rfb.PixelFormat`` still imports (@sibson, #415)

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -15,6 +15,7 @@ https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst
 from __future__ import annotations
 
 import getpass
+import logging
 import sys
 import warnings
 import zlib
@@ -46,6 +47,11 @@ from .keys import Key
 from .pixelformat import PixelFormat
 
 Ver = Tuple[int, int]
+
+# The per-rectangle trace, which a full-screen update emits over a thousand
+# times. `log.msg` builds and publishes an event whether or not an observer
+# wants one; a stdlib logger asked first costs a level check.
+_trace = logging.getLogger(__name__)
 
 # ~ from twisted.internet import reactor
 
@@ -391,7 +397,10 @@ class RFBClient(Protocol):  # type: ignore[misc]
 
     def _handleRectangle(self, block: bytes) -> None:
         (x, y, width, height, encoding) = unpack("!HHHHi", block)
-        log.msg(f"x={x} y={y} w={width} h={height} {Encoding.lookup(encoding)!r}")
+        if _trace.isEnabledFor(logging.DEBUG):
+            _trace.debug(
+                "x=%d y=%d w=%d h=%d %r", x, y, width, height, Encoding.lookup(encoding)
+            )
         if encoding == Encoding.PSEUDO_LAST_RECT:
             self.rectangles = 0
 

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -15,7 +15,6 @@ https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst
 from __future__ import annotations
 
 import getpass
-import logging
 import sys
 import warnings
 import zlib
@@ -47,11 +46,6 @@ from .keys import Key
 from .pixelformat import PixelFormat
 
 Ver = Tuple[int, int]
-
-# The per-rectangle trace, which a full-screen update emits over a thousand
-# times. `log.msg` builds and publishes an event whether or not an observer
-# wants one; a stdlib logger asked first costs a level check.
-_trace = logging.getLogger(__name__)
 
 # ~ from twisted.internet import reactor
 
@@ -397,10 +391,6 @@ class RFBClient(Protocol):  # type: ignore[misc]
 
     def _handleRectangle(self, block: bytes) -> None:
         (x, y, width, height, encoding) = unpack("!HHHHi", block)
-        if _trace.isEnabledFor(logging.DEBUG):
-            _trace.debug(
-                "x=%d y=%d w=%d h=%d %r", x, y, width, height, Encoding.lookup(encoding)
-            )
         if encoding == Encoding.PSEUDO_LAST_RECT:
             self.rectangles = 0
 


### PR DESCRIPTION
`_handleRectangle` called `log.msg()` unconditionally once per rectangle. Twisted's `log.msg` builds an event dict and walks the full observer chain whether or not anything is listening, so this cost more than the pump it was tracing — and it had never been used to diagnose anything, so it's dropped outright rather than guarded.

`make bench` on `tigervnc-raw-bgrx8888` (8 updates x 300 runs), before/after back to back on the same machine:

| | best | p10 | median |
|---|---|---|---|
| before | 905.9us | 926.2us | 1004.5us |
| after | 635.1us | 663.8us | 710.2us |

cProfile confirms the mechanism: `_handleRectangle`'s cumulative time drops from 2.43s to 0.58s over 192k calls (2000-run profile), with `log.msg`'s Twisted observer/filter/threadable chain (1.23s of that) gone entirely.

Tested: `make test` (284 unit tests), `flake8`, `make bench`.