### PR TITLE
Drop the cross-format golden oracle, and stop inferring a capture's format

### DIFF
--- a/specs/decoder-architecture.md
+++ b/specs/decoder-architecture.md
@@ -49,8 +49,9 @@ Stated independently of how. Each design decision should trace to one.
 - **R3** The framebuffer a client sees does not depend on the pixel format the
   server negotiated. Stated over the framebuffer rather than over decoder
   output, because decoders emit the layout they were sent and name it; the
-  format-independence is the client's paste, and the goldens' cross-format
-  comparison is what checks it. Servers that ignore `SetPixelFormat` cause #90
+  format-independence is the client's paste, and what checks it is each golden
+  fixture decoding to its scene PNG at the format it was captured at. Servers
+  that ignore `SetPixelFormat` cause #90
   and #275.
 - **R4** The user can choose which encodings are offered (#167, #168). Without
   this, every encoding except Raw is dead code and none of it can be tested

--- a/specs/decoder-goldens.md
+++ b/specs/decoder-goldens.md
@@ -167,6 +167,11 @@ opening anything.
 
 ## conditions.json
 
+`--pixel-format` is required, so `pixel_format` always names a format rather
+than recording "the server's own". Nothing on the wire would correct it — the
+server never acknowledges `SetPixelFormat` — so a fixture that does not say
+what it asked for cannot be replayed at the format its pixels are in.
+
 Written by the harness from what happened, never from what was intended: the
 compose service, the geometry, and vnclog's own `meta` — protocol version,
 security types, the encodings the server actually used, and the capture
@@ -185,23 +190,23 @@ file the server was shown.
 
 At reduced depth the server quantizes, so a decoded frame will not equal that
 image, and modelling the rounding ourselves would put our reading of the spec
-back into the oracle. Two checks are used together, because they fail on
-different things and share one capture run:
+back into the oracle. The comparison instead allows per-channel error bounded
+by the format's step, which bounds the server's rounding without modelling it
+and still catches channel swaps, wrong shifts, endianness errors and colour-map
+misindexing — the whole defect class R3, the framebuffer not depending on the
+negotiated format, is about. Every fixture is checked this way at the format it
+was captured at, and that is where R3 is checked.
 
-- **Source with tolerance.** Compare against the oracle allowing per-channel
-  error bounded by the format's step. This bounds the server's rounding without
-  modelling it, and still catches channel swaps, wrong shifts, endianness
-  errors and colour-map misindexing — the whole defect class R3, the framebuffer
-  not depending on the negotiated format, is about.
-- **Cross-format self-consistency.** Decode the same scene at every format and
-  assert the framebuffers agree within tolerance. This is R3 stated directly —
-  and it is where R3 is checked at all, since decoders emit the layout they were
-  sent (see [pixel-format.md](pixel-format.md)). It needs no external truth, but
-  a decoder wrong the same way at every depth passes it.
+The tolerance waits on a reduced-depth format: every format captured so far is
+32bpp truecolour, which is why it is zero.
 
-Cross-format self-consistency runs today. The tolerance oracle waits on a
-reduced-depth format: every format captured so far is 32bpp truecolour, which
-is why the tolerance is zero.
+**Cross-format self-consistency** — decode one scene at two formats, assert the
+framebuffers agree — is not used, though it reads like R3 stated directly. It
+cannot fail alone: every fixture is pinned to the PNG, so one member of a pair
+equals the PNG exactly and comparing the other against it is the comparison
+above at a looser bound. Reduced depth does not change that. The version with
+independent power — quantize the PNG onto the reduced grid, demand exact
+equality — is the rounding model this section rejects.
 
 ## The unit test
 

--- a/specs/pixel-format.md
+++ b/specs/pixel-format.md
@@ -94,7 +94,8 @@ so that class of bug cannot be written — including the live one, ZRLE's
 (`rfb.py`).
 
 R3 moves with it: stated over the framebuffer, not decoder output, and checked
-by the goldens' cross-format comparison.
+by each golden fixture decoding to its scene PNG at the format it was captured
+at.
 
 ## Surface
 
@@ -220,8 +221,7 @@ absence, which is step 2 and the case a test would otherwise skip.
 oracle is the same committed scene PNG, so tolerance stops being zero: the bound
 is the format's own step, 255/31 for the 5-bit channels and 255/63 for the
 6-bit, rounded up, which covers truncation and round-to-nearest alike without
-modelling either. Two fixtures then allow the cross-format check — decode both,
-assert the framebuffers agree — which is R3 as restated.
+modelling either.
 
 `conditions.json` grows the pixel format, both the ServerInit one and any we
 requested. They are different facts and the interesting fixtures are where they
@@ -241,8 +241,8 @@ records which ran.
 2. `client.py` resolves the mode per rectangle; `PF2IM`, `setImageMode`,
    `image_mode` go. BGRX behaviour unchanged (R5).
 3. `--pixel-format`, the policy, the `api.connect` keyword.
-4. Capture `tigervnc-raw-rgb565`; tolerance and the cross-format check in
-   `test_goldens.py`; the fleet case.
+4. Capture `tigervnc-raw-rgb565`; tolerance in `test_goldens.py`; the fleet
+   case.
 
 ## Validated against the specs
 
@@ -275,9 +275,12 @@ document covers it; a capture will.
 
 ## Risks
 
-- A tolerance wide enough for 5-bit quantization can hide a real defect. The
-  cross-format check compensates: no external truth needed, and it fails on the
-  channel-order and shift errors the loose bound would swallow.
+- A tolerance wide enough for 5-bit quantization can hide a real defect, and
+  nothing compensates — a cross-format comparison does not, for the reason in
+  [decoder-goldens.md](decoder-goldens.md). What hides is narrower than the
+  whole class: a channel swap moves a coloured pixel much further than 255/31,
+  so the tolerant comparison still fails on it, and what survives is a shift or
+  rounding error smaller than one quantization step.
 - Tagging moves the trust from our arithmetic to Pillow's mode strings. A mode
   meaning something other than we think decodes silently wrong, where a bad
   shift would at least be ours to read — hence unit tests asserting Pillow's

--- a/tests/goldens/capture.py
+++ b/tests/goldens/capture.py
@@ -13,7 +13,6 @@ import tempfile
 import time
 import zipfile
 from pathlib import Path
-from typing import Optional
 
 from tests.functional.utils import HOST, TIGERVNC, VNCDO, VNCLOG
 from tests.goldens import distill, scenes
@@ -50,28 +49,13 @@ def _start_vnclog(archive: Path) -> subprocess.Popen:
     return proxy
 
 
-def _refuse_duplicate_format(name: str, pixel_format: Optional[str]) -> None:
-    """Two fixtures of one server and encoding captured at the same format
-    would compare equal whatever a client does with a format, leaving the
-    cross-format check asserting nothing.
-    """
-    group = name.rsplit("-", 1)[0]
-    for sibling in sorted(FIXTURE_ROOT.glob(f"{group}-*")):
-        if sibling.name == name or not (sibling / "conditions.json").exists():
-            continue
-        recorded = json.loads((sibling / "conditions.json").read_text()).get("pixel_format")
-        if recorded == pixel_format:
-            raise SystemExit(
-                f"{sibling.name} was already captured at {pixel_format or 'the server\'s own format'}"
-            )
-
-
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--pixel-format",
         choices=sorted(pixelformat.PIXEL_FORMATS),
-        help="format the capturing client asks the server for [the server's own]",
+        required=True,
+        help="format the capturing client asks the server for",
     )
     parser.add_argument(
         "--encoding",
@@ -81,11 +65,10 @@ def main() -> int:
     )
     parser.add_argument(
         "--name",
-        help="fixture directory name [tigervnc-ENCODING-PIXEL_FORMAT, or -native]",
+        help="fixture directory name [tigervnc-ENCODING-PIXEL_FORMAT]",
     )
     args = parser.parse_args()
-    name = args.name or f"tigervnc-{args.encoding}-{args.pixel_format or 'native'}"
-    _refuse_duplicate_format(name, args.pixel_format)
+    name = args.name or f"tigervnc-{args.encoding}-{args.pixel_format}"
 
     with tempfile.TemporaryDirectory() as tmp:
         archive = Path(tmp) / "capture.zip"

--- a/tests/goldens/distill.py
+++ b/tests/goldens/distill.py
@@ -83,15 +83,14 @@ class _Recorder(client.VNCDoToolClient):
         return s2c[: self.init_end], steps
 
 
-def _make_client(pixel_format: Optional[str]) -> _Recorder:
+def _make_client(pixel_format: str) -> _Recorder:
     """SetPixelFormat is client-to-server (RFC 6143 section 7.5.1), so the s2c
-    stream being replayed never says the server switched layouts. Untold, the
-    recorder unpacks the bytes as ServerInit announced them and permutes every
-    channel.
+    stream being replayed never says the server switched layouts. The recorder
+    has to be told, or it unpacks the bytes as ServerInit announced them and
+    permutes every channel.
     """
     recorder = _Recorder()
-    if pixel_format is not None:
-        recorder.requested_pixel_format = pixelformat.PIXEL_FORMATS[pixel_format]
+    recorder.requested_pixel_format = pixelformat.PIXEL_FORMATS[pixel_format]
     recorder.transport = mock.Mock()
     recorder.factory = mock.Mock()
     recorder.factory.shared = 0
@@ -104,7 +103,7 @@ def _make_client(pixel_format: Optional[str]) -> _Recorder:
     return recorder
 
 
-def split(s2c: bytes, pixel_format: Optional[str]) -> Tuple[bytes, List[Step]]:
+def split(s2c: bytes, pixel_format: str) -> Tuple[bytes, List[Step]]:
     return _make_client(pixel_format).split(s2c)
 
 

--- a/tests/unit/test_distill.py
+++ b/tests/unit/test_distill.py
@@ -39,12 +39,12 @@ def screen(key: str) -> Image.Image:
 
 class TestSplit(unittest.TestCase):
     def test_init_stops_at_the_first_update(self) -> None:
-        init, _ = distill.split(handshake_bytes() + raw_update(screen("0")), None)
+        init, _ = distill.split(handshake_bytes() + raw_update(screen("0")), "rgbx8888")
         self.assertEqual(init, handshake_bytes())
 
     def test_one_step_per_update(self) -> None:
         stream = handshake_bytes() + raw_update(screen("0")) + raw_update(screen("s"))
-        _, steps = distill.split(stream, None)
+        _, steps = distill.split(stream, "rgbx8888")
         self.assertEqual([step.index for step in steps], [1, 2])
 
     def test_a_scene_split_across_updates_is_one_step(self) -> None:
@@ -53,23 +53,23 @@ class TestSplit(unittest.TestCase):
         # scene ends.
         first, second = raw_update(screen("0")), raw_update(screen("s"))
         stream = handshake_bytes() + first + raw_update(screen("0")) + second
-        _, steps = distill.split(stream, None)
+        _, steps = distill.split(stream, "rgbx8888")
         self.assertEqual([step.key for step in steps], ["0", "s"])
         self.assertEqual(steps[0].data, first + raw_update(screen("0")))
         self.assertEqual(steps[1].data, second)
 
     def test_steps_are_labelled_by_the_patch(self) -> None:
         stream = handshake_bytes() + raw_update(screen("0")) + raw_update(screen("d"))
-        _, steps = distill.split(stream, None)
+        _, steps = distill.split(stream, "rgbx8888")
         self.assertEqual([step.key for step in steps], ["0", "d"])
 
     def test_a_step_holds_exactly_its_own_update_bytes(self) -> None:
         first, second = raw_update(screen("0")), raw_update(screen("s"))
-        _, steps = distill.split(handshake_bytes() + first + second, None)
+        _, steps = distill.split(handshake_bytes() + first + second, "rgbx8888")
         self.assertEqual([step.data for step in steps], [first, second])
 
     def test_an_unstamped_frame_has_no_key(self) -> None:
-        _, steps = distill.split(handshake_bytes() + raw_update(Image.new("RGB", SIZE, (1, 2, 3))), None)
+        _, steps = distill.split(handshake_bytes() + raw_update(Image.new("RGB", SIZE, (1, 2, 3))), "rgbx8888")
         self.assertIsNone(steps[0].key)
 
     def test_the_requested_format_reads_the_bytes_the_server_sent(self) -> None:
@@ -81,7 +81,7 @@ class TestSplit(unittest.TestCase):
 class TestWriteFixture(unittest.TestCase):
     def test_writes_one_pair_per_step_plus_conditions(self) -> None:
         stream = handshake_bytes() + raw_update(screen("0")) + raw_update(screen("s"))
-        init, steps = distill.split(stream, None)
+        init, steps = distill.split(stream, "rgbx8888")
         with tempfile.TemporaryDirectory() as tmp:
             directory = Path(tmp) / "fixture"
             distill.write_fixture(directory, init, steps, {"server": "tigervnc"})

--- a/tests/unit/test_goldens.py
+++ b/tests/unit/test_goldens.py
@@ -30,13 +30,6 @@ class Fixture:
         self.conditions = json.loads((path / "conditions.json").read_text())
 
     @property
-    def group(self) -> str:
-        """Fixtures of one server and encoding share this; the part after it
-        is the format the capture asked for.
-        """
-        return self.name.rsplit("-", 1)[0]
-
-    @property
     def tolerance(self) -> int:
         return self.conditions["tolerance"]
 
@@ -54,33 +47,9 @@ class Fixture:
         cli.factory.pseudodesktop = False
         cli.factory.last_rect = False
         cli.factory.qemu_extended_key = False
-        requested = self.conditions.get("pixel_format")
-        if requested is not None:
-            cli.requested_pixel_format = pixelformat.PIXEL_FORMATS[requested]
+        cli.requested_pixel_format = pixelformat.PIXEL_FORMATS[self.conditions["pixel_format"]]
         cli.dataReceived(gzip.decompress((self.path / "init.bin.gz").read_bytes()))
         return cli
-
-    def replay(self) -> List[Tuple[str, Image.Image]]:
-        """Every step, as (scene key, framebuffer)."""
-        cli = self.client()
-        screens = []
-        for step in self.steps():
-            cli.dataReceived(gzip.decompress(step.read_bytes()))
-            assert cli.screen is not None, f"{step.name}: no framebuffer after the update"
-            screens.append((step.name.removesuffix(".bin.gz").split("-", 2)[2], cli.screen.copy()))
-        return screens
-
-    def quantization(self) -> int:
-        """Widest per-channel step the format this capture negotiated can hold.
-
-        The negotiated format, not the announced one: a capture taken at a
-        reduced format is quantized however wide the server's own pixels are.
-        """
-        fmt = self.client().pixel_format
-        maxima = (fmt.redmax, fmt.greenmax, fmt.bluemax)
-        if not all(maxima):
-            raise AssertionError(f"{self.name}: no per-channel maxima in {fmt}")
-        return max(255 // maximum for maximum in maxima)
 
 
 def fixtures() -> List[Fixture]:
@@ -107,41 +76,6 @@ def first_difference(actual: Image.Image, expected: Image.Image, tolerance: int)
 class TestGoldens(unittest.TestCase):
     def test_at_least_one_fixture_is_committed(self) -> None:
         self.assertTrue(fixtures(), f"no golden fixtures under {FIXTURE_ROOT}; capture one with `make goldens`")
-
-
-def fixture_groups() -> "dict[str, List[Fixture]]":
-    groups: "dict[str, List[Fixture]]" = {}
-    for fixture in fixtures():
-        groups.setdefault(fixture.group, []).append(fixture)
-    return groups
-
-
-class CrossFormat:
-    """The framebuffer does not depend on the format the server negotiated.
-
-    Not a TestCase itself, so the loader collects it only through the
-    subclasses load_tests builds.
-    """
-
-    reference: Fixture
-    other: Fixture
-
-    def test_decodes_the_same_as_its_pair(self) -> None:
-        expected = dict(self.reference.replay())
-        steps = self.other.replay()
-        self.assertEqual(
-            sorted(key for key, _ in steps), sorted(expected),
-            f"{self.other.name} and {self.reference.name} cover different scenes",
-        )
-        tolerance = max(self.reference.quantization(), self.other.quantization())
-        for key, screen in steps:
-            difference = first_difference(screen, expected[key], tolerance)
-            if difference is not None:
-                x, y, got, want = difference
-                self.fail(
-                    f"{self.other.name} scene {key}: pixel ({x},{y}) decoded {got}, "
-                    f"{self.reference.name} decoded {want} (tolerance {tolerance})"
-                )
 
 
 class GoldenReplay:
@@ -176,15 +110,6 @@ def load_tests(loader: unittest.TestLoader, tests: unittest.TestSuite, pattern: 
         name = f"TestGolden_{fixture.name.replace('-', '_')}"
         case = type(name, (GoldenReplay, unittest.TestCase), {"fixture": fixture})
         suite.addTest(case("test_decodes_to_its_oracle"))
-    for members in fixture_groups().values():
-        reference, *others = members
-        for other in others:
-            name = f"TestCrossFormat_{reference.name}_vs_{other.name}".replace("-", "_")
-            case = type(
-                name, (CrossFormat, unittest.TestCase),
-                {"reference": reference, "other": other},
-            )
-            suite.addTest(case("test_decodes_the_same_as_its_pair"))
     return suite
 
 


### PR DESCRIPTION
Removes the cross-format golden check, which cannot fail on its own: every fixture is already compared to its scene PNG at tolerance 0, so one member of a pair equals the PNG exactly and comparing the other against it is that same comparison at a looser bound. Reduced depth, where it was meant to start earning its place, does not change that.

So R3 is checked per format by each fixture against its PNG. Three specs said otherwise, and `pixel-format.md` additionally claimed this check compensates for a wide reduced-depth tolerance, which it does not — that risk is now recorded as unmitigated.

`--pixel-format` becomes required at capture, so a fixture can no longer record `null` and be replayed at whatever ServerInit announced. All six committed fixtures already name a format: they replay untouched and conditions.json is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)