### PR TITLE
fix(api): disconnect() after a failed command, not just success

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@
   - [BREAKING] ``vncdotool.rfb.Rect`` is gone; annotate rectangles as ``tuple[int, int, int, int]`` (@sibson, #415)
   - Local development moves from Makefile.venv + pip to uv; ``make`` targets run under ``uv run`` (@sibson, #383)
   - Fix ``make release`` tagging an empty version (@sibson, #382)
+  - Fix: ``api.ThreadedVNCClientProxy.disconnect()`` hanging forever after a failed command (e.g. ``captureScreen`` to a missing directory) left the client's deferred errored, so ``disconnect()``'s success-only callback never ran (@sibson, #146)
 
 1.4.1 (2026-08-19)
 ----------------------

--- a/tests/functional/test_api_lifecycle.py
+++ b/tests/functional/test_api_lifecycle.py
@@ -126,6 +126,23 @@ class TestApiLifecycle(unittest.TestCase):
                 "factory_connect ran outside the reactor thread",
             )
 
+    def test_disconnect_after_command_error_returns_promptly(self) -> None:
+        """A failed command must not stop ``disconnect()`` from firing.
+
+        ``disconnect()`` chains onto ``factory.deferred``, which a failed
+        ``captureScreen`` leaves in an errored state -- see #146.
+        """
+        client = connect(LIBVNC, timeout=SHORT_TIMEOUT)
+
+        with self.assertRaises(FileNotFoundError):
+            client.captureScreen("no/such/dir/test.png")
+
+        start = time.monotonic()
+        client.disconnect()
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, SHORT_TIMEOUT / 2)
+
     def test_closed_port_raises_promptly(self) -> None:
         """Bounded twice over -- a per-client timeout, and a helper thread
         joined with a deadline -- so even a wedge fails only this test,

--- a/tests/functional/test_api_lifecycle.py
+++ b/tests/functional/test_api_lifecycle.py
@@ -127,11 +127,7 @@ class TestApiLifecycle(unittest.TestCase):
             )
 
     def test_disconnect_after_command_error_returns_promptly(self) -> None:
-        """A failed command must not stop ``disconnect()`` from firing.
-
-        ``disconnect()`` chains onto ``factory.deferred``, which a failed
-        ``captureScreen`` leaves in an errored state -- see #146.
-        """
+        """A failed command must not stop ``disconnect()`` from firing."""
         client = connect(LIBVNC, timeout=SHORT_TIMEOUT)
 
         with self.assertRaises(FileNotFoundError):

--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -77,8 +77,10 @@ class ThreadedVNCClientProxy:
             event.set()
 
         def disconnector(_: Any) -> None:
-            # self.protocol, not the chained result: on a failed command
-            # that result is a Failure, not the protocol.
+            # The argument is unused on purpose: addBoth passes whatever
+            # factory.deferred resolved to, which after a failed command is
+            # a Failure, not the protocol. self.protocol was captured
+            # separately in connect() and is still good to disconnect.
             protocol = self.protocol
             if protocol is None:
                 event.set()

--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -77,10 +77,8 @@ class ThreadedVNCClientProxy:
             event.set()
 
         def disconnector(_: Any) -> None:
-            # addBoth, not addCallback: a prior command's failure leaves
-            # factory.deferred errored, and self.protocol -- not the
-            # chained result, which would be a Failure -- is what's still
-            # good to disconnect.
+            # self.protocol, not the chained result: on a failed command
+            # that result is a Failure, not the protocol.
             protocol = self.protocol
             if protocol is None:
                 event.set()

--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -76,11 +76,19 @@ class ThreadedVNCClientProxy:
         def on_disconnected(reason: Any) -> None:
             event.set()
 
-        def disconnector(protocol: VNCDoToolClient) -> None:
+        def disconnector(_: Any) -> None:
+            # addBoth, not addCallback: a prior command's failure leaves
+            # factory.deferred errored, and self.protocol -- not the
+            # chained result, which would be a Failure -- is what's still
+            # good to disconnect.
+            protocol = self.protocol
+            if protocol is None:
+                event.set()
+                return
             self.factory._disconnect_callbacks.append(on_disconnected)
             protocol.transport.loseConnection()
 
-        reactor.callFromThread(self.factory.deferred.addCallback, disconnector)
+        reactor.callFromThread(self.factory.deferred.addBoth, disconnector)
         event.wait(timeout=self.timeout)
 
     def __getattr__(self, attr: str) -> Any:

--- a/vncdotool/api.py
+++ b/vncdotool/api.py
@@ -77,16 +77,11 @@ class ThreadedVNCClientProxy:
             event.set()
 
         def disconnector(_: Any) -> None:
-            # The argument is unused on purpose: addBoth passes whatever
-            # factory.deferred resolved to, which after a failed command is
-            # a Failure, not the protocol. self.protocol was captured
-            # separately in connect() and is still good to disconnect.
-            protocol = self.protocol
-            if protocol is None:
+            if self.protocol is None:
                 event.set()
                 return
             self.factory._disconnect_callbacks.append(on_disconnected)
-            protocol.transport.loseConnection()
+            self.protocol.transport.loseConnection()
 
         reactor.callFromThread(self.factory.deferred.addBoth, disconnector)
         event.wait(timeout=self.timeout)


### PR DESCRIPTION
## Summary
- `ThreadedVNCClientProxy.disconnect()` chained a success-only `addCallback` onto `factory.deferred`; a prior command failure (e.g. `captureScreen` to a missing directory) left that deferred errored, so `disconnect()` blocked for its full timeout — forever with the default `timeout=None`.
- Switch to `addBoth`, disconnect using `self.protocol` rather than the chained result (which would be a `Failure`).
- The CLI-side hang in #146 was already fixed by #345; this closes the remaining `api.py` path, confirmed live against the docker fleet.

Closes #146

## Test plan
- [x] `tests/functional/test_api_lifecycle.py::test_disconnect_after_command_error_returns_promptly` added, exercises the failed-capture-then-disconnect path