### PR TITLE
Scope typecheck target to vncdotool, drop tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 help:
 	@echo "test:		run unit tests"
 	@echo "test-func:	run functional tests"
-	@echo "typecheck:	run mypy over vncdotool and tests"
+	@echo "typecheck:	run mypy over vncdotool"
 	@echo "servers-up:	start the docker VNC test servers"
 	@echo "servers-down:	stop the docker VNC test servers"
 	@echo "test-servers:	run functional tests against the VNC test servers"
@@ -73,7 +73,7 @@ test-func:
 
 .PHONY: typecheck
 typecheck:
-	uv run mypy vncdotool tests
+	uv run mypy vncdotool
 
 include tests/servers/servers.mk
 


### PR DESCRIPTION
mypy over tests/ is mostly noise right now — unittest's dynamic patterns (Mock, load_tests, patch targets) throw false positives that swamp real findings in vncdotool itself. #433 tracks cleaning tests/ up and re-adding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)