### PR TITLE
Drop the version-3.889 pixel-format guess and the image_mode shim

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@
   - Fix screenshots shifted against any server whose first rectangle does not start at (0, 0) (@sibson)
   - Fix ``VMWareClient`` raising ``AttributeError`` instead of detecting the VMware single-pixel update it exists to filter (@sibson, #400)
   - ``PixelFormat`` moves to ``vncdotool.pixelformat``; ``vncdotool.rfb.PixelFormat`` still imports (@sibson, #415)
+  - [BREAKING] ``VNCDoToolClient.image_mode`` is gone; its ``FutureWarning`` shipped in 1.4, see #385 (@sibson)
+  - A server that announces an unreadable pixel format is now asked for ``rgbx8888`` even when it identifies as Apple Remote Desktop (RFB 3.889); the previous ``rgb565`` fallback there was never confirmed necessary and never fired against any measured server (@sibson)
   - [BREAKING] ``vncdotool.rfb.Rect`` is gone; annotate rectangles as ``tuple[int, int, int, int]`` (@sibson, #415)
   - Local development moves from Makefile.venv + pip to uv; ``make`` targets run under ``uv run`` (@sibson, #383)
   - Fix ``make release`` tagging an empty version (@sibson, #382)

--- a/specs/pixel-format.md
+++ b/specs/pixel-format.md
@@ -21,12 +21,9 @@ matrix has one fixture and the pixel plumbing has never run at a second format.
 The `pixelformat.py` machinery: computing a Pillow mode from any byte-aligned
 truecolor `PixelFormat` instead of a five-entry lookup table, plus the CPIXEL
 functions ZRLE needs at Phase 5. `rgb565` is in the registry as a second
-requestable format — RFB permits it and the code was already written for it —
-but nothing here depends on it: R3 (one scene decoding to the same framebuffer
-at two formats) is already discharged by `bgrx8888` and `rgbx8888`, both
-captured today. Verifying `rgb565` end-to-end — a golden fixture, a fleet
-case — is deferred; see below. Colour map, and the layouts Pillow cannot
-unpack, wait for a server that needs them.
+requestable format, but verifying it end-to-end is deferred (see below).
+Colour map, and the layouts Pillow cannot unpack, wait for a server that
+needs them.
 
 ## What servers actually send
 
@@ -232,8 +229,7 @@ requested. They are different facts and the interesting fixtures are where they
 differ.
 
 Golden and functional coverage at a second, reduced-precision format
-(`rgb565`) is deferred — see below — since R3 is already satisfied by the two
-32 bpp formats already captured.
+(`rgb565`) is deferred (see below).
 
 ## Phasing
 

--- a/specs/pixel-format.md
+++ b/specs/pixel-format.md
@@ -18,10 +18,15 @@ matrix has one fixture and the pixel plumbing has never run at a second format.
 
 ## Scope
 
-The `pixelformat.py` machinery, plus one new negotiated format: `rgb565`. That
-discharges R3 for two formats — one scene decoding to the same framebuffer at
-both. Colour map, and the layouts Pillow cannot unpack, wait for a server that
-needs them.
+The `pixelformat.py` machinery: computing a Pillow mode from any byte-aligned
+truecolor `PixelFormat` instead of a five-entry lookup table, plus the CPIXEL
+functions ZRLE needs at Phase 5. `rgb565` is in the registry as a second
+requestable format — RFB permits it and the code was already written for it —
+but nothing here depends on it: R3 (one scene decoding to the same framebuffer
+at two formats) is already discharged by `bgrx8888` and `rgbx8888`, both
+captured today. Verifying `rgb565` end-to-end — a golden fixture, a fleet
+case — is deferred; see below. Colour map, and the layouts Pillow cannot
+unpack, wait for a server that needs them.
 
 ## What servers actually send
 
@@ -52,9 +57,14 @@ Three consequences:
   only by declaring depth 32 — the historical quirk rfbproto warns about — so we
   renegotiate to a format byte-identical to the one already arriving. Computing
   the mode from the fields removes the failure mode.
-- **The 3.889 Apple branch never fires against current Screen Sharing**, whose
-  native is in `PF2IM` already. It is dropped rather than carried forward; if an
-  older ARD server needs it, it returns as a measurement.
+- **The version-3.889 special case (request `BGR;16` for Apple Remote
+  Desktop) is dropped, not carried forward.** It traced to PR #243 fixing
+  issue #205, a generic 16bpp black-screen report with no confirmation the
+  reporter's server was ARD or that `rgb565` was what fixed it. Measured
+  Screen Sharing today sends the same BGRX every other server does, already
+  readable by `raw_mode`, so the branch never fired. If an older ARD server
+  genuinely needs a non-default format, that comes back as a measurement, not
+  a guess kept on file.
 - **One dominant native is not a safe assumption.** `PF2IM` was shaped around
   the formats someone had met, and libvncserver-example is a depth declaration
   away from an entry.
@@ -217,32 +227,20 @@ and the negative cases falling back to PIXEL width.
 **Negotiation.** Mocked transport asserting the `SetPixelFormat` bytes, or their
 absence, which is step 2 and the case a test would otherwise skip.
 
-**Golden.** A second fixture, `tigervnc-raw-rgb565`, from `make goldens`. Its
-oracle is the same committed scene PNG, so tolerance stops being zero: the bound
-is the format's own step, 255/31 for the 5-bit channels and 255/63 for the
-6-bit, rounded up, which covers truncation and round-to-nearest alike without
-modelling either.
-
 `conditions.json` grows the pixel format, both the ServerInit one and any we
 requested. They are different facts and the interesting fixtures are where they
 differ.
 
-**Functional.** One fleet case: `--pixel-format rgb565` capture is not flat.
-
-**Capture script.** `scene.vdo` steps with `expect scenes/X.png 0`, a histogram
-RMS of exactly zero, which `rgb565` can never reach — every step would poll
-until the capture hung rather than failed. The driving script becomes
-per-format, `make goldens` supplying the maxrms; `session.vdo` in the archive
-records which ran.
+Golden and functional coverage at a second, reduced-precision format
+(`rgb565`) is deferred — see below — since R3 is already satisfied by the two
+32 bpp formats already captured.
 
 ## Phasing
 
 1. `pixelformat.py`, the registry, unit tests. No call sites change.
-2. `client.py` resolves the mode per rectangle; `PF2IM`, `setImageMode`,
-   `image_mode` go. BGRX behaviour unchanged (R5).
+2. `client.py` resolves the mode per rectangle; `PF2IM` and the `image_mode`
+   property go. BGRX behaviour unchanged (R5).
 3. `--pixel-format`, the policy, the `api.connect` keyword.
-4. Capture `tigervnc-raw-rgb565`; tolerance in `test_goldens.py`; the fleet
-   case.
 
 ## Validated against the specs
 
@@ -266,6 +264,14 @@ document covers it; a capture will.
 
 ## Deferred
 
+- **`rgb565` golden and fleet coverage.** The format is in the registry and
+  reachable from `--pixel-format`, but nothing has captured
+  `tigervnc-raw-rgb565` or run a fleet case against it — R3 doesn't need it,
+  and no server has been found that requires it over the two 32 bpp formats
+  already verified. Capturing it needs a per-format `maxrms` in the driving
+  script (`scene.vdo`'s exact-histogram `expect` can't pass at 5-bit
+  quantization) and the tolerance bound noted under Risks below, whenever
+  someone wants the second format actually exercised end-to-end.
 - The four layouts Pillow cannot unpack, each waiting for a capture from a
   server that sends one and ignores `SetPixelFormat`.
 - Colour map: `P` plus a palette, and the `SetColourMapEntries` ordering above.
@@ -280,12 +286,13 @@ document covers it; a capture will.
   [decoder-goldens.md](decoder-goldens.md). What hides is narrower than the
   whole class: a channel swap moves a coloured pixel much further than 255/31,
   so the tolerant comparison still fails on it, and what survives is a shift or
-  rounding error smaller than one quantization step.
+  rounding error smaller than one quantization step. Applies once the
+  deferred `rgb565` golden above is captured.
 - Tagging moves the trust from our arithmetic to Pillow's mode strings. A mode
   meaning something other than we think decodes silently wrong, where a bad
   shift would at least be ours to read — hence unit tests asserting Pillow's
   behaviour per mode, not only which mode we picked.
-- Retiring the 3.889 branch rests on one macOS version on a hosted runner. If an
-  older ARD server announces something unreadable, it now gets a
-  `SetPixelFormat` for `rgbx8888` — the correct fallback, untested against that
-  server.
+- Dropping the version-3.889 special case rests on one macOS version on a
+  hosted runner. If an older ARD server announces something unreadable, it
+  now gets a `SetPixelFormat` for `rgbx8888` — the correct fallback, untested
+  against that server.

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,7 +1,6 @@
 from unittest import TestCase, mock
 import io
 import struct
-import warnings
 
 from vncdotool import client, pixelformat, rfb
 from vncdotool.pixelformat import PIXEL_FORMATS
@@ -348,66 +347,33 @@ class TestImageMode(TestCase):
         self.addCleanup(patcher.stop)
         return patcher.start()
 
-    def test_image_mode_warns_on_access(self):
-        with self.assertWarns(FutureWarning):
-            self.client.image_mode
-
-    def test_image_mode_returns_negotiated_mode(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            assert self.client.image_mode == "RGBX"
-
-    def test_setImageMode_does_not_warn(self):
-        self.client._version_server = (3, 8)
+    def test_setImageMode_keeps_the_negotiated_mode(self):
         self.client.pixel_format = RGB24
         self.patch_setPixelFormat()
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", FutureWarning)
-            self.client.setImageMode()
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            assert self.client.image_mode == "RGB"
-
-    def test_setImageMode_falls_back_for_apple_remote_desktop(self):
-        self.client._version_server = (3, 889)
-        self.client.pixel_format = COLOUR_MAPPED
-        setPixelFormat = self.patch_setPixelFormat()
-
         self.client.setImageMode()
 
-        setPixelFormat.assert_called_once_with(PIXEL_FORMATS["rgb565"])
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            assert self.client.image_mode == "BGR;16"
+        assert self.client._image_mode == "RGB"
 
     def test_setImageMode_falls_back_when_the_server_format_cannot_be_unpacked(self):
-        self.client._version_server = (3, 8)
         self.client.pixel_format = COLOUR_MAPPED
         setPixelFormat = self.patch_setPixelFormat()
 
         self.client.setImageMode()
 
         setPixelFormat.assert_called_once_with(PIXEL_FORMATS["rgbx8888"])
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            assert self.client.image_mode == "RGBX"
+        assert self.client._image_mode == "RGBX"
 
     def test_setImageMode_keeps_a_server_format_pillow_can_unpack(self):
-        self.client._version_server = (3, 8)
         self.client.pixel_format = rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 24, 16, 8)
         setPixelFormat = self.patch_setPixelFormat()
 
         self.client.setImageMode()
 
         setPixelFormat.assert_not_called()
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            assert self.client.image_mode == "XBGR"
+        assert self.client._image_mode == "XBGR"
 
     def test_setImageMode_asks_for_the_format_the_caller_requested(self):
-        self.client._version_server = (3, 8)
         self.client.pixel_format = PIXEL_FORMATS["rgbx8888"]
         self.client.requested_pixel_format = PIXEL_FORMATS["rgb565"]
         setPixelFormat = self.patch_setPixelFormat()
@@ -415,15 +381,12 @@ class TestImageMode(TestCase):
         self.client.setImageMode()
 
         setPixelFormat.assert_called_once_with(PIXEL_FORMATS["rgb565"])
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            assert self.client.image_mode == "BGR;16"
+        assert self.client._image_mode == "BGR;16"
 
     def test_setImageMode_keeps_bypp_in_step_with_the_negotiated_format(self):
         # setPixelFormat is real here, not mocked like the tests above: bypp
         # is a read-through of the pixel_format it assigns, so a mock hides
         # any drift between it and the raw mode _image_mode negotiates.
-        self.client._version_server = (3, 8)
         self.client.pixel_format = PIXEL_FORMATS["rgbx8888"]
         self.client.requested_pixel_format = PIXEL_FORMATS["rgb565"]
 
@@ -433,7 +396,6 @@ class TestImageMode(TestCase):
         assert self.client._image_mode == pixelformat.raw_mode(PIXEL_FORMATS["rgb565"])
 
     def test_setImageMode_fails_the_connection_for_a_format_it_cannot_read(self):
-        self.client._version_server = (3, 8)
         self.client.pixel_format = PIXEL_FORMATS["rgbx8888"]
         self.client.requested_pixel_format = COLOUR_MAPPED
         setPixelFormat = self.patch_setPixelFormat()
@@ -443,25 +405,6 @@ class TestImageMode(TestCase):
         setPixelFormat.assert_not_called()
         self.client.factory.clientConnectionFailed.assert_called_once()
         self.client.transport.loseConnection.assert_called_once()
-
-    @mock.patch('PIL.Image.frombytes')
-    def test_updateRectangle_does_not_warn(self, frombytes):
-        cli = self.client
-        cli.image = mock.Mock()
-        cli.width, cli.height = 100, 200
-        frombytes.return_value = client.Image.new("RGB", (100, 200))
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", FutureWarning)
-            cli.updateRectangle(0, 0, 100, 200, mock.Mock(), cli.pixel_format)
-
-    def test_updateCursor_does_not_warn(self):
-        cli = self.client
-        cli.factory.nocursor = False
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", FutureWarning)
-            cli.updateCursor(0, 0, 4, 4, b"\x00" * (4 * 4 * 4), b"\x00" * 4)
 
 
 class TestVMWareClient(TestCase):

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import logging
 import math
 import socket
-import warnings
 from pathlib import Path
 from struct import pack
 from typing import IO, Any, Callable, Iterator, TypeVar, Union
@@ -297,16 +296,6 @@ class VNCDoToolClient(rfb.RFBClient):
 
         returnValue(self)
 
-    @property
-    def image_mode(self) -> str:
-        warnings.warn(
-            "image_mode will change in a future release; please comment on "
-            "https://github.com/sibson/vncdotool/issues/385 if you rely on it",
-            FutureWarning,
-            stacklevel=2,
-        )
-        return self._image_mode
-
     def _rawModeFor(self, pixel_format: rfb.PixelFormat) -> str:
         # Called once per rectangle. A PixelFormat is a frozen dataclass, so
         # hashing one for a cache lookup costs more than the identity check
@@ -325,10 +314,7 @@ class VNCDoToolClient(rfb.RFBClient):
                 return
             except pixelformat.UnsupportedPixelFormat as exc:
                 log.debug("cannot unpack the server's format (%s), asking for another", exc)
-                if self._version_server == (3, 889):  # Apple Remote Desktop
-                    pixel_format = pixelformat.PIXEL_FORMATS["rgb565"]
-                else:
-                    pixel_format = pixelformat.PIXEL_FORMATS["rgbx8888"]
+                pixel_format = pixelformat.PIXEL_FORMATS["rgbx8888"]
 
         # Resolved before the request goes out: failing afterwards would
         # leave the server sending pixels in a format we cannot read.


### PR DESCRIPTION
## Summary
- Removes the RFB-3.889 (Apple Remote Desktop) special case that requested `rgb565` on an unreadable server format. Traced its origin to PR #243 fixing a generic 16bpp black-screen report (#205) with no confirmation the reporter's server was ARD or that `rgb565` was the fix; every measured Screen Sharing server sends plain BGRX, already readable, so the branch never fired. Falls back to `rgbx8888` like any other server now.
- Removes `VNCDoToolClient.image_mode`, whose `FutureWarning` shipped in 1.4 (#385) — this is 2.0, so the deprecated shim goes per the design doc's own phasing.
- `rgb565` itself stays in the registry/CLI/tests — it's a spec-valid, already-implemented format, just no longer treated as an ARD-specific requirement.
- `specs/pixel-format.md`: moved rgb565's golden fixture + fleet case to Deferred, since R3 (two formats decoding to the same framebuffer) is already discharged by the two 32bpp formats already captured.

## Test plan
- [x] `make test` (297 unit tests, all pass)
- [x] `flake8 vncdotool tests` clean