### PR TITLE
Clear mypy's remaining errors in loggingproxy.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 2.0.0.dev0 (UNRELEASED)
 ----------------------
+  - Fix ``VNCLoggingServerProxy.connectionLost`` rejecting the no-argument call ``Protocol.connectionLost`` promises callers (@sibson)
   - Dependency resolution ignores releases younger than a week, so a compromised upload has to survive public scrutiny before it can reach a build here (@sibson)
   - CI installs from the committed ``uv.lock`` and fails if it is stale, rather than silently resolving something else; ``uv.lock`` is no longer listed in ``.gitignore``, where it had no effect anyway (@sibson)
   - ``--encodings hextile`` offers Hextile, which sends less than Raw on ordinary screen content (@sibson)

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -26,6 +26,7 @@ from vncdotool.capture import (
 )
 from vncdotool.const import AuthTypes, Encoding
 from vncdotool.loggingproxy import (
+    RFBServer,
     VNCLoggingClientProxy,
     VNCLoggingServerFactory,
     VNCLoggingServerProxy,
@@ -558,6 +559,17 @@ class TestCaptureWriter(TestCase):
         self.assertEqual(s2c, VERSION_33 + NONE_AUTH_33)
 
 
+class TestRFBServer(TestCase):
+
+    def test_connectionMade_sets_tcp_nodelay(self) -> None:
+        server = RFBServer()
+        server.transport = mock.Mock()
+
+        server.connectionMade()
+
+        server.transport.setTcpNoDelay.assert_called_once_with(True)
+
+
 class TestProxyCaptureWiring(TestCase):
     """Drive both proxy halves directly, with mocked transports standing in
     for the peer connections portforward would otherwise wire up.
@@ -799,6 +811,20 @@ class TestProxyCaptureWiring(TestCase):
         self.assertFalse(factory.session_taken)
         self.assertIsNone(probe.capture)
         factory.sessionFinished.assert_not_called()
+
+    def test_connectionLost_accepts_no_argument(self) -> None:
+        """Protocol.connectionLost has a default reason; an override that
+        drops the default breaks any caller relying on that contract.
+        """
+        factory = mock.Mock()
+
+        proxy = VNCLoggingServerProxy()
+        proxy.factory = factory
+        proxy.transport = mock.Mock()
+
+        proxy.connectionLost()
+
+        factory.clientConnectionLost.assert_called_once_with(proxy)
 
     def test_greeting_only_session_is_still_written(self) -> None:
         """A server rejecting the client before it speaks (TigerVNC's "Too

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -8,12 +8,14 @@ import socket
 import sys
 import time
 from struct import unpack, unpack_from
-from typing import IO, Callable, Sequence
+from typing import IO, Callable, Iterable, Sequence, cast
 
 from twisted.internet.error import ReactorNotRunning
-from twisted.internet.protocol import Protocol
+from twisted.internet.interfaces import IAddress, ITCPTransport, ITransport
+from twisted.internet.protocol import Protocol, connectionDone
 from twisted.protocols import portforward
 from twisted.python.failure import Failure
+from zope.interface import implementer
 
 from . import __version__ as VNCDOTOOL_VERSION
 from .capture import CaptureWriter, HandshakeScrubber
@@ -46,7 +48,10 @@ class RFBServer(Protocol):
 
     def connectionMade(self) -> None:
         super().connectionMade()
-        self.transport.setTcpNoDelay(True)
+        # Only ever reached via listenTCP (see command.py) -- unlike
+        # client.py's transport, which also serves UNIX sockets, there is no
+        # real ambiguity to check here.
+        cast(ITCPTransport, self.transport).setTcpNoDelay(True)
 
         self.buffer = bytearray()
         # XXX send version message
@@ -61,7 +66,7 @@ class RFBServer(Protocol):
         msg = self.buffer[:12]
         del self.buffer[:12]
         if not msg.startswith(b"RFB 003.") and msg.endswith(b"\n"):
-            self.transport.loseConnection()
+            cast(ITransport, self.transport).loseConnection()
 
         version = msg[8:11]
         if version in (b"003", b"005"):
@@ -171,17 +176,24 @@ class RFBServer(Protocol):
         self.handle_keyEvent(keysym, down)
 
 
+@implementer(ITransport)
 class NullTransport:
     addressFamily = socket.AF_UNSPEC
 
     def write(self, data: bytes) -> None:
         return
 
-    def writeSequence(self, data: bytes) -> None:
+    def writeSequence(self, data: Iterable[bytes]) -> None:
         return
 
     def setTcpNoDelay(self, enabled: bool) -> None:
         return
+
+    def getPeer(self) -> IAddress:
+        raise NotImplementedError("vnclog's server-side client has no real peer")
+
+    def getHost(self) -> IAddress:
+        raise NotImplementedError("vnclog's server-side client has no real host")
 
     def loseConnection(self) -> None:
         return
@@ -192,6 +204,7 @@ class VNCLoggingClient(VNCDoToolClient):
 
     capture_file: str | None = None
     capture: CaptureWriter | None = None
+    recorder: Callable[[str], int] | None = None
 
     def _handleRectangle(self, block: bytes) -> None:
         # Tallied off the decoded stream: SetEncodings only says what the
@@ -205,6 +218,7 @@ class VNCLoggingClient(VNCDoToolClient):
         if self.capture_file:
             assert self.screen is not None
             self.screen.save(self.capture_file)
+            assert self.recorder is not None
             self.recorder("expect %s\n" % self.capture_file)
             self.capture_file = None
 
@@ -274,7 +288,7 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):
     """
 
     clientProtocolFactory = VNCLoggingClientFactory
-    factory: VNCLoggingServerFactory
+    factory: VNCLoggingServerFactory  # type: ignore[assignment]
     peer: VNCLoggingClientProxy
 
     server: str | None = None
@@ -289,19 +303,25 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):
     refused: bool = False
     took_session: bool = False
 
+    def _peerHost(self) -> object:
+        # Only IPv4Address/IPv6Address carry .host; this proxy only ever
+        # listens with listenTCP, so that's what getPeer() returns in
+        # practice, but IAddress itself doesn't promise it.
+        return getattr(self.transport.getPeer(), "host", None)
+
     def connectionMade(self) -> None:
         # Taken on accept rather than on first byte, so a second concurrent
         # connection is refused rather than interleaved into the session.
         if self.factory.one_shot and self.factory.session_taken:
             log.warning(
                 "--one-shot: already serving a session; refusing connection from %s",
-                self.transport.getPeer().host,
+                self._peerHost(),
             )
             self.refused = True
             self.transport.loseConnection()
             return
 
-        log.info("new connection from %s", self.transport.getPeer().host)
+        log.info("new connection from %s", self._peerHost())
         super().connectionMade()
         RFBServer.connectionMade(self)
         self.mouse: tuple[int | None, int | None] = (None, None)
@@ -316,7 +336,7 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):
                 scrubber=HandshakeScrubber(preserve_auth=self.factory.capture_preserve_auth),
             )
 
-    def connectionLost(self, reason: Failure) -> None:
+    def connectionLost(self, reason: Failure = connectionDone) -> None:
         if self.refused:
             # Touching the factory here would release the live session's
             # claim, or close the recorder it is still writing to.


### PR DESCRIPTION
`vncdotool` alone: 89 → 79 errors. Six distinct causes in `loggingproxy.py`, each fixed independently:

- `RFBServer.transport` — same MRO conflict #407 already found for this attribute; `cast()` at each call site instead of `isinstance`. `client.py:86` uses `isinstance` because that class genuinely serves both TCP and UNIX sockets; `RFBServer` here is only ever reached via `listenTCP`, so there's no real ambiguity to check — and `isinstance` against a zope Interface silently returns `False` for a plain `Mock`, which was quietly making `setTcpNoDelay` a no-op under every existing test. Added `TestRFBServer` to catch that.
- `VNCLoggingClient.recorder` — set externally right after construction, never declared (same shape as the `RFBFactory.username` gap); declared it with the `assert` guard `VNCLoggingServerProxy.recorder` already uses.
- `NullTransport` — wasn't actually a valid `ITransport` (missing `getPeer`/`getHost`, wrong `writeSequence` signature); now a real `@implementer(ITransport)`.
- `VNCLoggingServerProxy.factory` — one `# type: ignore[assignment]`; Twisted's `Factory[T]` is invariant, so narrowing it properly would mean casting at all 16 attribute-access call sites instead.
- `getPeer().host` — `IAddress` doesn't guarantee `.host`; added `_peerHost()` (a `getattr` with a `None` fallback) rather than importing/`isinstance`-checking two address classes for a log line.
- `connectionLost` signature — restored the default `reason` argument (`= connectionDone`) that `Protocol.connectionLost` promises callers. This one's a genuine, if never-yet-triggered, Liskov violation, not just a typing nit — `client.py:89` has the identical bug, out of scope here.

Tested: `make test` 299 pass (adds a `connectionLost()`-with-no-argument regression test), `flake8` clean, `mypy vncdotool` 79 (`loggingproxy.py`: 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
