### PR TITLE
Phase 5: migrate Cursor, DesktopSize, QEMU key to the decoder registry

### DIFF
--- a/tests/unit/test_decoder_control.py
+++ b/tests/unit/test_decoder_control.py
@@ -27,7 +27,6 @@ class TestDesktopSize(unittest.TestCase):
 
         self.assertIsNotNone(self.cli.screen)
         self.assertEqual(self.cli.screen.size, (8, 6))
-        # Only the Raw rect carries content; DesktopSize is not recorded.
         self.assertEqual(self.cli.rectanglePos, [(0, 0, 4, 4)])
 
 

--- a/tests/unit/test_decoder_control.py
+++ b/tests/unit/test_decoder_control.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import unittest
+
+from vncdotool.const import Encoding
+
+from tests.unit.utils import (
+    _pixel,
+    framebuffer_update,
+    handshake,
+    make_client,
+    rect,
+)
+
+
+class TestDesktopSize(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cli = make_client()
+
+    def test_desktop_size_resizes_screen_and_is_not_a_content_rect(self) -> None:
+        handshake(self.cli, 4, 4)
+
+        raw_body = b"".join(_pixel(1, 2, 3) for _ in range(16))
+        raw_rect = rect(0, 0, 4, 4, Encoding.RAW, raw_body)
+        resize_rect = rect(0, 0, 8, 6, Encoding.PSEUDO_DESKTOP_SIZE)
+        self.cli.dataReceived(framebuffer_update([raw_rect, resize_rect]))
+
+        self.assertIsNotNone(self.cli.screen)
+        self.assertEqual(self.cli.screen.size, (8, 6))
+        # Only the Raw rect carries content; DesktopSize is not recorded.
+        self.assertEqual(self.cli.rectanglePos, [(0, 0, 4, 4)])
+
+
+class TestQemuExtendedKey(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cli = make_client()
+
+    def test_qemu_extended_key_is_negotiated_and_is_not_a_content_rect(self) -> None:
+        handshake(self.cli, 2, 2)
+        self.assertNotIn(
+            Encoding.PSEUDO_QEMU_EXTENDED_KEY_EVENT, self.cli.negotiated_encodings
+        )
+
+        qemu_rect = rect(0, 0, 0, 0, Encoding.PSEUDO_QEMU_EXTENDED_KEY_EVENT)
+        self.cli.dataReceived(framebuffer_update([qemu_rect]))
+
+        self.assertIn(
+            Encoding.PSEUDO_QEMU_EXTENDED_KEY_EVENT, self.cli.negotiated_encodings
+        )
+        self.assertEqual(self.cli.rectanglePos, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_decoder_cursor.py
+++ b/tests/unit/test_decoder_cursor.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import unittest
+
+from vncdotool.const import Encoding
+
+from tests.unit.utils import (
+    _pixel,
+    assert_pixels,
+    framebuffer_update,
+    handshake,
+    make_client,
+    rect,
+)
+
+
+class TestCursor(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cli = make_client()
+
+    # Hotspot (1, 1), 2x2 image, fully-opaque mask -- rfbproto's Cursor
+    # pseudo-encoding: pixel values, then a byte-padded MSB-first scanline
+    # bitmask, one bit per pixel, 1 meaning valid.
+    IMAGE_2X2 = [(255, 0, 0), (0, 255, 0), (0, 0, 255), (255, 255, 0)]
+    MASK_2X2 = bytes([0b11000000, 0b11000000])
+
+    def test_cursor_sets_image_mask_and_hotspot(self) -> None:
+        handshake(self.cli, 4, 4)
+
+        body = b"".join(_pixel(*p) for p in self.IMAGE_2X2) + self.MASK_2X2
+        cursor_rect = rect(1, 1, 2, 2, Encoding.PSEUDO_CURSOR, body)
+        self.cli.dataReceived(framebuffer_update([cursor_rect]))
+
+        self.assertIsNotNone(self.cli.cursor)
+        assert_pixels(self, self.cli.cursor, self.IMAGE_2X2)
+        self.assertEqual(self.cli.cfocus, (1, 1))
+        # Matches pre-migration behaviour: the cursor rectangle is still
+        # recorded, unlike DesktopSize/QEMU which carry no content.
+        self.assertEqual(self.cli.rectanglePos, [(1, 1, 2, 2)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_decoder_cursor.py
+++ b/tests/unit/test_decoder_cursor.py
@@ -18,9 +18,8 @@ class TestCursor(unittest.TestCase):
     def setUp(self) -> None:
         self.cli = make_client()
 
-    # Hotspot (1, 1), 2x2 image, fully-opaque mask -- rfbproto's Cursor
-    # pseudo-encoding: pixel values, then a byte-padded MSB-first scanline
-    # bitmask, one bit per pixel, 1 meaning valid.
+    # 2x2 image at hotspot (1, 1). MASK_2X2 is MSB-first, one bit per
+    # pixel; 0b11000000 flags both columns of each row valid.
     IMAGE_2X2 = [(255, 0, 0), (0, 255, 0), (0, 0, 255), (255, 255, 0)]
     MASK_2X2 = bytes([0b11000000, 0b11000000])
 
@@ -34,8 +33,6 @@ class TestCursor(unittest.TestCase):
         self.assertIsNotNone(self.cli.cursor)
         assert_pixels(self, self.cli.cursor, self.IMAGE_2X2)
         self.assertEqual(self.cli.cfocus, (1, 1))
-        # Matches pre-migration behaviour: the cursor rectangle is still
-        # recorded, unlike DesktopSize/QEMU which carry no content.
         self.assertEqual(self.cli.rectanglePos, [(1, 1, 2, 2)])
 
 

--- a/vncdotool/decoders/__init__.py
+++ b/vncdotool/decoders/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Dict, Type
 
 from ..const import Encoding
-from .base import ClientDecoder, ControlDecoder, Decoder, PixelDecoder
+from .base import ClientDecoder, ControlDecoder, Decoder, PixelDecoder, RectDecoder
 from .buffer import RectBuffer
 from .control import DesktopSizeDecoder, QemuExtendedKeyDecoder
 from .copyrect import CopyRectDecoder
@@ -57,5 +57,6 @@ __all__ = [
     "ENCODING_NAMES",
     "PixelDecoder",
     "RectBuffer",
+    "RectDecoder",
     "for_connection",
 ]

--- a/vncdotool/decoders/__init__.py
+++ b/vncdotool/decoders/__init__.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from typing import Dict, Type
 
 from ..const import Encoding
-from .base import ClientDecoder, Decoder, PixelDecoder
+from .base import ClientDecoder, ControlDecoder, Decoder, PixelDecoder
 from .buffer import RectBuffer
+from .control import DesktopSizeDecoder, QemuExtendedKeyDecoder
 from .copyrect import CopyRectDecoder
+from .cursor import CursorDecoder
 from .errors import DecodeError
 from .hextile import HextileDecoder
 from .raw import RawDecoder
@@ -24,6 +26,9 @@ DECODERS: Dict[Encoding, Type[Decoder]] = {
         CoRREDecoder,
         HextileDecoder,
         ZRLEDecoder,
+        CursorDecoder,
+        DesktopSizeDecoder,
+        QemuExtendedKeyDecoder,
     )
 }
 
@@ -45,6 +50,7 @@ def for_connection() -> Dict[Encoding, Decoder]:
 
 __all__ = [
     "ClientDecoder",
+    "ControlDecoder",
     "DECODERS",
     "DecodeError",
     "Decoder",

--- a/vncdotool/decoders/base.py
+++ b/vncdotool/decoders/base.py
@@ -42,3 +42,9 @@ class PixelDecoder(Decoder):
 
 class ClientDecoder(Decoder):
     """Consumes bytes, calls a client method."""
+
+
+class ControlDecoder(Decoder):
+    """Calls a client method as a side effect; carries no framebuffer
+    content, so the pump never records its rectangle as a screen change.
+    """

--- a/vncdotool/decoders/base.py
+++ b/vncdotool/decoders/base.py
@@ -27,7 +27,11 @@ class Decoder:
         raise NotImplementedError
 
 
-class PixelDecoder(Decoder):
+class RectDecoder(Decoder):
+    """Its rectangle is a real screen change, recorded as one."""
+
+
+class PixelDecoder(RectDecoder):
     """Consumes bytes, fills a rect buffer."""
 
     # False when the decoder's wire bytes are already its output bytes, in order.
@@ -40,7 +44,7 @@ class PixelDecoder(Decoder):
         return pixel_format
 
 
-class ClientDecoder(Decoder):
+class ClientDecoder(RectDecoder):
     """Consumes bytes, calls a client method."""
 
 

--- a/vncdotool/decoders/base.py
+++ b/vncdotool/decoders/base.py
@@ -45,6 +45,5 @@ class ClientDecoder(Decoder):
 
 
 class ControlDecoder(Decoder):
-    """Calls a client method as a side effect; carries no framebuffer
-    content, so the pump never records its rectangle as a screen change.
-    """
+    """Calls a client method as a side effect; its rectangle is never
+    recorded as a screen change."""

--- a/vncdotool/decoders/control.py
+++ b/vncdotool/decoders/control.py
@@ -1,7 +1,4 @@
-"""DesktopSize and QEMU extended key pseudo-encodings: no payload, a client
-side effect only. LastRect stays on rfb.py's own path -- it mutates the
-rectangle loop counter itself rather than calling a client method.
-"""
+"""DesktopSize and QEMU extended key pseudo-encodings. rfbproto."""
 from __future__ import annotations
 
 from typing import ClassVar, Iterator

--- a/vncdotool/decoders/control.py
+++ b/vncdotool/decoders/control.py
@@ -1,0 +1,34 @@
+"""DesktopSize and QEMU extended key pseudo-encodings: no payload, a client
+side effect only. LastRect stays on rfb.py's own path -- it mutates the
+rectangle loop counter itself rather than calling a client method.
+"""
+from __future__ import annotations
+
+from typing import ClassVar, Iterator
+
+from ..const import Encoding
+from ..pixelformat import PixelFormat
+from .base import ControlDecoder
+
+
+class DesktopSizeDecoder(ControlDecoder):
+    ENCODING: ClassVar[Encoding] = Encoding.PSEUDO_DESKTOP_SIZE
+
+    def decodeForClient(
+        self, client: object, rect: tuple[int, int, int, int], pixel_format: PixelFormat
+    ) -> Iterator[int]:
+        _, _, width, height = rect
+        client.updateDesktopSize(width, height)
+        return
+        yield  # pragma: no cover -- never runs; keeps this a generator
+
+
+class QemuExtendedKeyDecoder(ControlDecoder):
+    ENCODING: ClassVar[Encoding] = Encoding.PSEUDO_QEMU_EXTENDED_KEY_EVENT
+
+    def decodeForClient(
+        self, client: object, rect: tuple[int, int, int, int], pixel_format: PixelFormat
+    ) -> Iterator[int]:
+        client.negotiated_encodings.add(Encoding.PSEUDO_QEMU_EXTENDED_KEY_EVENT)
+        return
+        yield  # pragma: no cover -- never runs; keeps this a generator

--- a/vncdotool/decoders/cursor.py
+++ b/vncdotool/decoders/cursor.py
@@ -1,0 +1,23 @@
+"""Cursor pseudo-encoding. rfbproto: pixel values, then a byte-padded
+MSB-first scanline bitmask, one bit per pixel.
+"""
+from __future__ import annotations
+
+from typing import ClassVar, Iterator
+
+from ..const import Encoding
+from ..pixelformat import PixelFormat
+from .base import ClientDecoder
+
+
+class CursorDecoder(ClientDecoder):
+    ENCODING: ClassVar[Encoding] = Encoding.PSEUDO_CURSOR
+
+    def decodeForClient(
+        self, client: object, rect: tuple[int, int, int, int], pixel_format: PixelFormat
+    ) -> Iterator[int]:
+        x, y, width, height = rect
+        pixel_len = width * height * pixel_format.bypp
+        mask_len = ((width + 7) // 8) * height
+        block = yield pixel_len + mask_len
+        client.updateCursor(x, y, width, height, block[:pixel_len], block[pixel_len:])

--- a/vncdotool/decoders/cursor.py
+++ b/vncdotool/decoders/cursor.py
@@ -1,6 +1,4 @@
-"""Cursor pseudo-encoding. rfbproto: pixel values, then a byte-padded
-MSB-first scanline bitmask, one bit per pixel.
-"""
+"""Cursor pseudo-encoding. rfbproto."""
 from __future__ import annotations
 
 from typing import ClassVar, Iterator

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -70,10 +70,7 @@ class RFBClient(Protocol):
     }
     _UNMIGRATED_ENCODINGS = {
         Encoding.ZRLE,
-        Encoding.PSEUDO_CURSOR,
-        Encoding.PSEUDO_DESKTOP_SIZE,
         Encoding.PSEUDO_LAST_RECT,
-        Encoding.PSEUDO_QEMU_EXTENDED_KEY_EVENT,
     }
     SUPPORTED_ENCODINGS = set(decoders.DECODERS) | _UNMIGRATED_ENCODINGS
 
@@ -353,22 +350,10 @@ class RFBClient(Protocol):
 
         if self.rectangles:
             self.rectangles -= 1
-            self.rectanglePos.append((x, y, width, height))
             entry = self._decoders.get(encoding)
             if entry is not None:
                 decoder, pump = entry
                 pump(decoder, x, y, width, height)
-            elif encoding == Encoding.PSEUDO_CURSOR:
-                length = width * height * self.bypp
-                length += ((width + 7) // 8) * height
-                self.expect(self._handleDecodePsuedoCursor, length, x, y, width, height)
-            elif encoding == Encoding.PSEUDO_DESKTOP_SIZE:
-                del self.rectanglePos[-1]  # undo append as this carries no pixel data
-                self._handleDecodeDesktopSize(width, height)
-            elif encoding == Encoding.PSEUDO_QEMU_EXTENDED_KEY_EVENT:
-                self.negotiated_encodings.add(Encoding.PSEUDO_QEMU_EXTENDED_KEY_EVENT)
-                del self.rectanglePos[-1]  # undo append as this is no real update
-                self._doConnection()
             else:
                 self.vncProtocolError(
                     f"unknown encoding received {Encoding.lookup(encoding)!r}"
@@ -382,6 +367,8 @@ class RFBClient(Protocol):
             if not decoder.buffered:
                 return self._pumpRectangle
             return self._pumpBufferedRectangle
+        if isinstance(decoder, decoders.ControlDecoder):
+            return self._pumpForControl
         return self._pumpForClient
 
     def _pumpRectangle(
@@ -399,19 +386,30 @@ class RFBClient(Protocol):
         target = self._allocateBuffer(width, height)
         if target is None:
             return
-        self._pumpBlock(
-            None,
-            decoder.decodePixels(target, self.pixel_format),
-            (decoder, target, (x, y, width, height)),
-        )
+        rect = (x, y, width, height)
+
+        def on_done() -> None:
+            output_format = decoder.output_format(self.pixel_format)
+            self._finishRectangle(target.tobytes(), output_format, rect)
+
+        self._pumpBlock(None, decoder.decodePixels(target, self.pixel_format), on_done)
 
     def _pumpForClient(
         self, decoder: decoders.ClientDecoder, x: int, y: int, width: int, height: int
     ) -> None:
         rect = (x, y, width, height)
-        self._pumpBlock(
-            None, decoder.decodeForClient(self, rect, self.pixel_format), None
-        )
+
+        def on_done() -> None:
+            self.rectanglePos.append(rect)
+            self._doConnection()
+
+        self._pumpBlock(None, decoder.decodeForClient(self, rect, self.pixel_format), on_done)
+
+    def _pumpForControl(
+        self, decoder: decoders.ControlDecoder, x: int, y: int, width: int, height: int
+    ) -> None:
+        rect = (x, y, width, height)
+        self._pumpBlock(None, decoder.decodeForClient(self, rect, self.pixel_format), None)
 
     def _finishRectangle(
         self,
@@ -419,6 +417,7 @@ class RFBClient(Protocol):
         output_format: PixelFormat,
         rect: tuple[int, int, int, int],
     ) -> None:
+        self.rectanglePos.append(rect)
         x, y, width, height = rect
         self.updateRectangle(x, y, width, height, block, output_format)
         self._doConnection()
@@ -452,19 +451,15 @@ class RFBClient(Protocol):
         self,
         block: bytes | None,
         generator: Iterator[int],
-        finish: tuple[
-            decoders.PixelDecoder, decoders.RectBuffer, tuple[int, int, int, int]
-        ] | None,
+        on_done: Callable[[], None] | None,
     ) -> None:
         try:
             size = generator.send(block)
         except StopIteration:
-            if finish is None:
+            if on_done is None:
                 self._doConnection()
             else:
-                decoder, target, rect = finish
-                output_format = decoder.output_format(self.pixel_format)
-                self._finishRectangle(target.tobytes(), output_format, rect)
+                on_done()
             return
         except (decoders.DecodeError, StructError, MemoryError, zlib.error) as exc:
             generator.close()
@@ -475,22 +470,7 @@ class RFBClient(Protocol):
             generator.close()
             self.abortConnection(f"decoder asked for {size} bytes")
             return
-        self.expect(self._pumpBlock, size, generator, finish)
-
-    # --- Pseudo Cursor Encoding
-    def _handleDecodePsuedoCursor(
-        self, block: bytes, x: int, y: int, width: int, height: int
-    ) -> None:
-        split = width * height * self.bypp
-        image = block[:split]
-        mask = block[split:]
-        self.updateCursor(x, y, width, height, image, mask)
-        self._doConnection()
-
-    # --- Pseudo Desktop Size Encoding
-    def _handleDecodeDesktopSize(self, width: int, height: int) -> None:
-        self.updateDesktopSize(width, height)
-        self._doConnection()
+        self.expect(self._pumpBlock, size, generator, on_done)
 
     # ---  other server messages
 


### PR DESCRIPTION
Adds a third decoder base class, `ControlDecoder`, for pseudo-encodings that call a client method as a side effect but carry no framebuffer content (DesktopSize, QEMU extended key). Cursor stays a `ClientDecoder` since it does produce content, same as CopyRect.

Also moves `rectanglePos` bookkeeping from append-before-dispatch (with DesktopSize/QEMU undoing it after) to append-on-success, in each pump path. Fixes a latent bug where a rect that failed validation or errored mid-decode still left a phantom `rectanglePos` entry.

LastRect stays inline in `rfb.py` -- it mutates the rectangle loop counter itself rather than calling a client method, which doesn't fit either base class. Deferred to a follow-up PR.

No user-visible behavior change (R5 in `specs/decoder-architecture.md`): these pseudo-encodings already worked via the old inline handling.

**Tested:** `make test` (318 unit tests) and `flake8` clean.