### PR TITLE
Fix stale width/height after mid-session desktop resize

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 2.0.0.dev0 (UNRELEASED)
 ----------------------
+  - Fix ``self.width``/``self.height`` staying at the negotiated size after a server sends ``PSEUDO_DESKTOP_SIZE`` mid-session (@sibson)
   - Fix ``VNCLoggingServerProxy.connectionLost`` rejecting the no-argument call ``Protocol.connectionLost`` promises callers (@sibson)
   - Dependency resolution ignores releases younger than a week, so a compromised upload has to survive public scrutiny before it can reach a build here (@sibson)
   - CI installs from the committed ``uv.lock`` and fails if it is stale, rather than silently resolving something else; ``uv.lock`` is no longer listed in ``.gitignore``, where it had no effect anyway (@sibson)

--- a/tests/functional/test_desktop_resize.py
+++ b/tests/functional/test_desktop_resize.py
@@ -3,12 +3,9 @@ scene-catalogue testing cannot reach, since the scene player has no way to
 make a server change geometry (see "Deferred" in decoder-goldens.md and
 "Testing" in decoder-architecture.md).
 
-libvncserver-example is the one fleet server that can: its ``dokey()``
-(examples/example.c, LibVNCServer 0.9.14, matching this repo's pinned
-``LIBVNCSERVER_VERSION``) handles ``XK_Up``/``XK_Down`` by calling
-``rfbNewFramebuffer()``, cycling 640x480 -> 800x600 -> 1024x768 and back.
-There is no signal, stdin, or xrandr path -- only those two keysyms, which
-``vncdotool.keys.KEYMAP`` maps "up"/"down" onto exactly.
+libvncserver-example resizes only in response to ``XK_Up``/``XK_Down``
+(examples/example.c, LibVNCServer 0.9.14); no signal, stdin, or xrandr path
+exists.
 
 The cycle position is a static variable in the server process, not
 per-connection state, so a container a previous run already resized reports
@@ -19,7 +16,7 @@ from unittest import TestCase
 
 from PIL import Image
 
-from .utils import HOST, LIBVNCSERVER_EXAMPLE, port_open, run_vncdo, screenshot_dir
+from .utils import HOST, LIBVNCSERVER_EXAMPLE, distinct_colours, has_expected_content, port_open, run_vncdo, screenshot_dir
 
 FLOOR_SIZE = (640, 480)
 RESIZED_SIZE = (800, 600)
@@ -62,9 +59,21 @@ class TestDesktopResize(TestCase):
                 image.size, FLOOR_SIZE,
                 f"{LIBVNCSERVER_EXAMPLE.name}: two Downs did not floor the framebuffer at {FLOOR_SIZE}",
             )
+            colours = distinct_colours(image)
+
+        self.assertTrue(
+            has_expected_content(LIBVNCSERVER_EXAMPLE, colours),
+            f"{LIBVNCSERVER_EXAMPLE.name}: floor capture is a single flat colour, no screen content was decoded",
+        )
 
         with Image.open(resized_png) as image:
             self.assertEqual(
                 image.size, RESIZED_SIZE,
                 f"{LIBVNCSERVER_EXAMPLE.name}: one Up from the floor did not grow the framebuffer to {RESIZED_SIZE}",
             )
+            colours = distinct_colours(image)
+
+        self.assertTrue(
+            has_expected_content(LIBVNCSERVER_EXAMPLE, colours),
+            f"{LIBVNCSERVER_EXAMPLE.name}: resized capture is a single flat colour, no screen content was decoded",
+        )

--- a/tests/functional/test_desktop_resize.py
+++ b/tests/functional/test_desktop_resize.py
@@ -1,17 +1,3 @@
-"""Mid-session desktop resize: the case specs/decoder-architecture.md's
-scene-catalogue testing cannot reach, since the scene player has no way to
-make a server change geometry (see "Deferred" in decoder-goldens.md and
-"Testing" in decoder-architecture.md).
-
-libvncserver-example resizes only in response to ``XK_Up``/``XK_Down``
-(examples/example.c, LibVNCServer 0.9.14); no signal, stdin, or xrandr path
-exists.
-
-The cycle position is a static variable in the server process, not
-per-connection state, so a container a previous run already resized reports
-its current size at the next connection's ServerInit.
-"""
-
 from unittest import TestCase
 
 from PIL import Image

--- a/tests/functional/test_desktop_resize.py
+++ b/tests/functional/test_desktop_resize.py
@@ -12,10 +12,7 @@ There is no signal, stdin, or xrandr path -- only those two keysyms, which
 
 The cycle position is a static variable in the server process, not
 per-connection state, so a container a previous run already resized reports
-its current size at the next connection's ServerInit. Two Downs floor it at
-640x480 regardless of where it started (at most two steps between any of
-the three sizes), making the floor -- and everything that follows it --
-independent of connection order.
+its current size at the next connection's ServerInit.
 """
 
 from unittest import TestCase
@@ -38,10 +35,9 @@ class TestDesktopResize(TestCase):
             )
 
     def test_mid_session_resize_is_decoded(self) -> None:
-        """Floor the server's geometry, capture it, grow it one step, capture
-        again: each capture's size is the server's actual PSEUDO_DESKTOP_SIZE
-        rectangle decoded and applied to the client's framebuffer, not the
-        size ServerInit negotiated at connect time.
+        """Each capture's size reflects the server's actual PSEUDO_DESKTOP_SIZE
+        rectangle decoded onto the client's framebuffer, not the size
+        ServerInit negotiated at connect time.
         """
         floor_png = screenshot_dir() / f"{LIBVNCSERVER_EXAMPLE.name}-resize-floor.png"
         resized_png = screenshot_dir() / f"{LIBVNCSERVER_EXAMPLE.name}-resize-grown.png"

--- a/tests/functional/test_desktop_resize.py
+++ b/tests/functional/test_desktop_resize.py
@@ -1,0 +1,74 @@
+"""Mid-session desktop resize: the case specs/decoder-architecture.md's
+scene-catalogue testing cannot reach, since the scene player has no way to
+make a server change geometry (see "Deferred" in decoder-goldens.md and
+"Testing" in decoder-architecture.md).
+
+libvncserver-example is the one fleet server that can: its ``dokey()``
+(examples/example.c, LibVNCServer 0.9.14, matching this repo's pinned
+``LIBVNCSERVER_VERSION``) handles ``XK_Up``/``XK_Down`` by calling
+``rfbNewFramebuffer()``, cycling 640x480 -> 800x600 -> 1024x768 and back.
+There is no signal, stdin, or xrandr path -- only those two keysyms, which
+``vncdotool.keys.KEYMAP`` maps "up"/"down" onto exactly.
+
+The cycle position is a static variable in the server process, not
+per-connection state, so a container a previous run already resized reports
+its current size at the next connection's ServerInit. Two Downs floor it at
+640x480 regardless of where it started (at most two steps between any of
+the three sizes), making the floor -- and everything that follows it --
+independent of connection order.
+"""
+
+from unittest import TestCase
+
+from PIL import Image
+
+from .utils import HOST, LIBVNCSERVER_EXAMPLE, port_open, run_vncdo, screenshot_dir
+
+FLOOR_SIZE = (640, 480)
+RESIZED_SIZE = (800, 600)
+
+
+class TestDesktopResize(TestCase):
+
+    def setUp(self) -> None:
+        if not port_open(HOST, LIBVNCSERVER_EXAMPLE.port):
+            self.fail(
+                f"{LIBVNCSERVER_EXAMPLE.name} not reachable on {HOST}:{LIBVNCSERVER_EXAMPLE.port} -- "
+                f"{LIBVNCSERVER_EXAMPLE.how_to_start}"
+            )
+
+    def test_mid_session_resize_is_decoded(self) -> None:
+        """Floor the server's geometry, capture it, grow it one step, capture
+        again: each capture's size is the server's actual PSEUDO_DESKTOP_SIZE
+        rectangle decoded and applied to the client's framebuffer, not the
+        size ServerInit negotiated at connect time.
+        """
+        floor_png = screenshot_dir() / f"{LIBVNCSERVER_EXAMPLE.name}-resize-floor.png"
+        resized_png = screenshot_dir() / f"{LIBVNCSERVER_EXAMPLE.name}-resize-grown.png"
+
+        result = run_vncdo(
+            LIBVNCSERVER_EXAMPLE,
+            "key", "down",
+            "key", "down",
+            "pause", "0.5",
+            "capture", str(floor_png),
+            "key", "up",
+            "pause", "0.5",
+            "capture", str(resized_png),
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            f"{LIBVNCSERVER_EXAMPLE.name}: vncdo exited {result.returncode}, stderr:\n{result.stderr}",
+        )
+
+        with Image.open(floor_png) as image:
+            self.assertEqual(
+                image.size, FLOOR_SIZE,
+                f"{LIBVNCSERVER_EXAMPLE.name}: two Downs did not floor the framebuffer at {FLOOR_SIZE}",
+            )
+
+        with Image.open(resized_png) as image:
+            self.assertEqual(
+                image.size, RESIZED_SIZE,
+                f"{LIBVNCSERVER_EXAMPLE.name}: one Up from the floor did not grow the framebuffer to {RESIZED_SIZE}",
+            )

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -278,6 +278,15 @@ class TestVNCDoToolClient(TestCase):
         self.assertEqual(fired, [cli])
         assert cli.screen is not None
         self.assertEqual(cli.screen.size, (1920, 1200))
+        self.assertEqual((cli.width, cli.height), (1920, 1200))
+
+    def test_updateDesktopSize_updates_width_and_height(self) -> None:
+        cli = self.client
+        cli.width, cli.height = 100, 200
+
+        cli.updateDesktopSize(300, 400)
+
+        self.assertEqual((cli.width, cli.height), (300, 400))
 
     def test_vncRequestPassword_attribute(self):
         cli = self.client

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -467,6 +467,7 @@ class VNCDoToolClient(rfb.RFBClient):
         if self.screen:
             new_screen.paste(self.screen, (0, 0))
         self.screen = new_screen
+        self.width, self.height = width, height
 
 
 class VMWareClient(VNCDoToolClient):


### PR DESCRIPTION
Fixes `VNCDoToolClient.updateDesktopSize` never updating `self.width`/`self.height` after a mid-session `PSEUDO_DESKTOP_SIZE` resize, even though `self.screen` resized correctly. Also adds a live functional test against `libvncserver-example` -- the one fleet server that can trigger a real resize -- proving the client decodes it correctly; see the commits for why it's the only one that can.

Tests: `make test` (317 passing), `flake8` clean, and the new functional test run live against the fleet, including a check that the existing smoke suite's size assertion for the same server still passes afterward.