### PR TITLE
docs: describe --localcursor/--nocursor behavior, not rationale

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,11 +37,14 @@ make screen captures of the session::
 
     > vncdo capture screenshot.png
 
-Some servers don't draw the mouse pointer into the framebuffer themselves, so
-it's absent from captures by default. ``--localcursor`` asks the server for
-the cursor shape and draws it in; ``--nocursor`` is the opposite, forcing the
-pointer out of captures even if the server would have included it. This is
-mostly only useful when the server does not include the cursor itself::
+Per RFC 6143, the cursor pseudo-encoding exists so a client can draw the
+pointer locally instead of waiting on the server, cutting perceived lag for
+someone driving the session live. vncdo drives sessions with scripted
+commands rather than a live display, so that responsiveness rarely matters
+here. ``--localcursor`` is mostly only useful if a particular server does not
+otherwise draw the pointer into the framebuffer and you want it present in a
+capture; ``--nocursor`` does the opposite, forcing the pointer out of
+captures::
 
     > vncdo --localcursor capture screenshot.png
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,6 +37,14 @@ make screen captures of the session::
 
     > vncdo capture screenshot.png
 
+Some servers don't draw the mouse pointer into the framebuffer themselves, so
+it's absent from captures by default. ``--localcursor`` asks the server for
+the cursor shape and draws it in; ``--nocursor`` is the opposite, forcing the
+pointer out of captures even if the server would have included it. This is
+mostly only useful when the server does not include the cursor itself::
+
+    > vncdo --localcursor capture screenshot.png
+
 With Pillow_ installed, you can wait for the screen to match a known image::
 
     > vncdo expect somescreen.png 0

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -568,12 +568,12 @@ def vncdo(argv: list[str] | None = None) -> None:
     op.add_option(
         "--localcursor",
         action="store_true",
-        help="mouse pointer drawn client-side, useful when server does not include cursor",
+        help="request the cursor shape from the server and draw it into captures",
     )
     op.add_option(
         "--nocursor",
         action="store_true",
-        help="no mouse pointer in screen captures",
+        help="omit the mouse pointer from captures",
     )
     op.add_option(
         "--disable-desktop-resizing",


### PR DESCRIPTION
## Summary
- `--help` for `--localcursor`/`--nocursor` stated a use case rather than behavior; now describes what each flag does.
- Added a paragraph to `docs/usage.rst` covering when they're useful, hedged since other use cases aren't known.

## Test plan
- `flake8 --count --statistics vncdotool tests`: 0
- `python -m unittest discover tests/unit`: 318 passed