### PR TITLE
Give ControlDecoder its own non-generator method

### DIFF
--- a/tests/unit/test_pump.py
+++ b/tests/unit/test_pump.py
@@ -82,7 +82,7 @@ class TestDecodeErrorHandling(TestCase):
             raise decoders.DecodeError("bogus subencoding")
             yield  # pragma: no cover - never reached
 
-        cli._pumpBlock(None, failing(), None)
+        cli._pumpGenerator(None, failing(), None)
 
         cli.vncProtocolError.assert_called_once()
         self.assertIn("bogus subencoding", cli.vncProtocolError.call_args.args[0])

--- a/vncdotool/decoders/base.py
+++ b/vncdotool/decoders/base.py
@@ -50,9 +50,10 @@ class ClientDecoder(RectDecoder):
 
 class ControlDecoder(Decoder):
     """Calls a client method as a side effect; its rectangle is never
-    recorded as a screen change. Consumes no bytes, so unlike the other two
-    this is a plain call, not a generator.
-    """
+    recorded as a screen change."""
 
     def decodeForControl(self, client: object, width: int, height: int) -> None:
+        """Unlike decodePixels/decodeForClient, not a generator: this
+        consumes no bytes, so there is nothing to yield for.
+        """
         raise NotImplementedError

--- a/vncdotool/decoders/base.py
+++ b/vncdotool/decoders/base.py
@@ -50,4 +50,9 @@ class ClientDecoder(RectDecoder):
 
 class ControlDecoder(Decoder):
     """Calls a client method as a side effect; its rectangle is never
-    recorded as a screen change."""
+    recorded as a screen change. Consumes no bytes, so unlike the other two
+    this is a plain call, not a generator.
+    """
+
+    def decodeForControl(self, client: object, width: int, height: int) -> None:
+        raise NotImplementedError

--- a/vncdotool/decoders/control.py
+++ b/vncdotool/decoders/control.py
@@ -1,31 +1,21 @@
 """DesktopSize and QEMU extended key pseudo-encodings. rfbproto."""
 from __future__ import annotations
 
-from typing import ClassVar, Iterator
+from typing import ClassVar
 
 from ..const import Encoding
-from ..pixelformat import PixelFormat
 from .base import ControlDecoder
 
 
 class DesktopSizeDecoder(ControlDecoder):
     ENCODING: ClassVar[Encoding] = Encoding.PSEUDO_DESKTOP_SIZE
 
-    def decodeForClient(
-        self, client: object, rect: tuple[int, int, int, int], pixel_format: PixelFormat
-    ) -> Iterator[int]:
-        _, _, width, height = rect
+    def decodeForControl(self, client: object, width: int, height: int) -> None:
         client.updateDesktopSize(width, height)
-        return
-        yield  # pragma: no cover -- never runs; keeps this a generator
 
 
 class QemuExtendedKeyDecoder(ControlDecoder):
     ENCODING: ClassVar[Encoding] = Encoding.PSEUDO_QEMU_EXTENDED_KEY_EVENT
 
-    def decodeForClient(
-        self, client: object, rect: tuple[int, int, int, int], pixel_format: PixelFormat
-    ) -> Iterator[int]:
+    def decodeForControl(self, client: object, width: int, height: int) -> None:
         client.negotiated_encodings.add(Encoding.PSEUDO_QEMU_EXTENDED_KEY_EVENT)
-        return
-        yield  # pragma: no cover -- never runs; keeps this a generator

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -408,8 +408,8 @@ class RFBClient(Protocol):
     def _pumpForControl(
         self, decoder: decoders.ControlDecoder, x: int, y: int, width: int, height: int
     ) -> None:
-        rect = (x, y, width, height)
-        self._pumpBlock(None, decoder.decodeForClient(self, rect, self.pixel_format), None)
+        decoder.decodeForControl(self, width, height)
+        self._doConnection()
 
     def _finishRectangle(
         self,

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -363,6 +363,11 @@ class RFBClient(Protocol):
             self._doConnection()
 
     def _pumpFor(self, decoder: decoders.Decoder) -> Callable[..., None]:
+        # Called once per decoder in __init__, not per rectangle: the
+        # isinstance cost is paid here so the per-rectangle dispatch in
+        # _handleRectangle is a plain dict lookup and a bound-method call.
+        # See specs/decoder-architecture.md, "Which pump path a decoder
+        # takes is resolved once per connection".
         if isinstance(decoder, decoders.PixelDecoder):
             if not decoder.buffered:
                 return self._pumpRectangle

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -388,22 +388,22 @@ class RFBClient(Protocol):
             return
         rect = (x, y, width, height)
 
-        def on_done() -> None:
+        def finish_buffered() -> None:
             output_format = decoder.output_format(self.pixel_format)
             self._finishRectangle(target.tobytes(), output_format, rect)
 
-        self._pumpBlock(None, decoder.decodePixels(target, self.pixel_format), on_done)
+        self._pumpGenerator(None, decoder.decodePixels(target, self.pixel_format), finish_buffered)
 
     def _pumpForClient(
         self, decoder: decoders.ClientDecoder, x: int, y: int, width: int, height: int
     ) -> None:
         rect = (x, y, width, height)
 
-        def on_done() -> None:
+        def finish_client() -> None:
             self.rectanglePos.append(rect)
             self._doConnection()
 
-        self._pumpBlock(None, decoder.decodeForClient(self, rect, self.pixel_format), on_done)
+        self._pumpGenerator(None, decoder.decodeForClient(self, rect, self.pixel_format), finish_client)
 
     def _pumpForControl(
         self, decoder: decoders.ControlDecoder, x: int, y: int, width: int, height: int
@@ -447,7 +447,7 @@ class RFBClient(Protocol):
             self.abortConnection(f"no memory for a {width}x{height} rectangle")
             return None
 
-    def _pumpBlock(
+    def _pumpGenerator(
         self,
         block: bytes | None,
         generator: Iterator[int],
@@ -470,7 +470,7 @@ class RFBClient(Protocol):
             generator.close()
             self.abortConnection(f"decoder asked for {size} bytes")
             return
-        self.expect(self._pumpBlock, size, generator, on_done)
+        self.expect(self._pumpGenerator, size, generator, on_done)
 
     # ---  other server messages
 

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -363,11 +363,8 @@ class RFBClient(Protocol):
             self._doConnection()
 
     def _pumpFor(self, decoder: decoders.Decoder) -> Callable[..., None]:
-        # Called once per decoder in __init__, not per rectangle: the
-        # isinstance cost is paid here so the per-rectangle dispatch in
-        # _handleRectangle is a plain dict lookup and a bound-method call.
-        # See specs/decoder-architecture.md, "Which pump path a decoder
-        # takes is resolved once per connection".
+        # Called once per decoder at connect time, not per rectangle -- see
+        # specs/decoder-architecture.md.
         if isinstance(decoder, decoders.PixelDecoder):
             if not decoder.buffered:
                 return self._pumpRectangle

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -363,8 +363,6 @@ class RFBClient(Protocol):
             self._doConnection()
 
     def _pumpFor(self, decoder: decoders.Decoder) -> Callable[..., None]:
-        # Called once per decoder at connect time, not per rectangle -- see
-        # specs/decoder-architecture.md.
         if isinstance(decoder, decoders.PixelDecoder):
             if not decoder.buffered:
                 return self._pumpRectangle


### PR DESCRIPTION
Follow-up to #440's review comments (crossed with an accidental merge).

**ControlDecoder signature:** `decodeForClient` had the identical signature to `ClientDecoder.decodeForClient` -- nothing distinguished them at the method level, only which base class you'd inherited from. It also needed a `return`/`yield` trick just to satisfy the generator contract despite never yielding. Gives it its own `decodeForControl(client, width, height) -> None`: no `rect`, no `pixel_format`, no generator. `_pumpForControl` drops the generator machinery entirely.

**Pump naming:** `_pumpBlock` renamed to `_pumpGenerator` -- it doesn't decode anything, it drives whichever generator it's handed until StopIteration. Its two completion closures were both named `on_done`; renamed to `finish_buffered`/`finish_client`. Kept as closures -- matches the codebase's existing pattern for deferred completions (api.py's `on_disconnected`/`disconnector`/`result_callback`).

Addresses all 6 unresolved threads on #440.

**Tested:** 318 unit tests, flake8 clean.