### PR TITLE
Fix RFBFactory raising AttributeError on ARD authentication

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 2.0.0.dev0 (UNRELEASED)
 ----------------------
+  - Fix ``RFBFactory`` raising ``AttributeError`` on ARD authentication when used directly, instead of through ``VNCDoToolFactory`` (@sibson)
   - Add ``vncdo stable SECONDS [FUZZ]`` and ``rstable SECONDS X Y W H [FUZZ]``, waiting until the screen stops changing rather than until it matches a reference image (@sibson)
   - Fix ``rexpect`` polling until ``--timeout`` and ``rcapture`` writing black pixels when the region runs off the screen, and ``expect`` doing the same against a target image larger than the screen. All three now fail with a message naming the region and the screen size, exiting 30 (@sibson)
   - [BREAKING] ``expect`` and ``rexpect`` decide a match pixel by pixel, as a perceived colour difference, rather than by the root-mean-square difference of the two histograms. The number in ``expect FILE N`` is now that per-pixel bound, 0 (exact) to 255, on a scale unrelated to the old one; ``expectScreen`` and ``expectRegion`` take ``fuzz`` and ``blur`` in place of ``maxrms`` (@sibson)

--- a/tests/unit/test_rfb.py
+++ b/tests/unit/test_rfb.py
@@ -187,6 +187,18 @@ class TestRFB(TestCase):
             mock.call(b"\x00"),  # shared
         ])
 
+    def test_ardRequestCredentials_prompts_when_factory_has_no_username(self):
+        self.client.factory = rfb.RFBFactory()
+        with (
+            mock.patch("builtins.input", return_value="alice") as input_,
+            mock.patch("getpass.getpass", return_value="secret") as getpass_,
+        ):
+            self.client.ardRequestCredentials()
+        input_.assert_called_once()
+        getpass_.assert_called_once()
+        assert self.client.factory.username == "alice"
+        assert self.client.factory.password == "secret"
+
 
 class TestRFBClientSubclassWarning(TestCase):
 

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -667,6 +667,8 @@ class RFBFactory(protocol.ClientFactory):
     # should be overriden by application to use a derrived class
     protocol = RFBClient
 
+    username: str | None = None
+
     def __init__(self, password: str | None = None, shared: bool = False) -> None:
         self.password = password
         self.shared = shared


### PR DESCRIPTION
## Summary
RFBClient's ARD auth path reads and lazily fills `self.factory.username`, but only `VNCDoToolFactory` declared that attribute — `RFBFactory` itself, the base class applications are told to subclass directly, never did. A bare `RFBClient`/`RFBFactory` pair crashed with `AttributeError` before the username was ever read.

Recovered from an unpushed local commit found while cleaning up stray branch history; verified the bug is still live on current `main` before reapplying.

## Test plan
- `make test` — 319 passed
- `flake8 --count --statistics vncdotool tests` — clean