### PR TITLE
Add Fence extension support for TigerVNC shared sessions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 2.0.0.dev0 (UNRELEASED)
 ----------------------
+  - Add Fence extension support (``PSEUDO_FENCE``): the client offers it and auto-responds to a server's synchronisation request, which shared TigerVNC sessions require (@sibson, #323)
   - Fix ``self.width``/``self.height`` staying at the negotiated size after a server sends ``PSEUDO_DESKTOP_SIZE`` mid-session (@sibson)
   - Fix ``VNCLoggingServerProxy.connectionLost`` rejecting the no-argument call ``Protocol.connectionLost`` promises callers (@sibson)
   - Dependency resolution ignores releases younger than a week, so a compromised upload has to survive public scrutiny before it can reach a build here (@sibson)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 2.0.0.dev0 (UNRELEASED)
 ----------------------
-  - Add Fence extension support (``PSEUDO_FENCE``): the client offers it and auto-responds to a server's synchronisation request, which shared TigerVNC sessions require (@sibson, #323)
+  - Add Fence extension support (``PSEUDO_FENCE``): the client offers it and auto-responds to a server's synchronisation request, which shared TigerVNC sessions require (@sibson, based on @TeofilisMartisius's #323)
   - Fix ``self.width``/``self.height`` staying at the negotiated size after a server sends ``PSEUDO_DESKTOP_SIZE`` mid-session (@sibson)
   - Fix ``VNCLoggingServerProxy.connectionLost`` rejecting the no-argument call ``Protocol.connectionLost`` promises callers (@sibson)
   - Dependency resolution ignores releases younger than a week, so a compromised upload has to survive public scrutiny before it can reach a build here (@sibson)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 2.0.0.dev0 (UNRELEASED)
 ----------------------
-  - Add Fence extension support (``PSEUDO_FENCE``): the client offers it and auto-responds to a server's synchronisation request, which shared TigerVNC sessions require (@sibson, based on @TeofilisMartisius's #323)
+  - Add Fence extension support (``PSEUDO_FENCE``): the client offers it and auto-responds to a server's synchronisation request, which shared TigerVNC sessions require; ``vnclog``'s proxy understands the message too, so a proxied session keeps recording correctly (@sibson, based on @TeofilisMartisius's #323)
   - Fix ``self.width``/``self.height`` staying at the negotiated size after a server sends ``PSEUDO_DESKTOP_SIZE`` mid-session (@sibson)
   - Fix ``VNCLoggingServerProxy.connectionLost`` rejecting the no-argument call ``Protocol.connectionLost`` promises callers (@sibson)
   - Dependency resolution ignores releases younger than a week, so a compromised upload has to survive public scrutiny before it can reach a build here (@sibson)

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -24,7 +24,7 @@ from vncdotool.capture import (
     HandshakeScrubber,
     check_capture_target,
 )
-from vncdotool.const import AuthTypes, Encoding
+from vncdotool.const import AuthTypes, Encoding, FenceFlags, MsgC2S
 from vncdotool.loggingproxy import (
     RFBServer,
     VNCLoggingClientProxy,
@@ -569,6 +569,26 @@ class TestRFBServer(TestCase):
 
         server.transport.setTcpNoDelay.assert_called_once_with(True)
 
+    def test_client_fence_is_parsed_without_desyncing_the_next_message(self) -> None:
+        """A ptype absent from TYPE_LEN reads a zero-length header and never
+        advances the buffer, desyncing every message after it (see
+        CLIENT_CUT_TEXT). CLIENT_FENCE carries a variable payload the same
+        way, so it must consume exactly what it declares.
+        """
+        server = RFBServer()
+        server.transport = mock.Mock()
+        server.buffer = bytearray()
+        server._handler = (server._handle_protocol, 1)
+        server.handle_clientFence = mock.Mock()  # type: ignore[method-assign]
+        server.handle_keyEvent = mock.Mock()  # type: ignore[method-assign]
+
+        fence = pack("!BxxxIB", MsgC2S.CLIENT_FENCE, int(FenceFlags.REQUEST), 3) + b"abc"
+        key_event = pack("!BBxxI", MsgC2S.KEY_EVENT, 1, ord("a"))
+        server.dataReceived(fence + key_event)
+
+        server.handle_clientFence.assert_called_once_with(FenceFlags.REQUEST, b"abc")
+        server.handle_keyEvent.assert_called_once_with(ord("a"), 1)
+
 
 class TestProxyCaptureWiring(TestCase):
     """Drive both proxy halves directly, with mocked transports standing in
@@ -700,6 +720,20 @@ class TestProxyCaptureWiring(TestCase):
             capture.encodings_seen,
             {int(Encoding.ZRLE): 2, int(Encoding.HEXTILE): 1},
         )
+
+    def test_shadow_client_vncConnectionMade_survives_a_real_factory(self) -> None:
+        """VNCDoToolClient.vncConnectionMade reads factory.fence; the shadow
+        client's factory is VNCLoggingServerFactory, which must carry every
+        flag VNCDoToolFactory does or this raises AttributeError -- silently,
+        since startLogging's caller only logs it as a parse failure.
+        """
+        from vncdotool.loggingproxy import VNCLoggingClient
+
+        vnclog = VNCLoggingClient()
+        vnclog.transport = mock.Mock()
+        vnclog.factory = VNCLoggingServerFactory("localhost", 5900)
+
+        vnclog.vncConnectionMade()
 
     def test_forwarding_failures_are_not_swallowed(self) -> None:
         """Only the observers are wrapped.

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -44,6 +44,7 @@ class TestVNCDoToolClient(TestCase):
             client.rfb.Encoding.PSEUDO_DESKTOP_SIZE,
             client.rfb.Encoding.PSEUDO_LAST_RECT,
             client.rfb.Encoding.PSEUDO_QEMU_EXTENDED_KEY_EVENT,
+            client.rfb.Encoding.PSEUDO_FENCE,
         ])
 
     def test_keyPress_single_alpha(self):

--- a/tests/unit/test_rfb.py
+++ b/tests/unit/test_rfb.py
@@ -91,6 +91,60 @@ class TestRFB(TestCase):
             mock.call(b"\x00"),  # shared
         ])
 
+    def test_server_fence_dispatches_from_handleConnection(self):
+        self.client._handleConnection(b"\xf8")  # SERVER_FENCE
+        assert self.client._expected_handler == self.client._handleServerFence
+        assert self.client._expected_len == 8
+
+    def test_server_fence_request_gets_a_response_with_request_cleared(self):
+        self.client._handleServerFence(
+            b"\x00\x00\x00"  # padding
+            b"\x80\x00\x00\x03"  # flags: REQUEST | BLOCK_AFTER | BLOCK_BEFORE
+            b"\x00"  # payload length
+        )
+        self.client.transport.write.assert_called_once_with(
+            b"\xf8\x00\x00\x00"  # CLIENT_FENCE, padding
+            b"\x00\x00\x00\x03"  # flags: BLOCK_AFTER | BLOCK_BEFORE, REQUEST cleared
+            b"\x00"  # payload length
+        )
+
+    def test_server_fence_request_clears_bits_the_client_does_not_understand(self):
+        self.client._handleServerFence(
+            b"\x00\x00\x00"  # padding
+            b"\x80\x00\x00\x08"  # flags: REQUEST | an unknown bit
+            b"\x00"  # payload length
+        )
+        self.client.transport.write.assert_called_once_with(
+            b"\xf8\x00\x00\x00"
+            b"\x00\x00\x00\x00"  # the unknown bit is cleared in the response
+            b"\x00"
+        )
+
+    def test_server_fence_response_is_not_echoed_back(self):
+        self.client._handleServerFence(
+            b"\x00\x00\x00"  # padding
+            b"\x00\x00\x00\x03"  # flags: BLOCK_AFTER | BLOCK_BEFORE, no REQUEST
+            b"\x00"  # payload length
+        )
+        self.client.transport.write.assert_not_called()
+
+    def test_server_fence_payload_is_echoed_back_with_the_response(self):
+        self.client._handleServerFence(
+            b"\x00\x00\x00"
+            b"\x80\x00\x00\x00"  # REQUEST
+            b"\x04"  # payload length
+        )
+        self.client._handleServerFencePayload(b"ping", 0x80000000)
+        self.client.transport.write.assert_called_once_with(
+            b"\xf8\x00\x00\x00\x00\x00\x00\x00\x04ping"
+        )
+
+    def test_clientFence(self):
+        self.client.clientFence(rfb.FenceFlags.SYNC_NEXT, b"abc")
+        self.client.transport.write.assert_called_once_with(
+            b"\xf8\x00\x00\x00\x00\x00\x00\x04\x03abc"
+        )
+
     def test_auth_none38(self):
         self.client._packet += (
             b"RFB 003.008\n"  # header

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -361,6 +361,8 @@ class VNCDoToolClient(rfb.RFBClient):
             encodings.append(rfb.Encoding.PSEUDO_LAST_RECT)
         if self.factory.qemu_extended_key:
             encodings.append(rfb.Encoding.PSEUDO_QEMU_EXTENDED_KEY_EVENT)
+        if self.factory.fence:
+            encodings.append(rfb.Encoding.PSEUDO_FENCE)
         self.setEncodings(encodings)
         self.factory.clientConnectionMade(self)
 
@@ -511,6 +513,7 @@ class VNCDoToolFactory(rfb.RFBFactory):
     pseudodesktop = True
     qemu_extended_key = True
     last_rect = True
+    fence = True
     force_caps = False
     pixel_format: rfb.PixelFormat | None = None
     encodings: list[rfb.Encoding] | None = None

--- a/vncdotool/const.py
+++ b/vncdotool/const.py
@@ -146,6 +146,15 @@ class HextileEncoding(IntFlag):
     SUBRECTS_COLORED = 16
 
 
+class FenceFlags(IntFlag):
+    """rfbproto: ClientFence/ServerFence flags."""
+
+    BLOCK_BEFORE = 1 << 0
+    BLOCK_AFTER = 1 << 1
+    SYNC_NEXT = 1 << 2
+    REQUEST = 1 << 31
+
+
 class AuthTypes(IntEnumLookup):
     """:rfc:`6143` §7.1.2. Security Handshake."""
 

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -38,6 +38,7 @@ TYPE_LEN = {
     MsgC2S.KEY_EVENT: 8,
     MsgC2S.POINTER_EVENT: 6,
     MsgC2S.QEMU_CLIENT_MESSAGE: 1,
+    MsgC2S.CLIENT_FENCE: 9,
 }
 
 REVERSE_MAP = {v: n for (n, v) in KEYMAP.items()}
@@ -135,6 +136,11 @@ class RFBServer(Protocol):
             self.handle_pointerEvent(x, y, buttonmask)
         elif ptype == MsgC2S.CLIENT_CUT_TEXT:
             self.handle_clientCutText(block)
+        elif ptype == MsgC2S.CLIENT_FENCE:
+            flags, length = unpack("!xxxIB", block)
+            payload = bytes(self.buffer[:length])
+            del self.buffer[:length]
+            self.handle_clientFence(flags, payload)
         elif ptype == MsgC2S.QEMU_CLIENT_MESSAGE:
             (subtype,) = unpack("!B", block)
             if subtype == QemuClientMessage.EXTENDED_KEY_EVENT:
@@ -170,6 +176,9 @@ class RFBServer(Protocol):
         pass
 
     def handle_clientCutText(self, block: bytes) -> None:
+        pass
+
+    def handle_clientFence(self, flags: int, payload: bytes) -> None:
         pass
 
     def handle_keyEventExtended(self, keysym: int, down: bool, keycode: int) -> None:
@@ -465,6 +474,7 @@ class VNCLoggingServerFactory(portforward.ProxyFactory):
     pseudodesktop = True
     qemu_extended_key = True
     last_rect = True
+    fence = False
     force_caps = False
 
     password_required = False

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -41,7 +41,7 @@ from twisted.python import log, usage
 from twisted.python.failure import Failure
 
 from . import decoders
-from .const import Encoding, AuthTypes, MsgC2S, MsgS2C
+from .const import Encoding, AuthTypes, FenceFlags, MsgC2S, MsgS2C
 from .keys import Key
 from .pixelformat import PixelFormat
 
@@ -326,6 +326,8 @@ class RFBClient(Protocol):
             self.expect(self._handleConnection, 1)
         elif msgid == MsgS2C.SERVER_CUT_TEXT:
             self.expect(self._handleServerCutText, 7)
+        elif msgid == MsgS2C.SERVER_FENCE:
+            self.expect(self._handleServerFence, 8)
         else:
             self.vncProtocolError(f"unknown message received {MsgS2C.lookup(msgid)!r}")
             self.transport.loseConnection()
@@ -495,6 +497,25 @@ class RFBClient(Protocol):
         self.copy_text(block.decode("iso-8859-1"))
         self.expect(self._handleConnection, 1)
 
+    def _handleServerFence(self, block: bytes) -> None:
+        # rfbproto ServerFence: 3 bytes padding, U32 flags, U8 payload-length.
+        flags, length = unpack("!xxxIB", block)
+        if length:
+            self.expect(self._handleServerFencePayload, length, flags)
+        else:
+            self._doServerFence(flags, b"")
+
+    def _handleServerFencePayload(self, block: bytes, flags: int) -> None:
+        self._doServerFence(flags, block)
+
+    def _doServerFence(self, flags: int, payload: bytes) -> None:
+        if flags & FenceFlags.REQUEST:
+            # rfbproto ServerFence: the response clears Request and any bits
+            # the client does not understand, keeping the rest set.
+            known = FenceFlags.BLOCK_BEFORE | FenceFlags.BLOCK_AFTER | FenceFlags.SYNC_NEXT
+            self.clientFence(FenceFlags(flags) & known, payload)
+        self.expect(self._handleConnection, 1)
+
     # ------------------------------------------------------
     # incomming data redirector
     # ------------------------------------------------------
@@ -589,6 +610,10 @@ class RFBClient(Protocol):
         """
         data = message.encode("iso-8859-1")
         self.transport.write(pack("!BxxxI", MsgC2S.CLIENT_CUT_TEXT, len(data)) + data)
+
+    def clientFence(self, flags: FenceFlags, payload: bytes = b"") -> None:
+        """Request, or respond to, a Fence synchronisation of the data stream."""
+        self.transport.write(pack("!BxxxIB", MsgC2S.CLIENT_FENCE, flags, len(payload)) + payload)
 
     # ------------------------------------------------------
     # callbacks

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -510,8 +510,9 @@ class RFBClient(Protocol):
 
     def _doServerFence(self, flags: int, payload: bytes) -> None:
         if flags & FenceFlags.REQUEST:
-            # rfbproto ServerFence: the response clears Request and any bits
-            # the client does not understand, keeping the rest set.
+            # rfbproto ServerFence: masking to the flags handled here, rather
+            # than just clearing Request, is what lets the server tell which
+            # flags this client supports as new ones are defined.
             known = FenceFlags.BLOCK_BEFORE | FenceFlags.BLOCK_AFTER | FenceFlags.SYNC_NEXT
             self.clientFence(FenceFlags(flags) & known, payload)
         self.expect(self._handleConnection, 1)


### PR DESCRIPTION
Implements the Fence extension (rfbproto ClientFence/ServerFence messages) to support shared TigerVNC sessions, which require synchronisation of the data stream.

The client now:
- Advertises `PSEUDO_FENCE` encoding during connection setup
- Handles incoming `SERVER_FENCE` messages by parsing flags and payload
- Auto-responds to server fence requests (when `REQUEST` flag is set), clearing unknown flags to signal capability
- Provides a `clientFence()` method for manual fence synchronisation

Changes:
- Added `FenceFlags` enum in `const.py` with `BLOCK_BEFORE`, `BLOCK_AFTER`, `SYNC_NEXT`, and `REQUEST` flags
- Implemented `_handleServerFence()`, `_handleServerFencePayload()`, and `_doServerFence()` in `rfb.py` to process incoming fences
- Added `clientFence()` method in `rfb.py` to send fence messages
- Updated `VNCDoToolFactory` to advertise fence support via `fence = True` flag
- Added comprehensive unit tests covering request/response handling, flag masking, and payload echoing

Tested against unit tests covering fence dispatch, request handling with flag clearing, response suppression when not requested, and payload echoing.

https://claude.ai/code/session_01CFzuVEnxzakbEYT9K9T1Sd