### PR TITLE
Stop parsing buffered bytes after an unrecognized rectangle encoding

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 2.0.0.dev0 (UNRELEASED)
 ----------------------
+  - Fix an unrecognized rectangle encoding parsing further buffered bytes as bogus rectangle headers before the connection closed, instead of stopping immediately (@sibson)
   - Fix ``self.width``/``self.height`` staying at the negotiated size after a server sends ``PSEUDO_DESKTOP_SIZE`` mid-session (@sibson)
   - Fix ``VNCLoggingServerProxy.connectionLost`` rejecting the no-argument call ``Protocol.connectionLost`` promises callers (@sibson)
   - Dependency resolution ignores releases younger than a week, so a compromised upload has to survive public scrutiny before it can reach a build here (@sibson)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 2.0.0.dev0 (UNRELEASED)
 ----------------------
-  - Fix an unrecognized rectangle encoding parsing further buffered bytes as bogus rectangle headers before the connection closed, instead of stopping immediately (@sibson)
+  - Fix a malformed or unsupported server response (bad header, unknown security/auth type, connection refused, unknown message, unrecognized rectangle encoding) parsing further buffered bytes as if they were valid protocol data before the connection closed, instead of stopping immediately (@sibson)
   - Fix ``self.width``/``self.height`` staying at the negotiated size after a server sends ``PSEUDO_DESKTOP_SIZE`` mid-session (@sibson)
   - Fix ``VNCLoggingServerProxy.connectionLost`` rejecting the no-argument call ``Protocol.connectionLost`` promises callers (@sibson)
   - Dependency resolution ignores releases younger than a week, so a compromised upload has to survive public scrutiny before it can reach a build here (@sibson)

--- a/tests/unit/test_rfb.py
+++ b/tests/unit/test_rfb.py
@@ -22,6 +22,7 @@ class TestRFB(TestCase):
         self.client._packet += b"X"
         self.client._handler()
         self.client.vncProtocolError.assert_called_once()
+        assert self.client._aborted
 
     def test_unknown_security_types_reports_protocol_error(self):
         self.client.vncProtocolError = mock.Mock()
@@ -32,6 +33,7 @@ class TestRFB(TestCase):
         )
         self.client._handler()
         self.client.vncProtocolError.assert_called_once()
+        assert self.client._aborted
 
     def test_unknown_auth_type_reports_protocol_error(self):
         self.client.vncProtocolError = mock.Mock()
@@ -41,11 +43,20 @@ class TestRFB(TestCase):
         )
         self.client._handler()
         self.client.vncProtocolError.assert_called_once()
+        assert self.client._aborted
 
     def test_unknown_message_reports_protocol_error(self):
         self.client.vncProtocolError = mock.Mock()
         self.client._handleConnection(b"\x7f")
         self.client.vncProtocolError.assert_called_once()
+        assert self.client._aborted
+
+    def test_connection_refused_reports_protocol_error(self):
+        self.client.vncProtocolError = mock.Mock()
+        self.client._handleConnMessage(b"nope")
+        self.client.vncProtocolError.assert_called_once()
+        self.client.transport.loseConnection.assert_called_once()
+        assert self.client._aborted
 
     def test_unknown_encoding_stops_processing_buffered_rectangles(self):
         self.client.vncProtocolError = mock.Mock()

--- a/tests/unit/test_rfb.py
+++ b/tests/unit/test_rfb.py
@@ -48,10 +48,6 @@ class TestRFB(TestCase):
         self.client.vncProtocolError.assert_called_once()
 
     def test_unknown_encoding_stops_processing_buffered_rectangles(self):
-        # A rectangle with an unrecognized encoding should abort the
-        # connection immediately, not keep parsing whatever bytes of an
-        # undecodable stream happen to already be buffered as if they were
-        # more 12-byte rectangle headers.
         self.client.vncProtocolError = mock.Mock()
         self.client._handler = self.client._handleExpected
         self.client.rectangles = 3

--- a/tests/unit/test_rfb.py
+++ b/tests/unit/test_rfb.py
@@ -1,4 +1,5 @@
 import warnings
+from struct import pack
 from unittest import TestCase, mock
 
 from vncdotool import rfb
@@ -45,6 +46,24 @@ class TestRFB(TestCase):
         self.client.vncProtocolError = mock.Mock()
         self.client._handleConnection(b"\x7f")
         self.client.vncProtocolError.assert_called_once()
+
+    def test_unknown_encoding_stops_processing_buffered_rectangles(self):
+        # A rectangle with an unrecognized encoding should abort the
+        # connection immediately, not keep parsing whatever bytes of an
+        # undecodable stream happen to already be buffered as if they were
+        # more 12-byte rectangle headers.
+        self.client.vncProtocolError = mock.Mock()
+        self.client._handler = self.client._handleExpected
+        self.client.rectangles = 3
+        self.client.expect(self.client._handleRectangle, 12)
+        unknown_encoding = 0x7F
+        header = pack("!HHHHi", 0, 0, 1, 1, unknown_encoding)
+        self.client._packet += header * 3
+        self.client._handler()
+        self.client.vncProtocolError.assert_called_once()
+        self.client.transport.loseConnection.assert_called_once()
+        assert self.client._aborted
+        assert not self.client._packet
 
     def test_auth_incmplete(self):
         self.client._packet += b"RFB 000.000"

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -355,10 +355,9 @@ class RFBClient(Protocol):
                 decoder, pump = entry
                 pump(decoder, x, y, width, height)
             else:
-                self.vncProtocolError(
+                self.abortConnection(
                     f"unknown encoding received {Encoding.lookup(encoding)!r}"
                 )
-                self.transport.loseConnection()
         else:
             self._doConnection()
 

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -152,8 +152,7 @@ class RFBClient(Protocol):
             else:
                 self.expect(self._handleNumberSecurityTypes, 1)
         elif not self._HEADER.startswith(norm):
-            self.vncProtocolError(f"invalid initial server response {head!r}")
-            self.transport.loseConnection()
+            self.abortConnection(f"invalid initial server response {head!r}")
 
     def _handleNumberSecurityTypes(self, block: bytes) -> None:
         (num_types,) = unpack("!B", block)
@@ -180,8 +179,7 @@ class RFBClient(Protocol):
             elif sec_type == AuthTypes.DIFFIE_HELLMAN:
                 self.expect(self._handleDHAuth, 4)
         else:
-            self.vncProtocolError(f"unknown security types: {types!r}")
-            self.transport.loseConnection()
+            self.abortConnection(f"unknown security types: {types!r}")
 
     def _handleAuth(self, block: bytes) -> None:
         (auth,) = unpack("!I", block)
@@ -193,16 +191,14 @@ class RFBClient(Protocol):
         elif auth == AuthTypes.VNC_AUTHENTICATION:
             self.expect(self._handleVNCAuth, 16)
         else:
-            self.vncProtocolError(f"unknown auth response {AuthTypes.lookup(auth)!r}")
-            self.transport.loseConnection()
+            self.abortConnection(f"unknown auth response {AuthTypes.lookup(auth)!r}")
 
     def _handleConnFailed(self, block: bytes) -> None:
         (waitfor,) = unpack("!I", block)
         self.expect(self._handleConnMessage, waitfor)
 
     def _handleConnMessage(self, block: bytes) -> None:
-        self.vncProtocolError(f"Connection refused: {block!r}")
-        self.transport.loseConnection()
+        self.abortConnection(f"Connection refused: {block!r}")
 
     def _handleVNCAuth(self, block: bytes) -> None:
         self._challenge = block
@@ -327,8 +323,7 @@ class RFBClient(Protocol):
         elif msgid == MsgS2C.SERVER_CUT_TEXT:
             self.expect(self._handleServerCutText, 7)
         else:
-            self.vncProtocolError(f"unknown message received {MsgS2C.lookup(msgid)!r}")
-            self.transport.loseConnection()
+            self.abortConnection(f"unknown message received {MsgS2C.lookup(msgid)!r}")
 
     def _handleFramebufferUpdate(self, block: bytes) -> None:
         (self.rectangles,) = unpack("!xH", block)


### PR DESCRIPTION
## Summary
- `_handleRectangle`'s unknown-encoding branch called `vncProtocolError()` + `transport.loseConnection()` directly instead of the existing `abortConnection()` helper, so the async `loseConnection()` didn't stop the dispatch loop from treating already-buffered undecodable bytes as more rectangle headers.
- Switched that branch to `abortConnection()`, which sets the `_aborted` flag the dispatch loop checks every iteration.
- Observed against a real UltraVNC server offering only Tight (no decoder registered): one real "unknown encoding" line was followed by ~90 garbage lines before the connection actually closed — [job log](https://github.com/sibson/vncdotool/actions/runs/32687442324).

## Test plan
- Added `test_unknown_encoding_stops_processing_buffered_rectangles` in `tests/unit/test_rfb.py`, reproducing three concatenated bogus headers and asserting only one error/close.
- `make test` — 320 tests pass.
- `flake8 --count --statistics vncdotool tests` — clean.