### PR TITLE
Add the TPIXEL width rule and the layout its three bytes are in

### DIFF
--- a/tests/unit/test_pixelformat.py
+++ b/tests/unit/test_pixelformat.py
@@ -5,7 +5,14 @@ from unittest import TestCase
 from PIL import Image
 
 from vncdotool import rfb
-from vncdotool.pixelformat import UnsupportedPixelFormat, cpixel_bytes, cpixel_offset, raw_mode
+from vncdotool.pixelformat import (
+    TPIXEL_FORMAT,
+    UnsupportedPixelFormat,
+    cpixel_bytes,
+    cpixel_offset,
+    raw_mode,
+    tpixel_bytes,
+)
 
 BGRX8888 = rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 16, 8, 0)
 BGRX8888_DEPTH32 = rfb.PixelFormat(32, 32, False, True, 255, 255, 255, 16, 8, 0)
@@ -220,3 +227,44 @@ class TestCPixel(TestCase):
         pixel_format = rfb.PixelFormat(32, 24, False, True, 255, 255, 255, 4, 12, 20)
         self.assertEqual(cpixel_bytes(pixel_format), pixel_format.bypp)
         self.assertEqual(cpixel_offset(pixel_format), 0)
+
+
+class TestTPixel(TestCase):
+
+    def test_truecolor_32bpp_depth_24_with_8_bit_channels_is_three_bytes(self):
+        self.assertEqual(tpixel_bytes(BGRX8888), 3)
+        self.assertEqual(tpixel_bytes(RGBX8888), 3)
+
+    def test_16bpp_is_never_a_tpixel(self):
+        self.assertEqual(tpixel_bytes(BGR565), BGR565.bypp)
+
+    def test_depth_32_is_never_a_tpixel(self):
+        self.assertEqual(tpixel_bytes(BGRX8888_DEPTH32), BGRX8888_DEPTH32.bypp)
+
+    def test_colour_mapped_is_never_a_tpixel(self):
+        pixel_format = rfb.PixelFormat(8, 8, False, False, 0, 0, 0, 0, 0, 0)
+        self.assertEqual(tpixel_bytes(pixel_format), pixel_format.bypp)
+
+    def test_a_channel_narrower_than_8_bits_is_never_a_tpixel(self):
+        for channel in range(3):
+            maxima = [255, 255, 255]
+            maxima[channel] = 127
+            pixel_format = rfb.PixelFormat(32, 24, False, True, *maxima, 16, 8, 0)
+            with self.subTest(pixel_format=pixel_format):
+                self.assertEqual(tpixel_bytes(pixel_format), pixel_format.bypp)
+
+    def test_a_depth_16_cpixel_is_not_a_tpixel(self):
+        """CPIXEL applies at depth 24 or less, TPIXEL at depth exactly 24."""
+        pixel_format = rfb.PixelFormat(32, 16, False, True, 31, 63, 31, 19, 13, 8)
+        self.assertEqual(cpixel_bytes(pixel_format), 3)
+        self.assertEqual(tpixel_bytes(pixel_format), pixel_format.bypp)
+
+    def test_the_layout_ignores_endianness_and_the_negotiated_shifts(self):
+        for pixel_format in (BGRX8888, RGBX8888, XRGB8888, XBGR8888, BGRX8888_BIGENDIAN):
+            with self.subTest(pixel_format=pixel_format):
+                self.assertEqual(tpixel_bytes(pixel_format), 3)
+        self.assertEqual(raw_mode(TPIXEL_FORMAT), "RGB")
+
+    def test_the_three_bytes_decode_as_red_green_blue(self):
+        image = Image.frombytes("RGB", (1, 1), bytes([0x20, 0x40, 0x60]), "raw", raw_mode(TPIXEL_FORMAT))
+        self.assertEqual(image.getpixel((0, 0)), (0x20, 0x40, 0x60))

--- a/vncdotool/pixelformat.py
+++ b/vncdotool/pixelformat.py
@@ -1,11 +1,13 @@
 """
 The :class:`PixelFormat` wire structure, its resolution to a Pillow raw mode,
-and the CPIXEL width/offset rules ZRLE depends on.
+the CPIXEL width/offset rules ZRLE depends on, and the TPIXEL width Tight
+depends on.
 
 Reference:
 https://www.rfc-editor.org/rfc/rfc6143#section-7.4
 https://www.rfc-editor.org/rfc/rfc6143#section-7.7.5
 https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst (ZRLE Encoding)
+https://github.com/rfbproto/rfbproto/blob/152107db63cd34b3536ad8ddf54a0cfc9017a9f9/rfbproto.rst#tight-encoding
 """
 from __future__ import annotations
 
@@ -181,6 +183,29 @@ def cpixel_offset(pixel_format: PixelFormat) -> int:
         return 0
     low = _cpixel_placement(pixel_format) == "low"
     return 0 if low != pixel_format.bigendian else pixel_format.bypp - 3
+
+
+def tpixel_bytes(pixel_format: PixelFormat) -> int:
+    """3 for a TPIXEL-eligible format, otherwise ``bypp`` (a PIXEL).
+
+    Narrower than CPIXEL: rfbproto §Tight requires depth exactly 24 and three
+    8-bit channels, where CPIXEL takes depth 24 or less. See
+    ``specs/tight-wire.md`` §1.
+    """
+    if (
+        pixel_format.truecolor
+        and pixel_format.bpp == 32
+        and pixel_format.depth == 24
+        and _channel_widths(pixel_format) == (8, 8, 8)
+    ):
+        return 3
+    return pixel_format.bypp
+
+
+# The three bytes are byte 0 red, byte 1 green, byte 2 blue, whatever the
+# negotiated big-endian flag and channel shifts say; they only decide whether
+# the condition holds (rfbproto §Tight, specs/tight-wire.md §1).
+TPIXEL_FORMAT = PixelFormat(24, 24, False, True, 255, 255, 255, 0, 8, 16)
 
 
 PIXEL_FORMATS: dict[str, PixelFormat] = {


### PR DESCRIPTION
Tight's TPIXEL, which stage 2's pump and stage 3's decoder both need. It is not
CPIXEL under another name: it applies only at depth exactly 24 with three 8-bit
channels, and its three bytes are a fixed red, green, blue whatever the
big-endian flag and channel shifts say — so it gets its own function rather than
a flag on `cpixel_bytes`. `test_a_depth_16_cpixel_is_not_a_tpixel` is the guard
against the two rules collapsing into one.

Stage 1 of [specs/tight-encoding.md](specs/tight-encoding.md); the wire rule is
[specs/tight-wire.md](specs/tight-wire.md) §1, pinned to an rfbproto commit
rather than `master`. Nothing user-visible and no CHANGELOG entry: no decoder
uses it yet.

Tested: 329 unit tests, flake8 clean, no new mypy errors (main carries 83).

Noted, not fixed: the `pixelformat.py` header's pre-existing ZRLE citation still
points at rfbproto `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
