### PR TITLE
Add a whole-rectangle decoder base class and the pump path for it

### DIFF
--- a/tests/unit/test_pump.py
+++ b/tests/unit/test_pump.py
@@ -10,6 +10,7 @@ from unittest import TestCase, mock
 
 from vncdotool import client, decoders, rfb
 from vncdotool.const import Encoding
+from vncdotool.pixelformat import PixelFormat
 
 FIXTURE = (
     Path(__file__).resolve().parent
@@ -49,6 +50,33 @@ def raw_update(x: int, y: int, width: int, height: int, pixels: bytes) -> bytes:
     header = pack("!BxH", 0, 1)  # msg-type, padding, number-of-rectangles
     rect_header = pack("!HHHHi", x, y, width, height, Encoding.RAW)
     return header + rect_header + pixels
+
+
+# Tight's TPIXEL: three bytes, red-green-blue order (rfbproto, Tight Encoding).
+TPIXEL = PixelFormat(24, 24, False, True, 255, 255, 255, 0, 8, 16)
+
+
+class FakeWholeRect(decoders.WholeRectDecoder):
+    """Fills the rectangle with one TPIXEL colour, in two reads so the pump
+    has to resume the generator.
+    """
+
+    ENCODING = Encoding.TIGHT
+
+    def decodeRect(self, width, height, pixel_format):
+        colour = yield 3
+        (invert,) = yield 1
+        if invert:
+            colour = bytes(byte ^ 0xFF for byte in colour)
+        return colour * (width * height), TPIXEL
+
+
+def whole_rect_update(*rects: tuple[int, int, int, int, bytes]) -> bytes:
+    """A FramebufferUpdate of `FakeWholeRect` rectangles. RFC 6143 7.6.1."""
+    out = pack("!BxH", 0, len(rects))
+    for x, y, width, height, payload in rects:
+        out += pack("!HHHHi", x, y, width, height, FakeWholeRect.ENCODING) + payload
+    return out
 
 
 class TestSegmentation(TestCase):
@@ -357,3 +385,168 @@ class TestUnbufferedDecoders(TestCase):
         cli.vncProtocolError.assert_called_once()
         cli.transport.loseConnection.assert_called_once()
         cli.updateRectangle.assert_not_called()
+
+
+class TestWholeRectPump(TestCase):
+    """A `WholeRectDecoder` hands back the whole rectangle's bytes and the
+    format they are in, having filled no `RectBuffer`.
+    """
+
+    def setUp(self) -> None:
+        self.cli = make_pump_client()
+
+    def test_the_rectangle_carries_the_decoders_format_not_the_negotiated_one(self) -> None:
+        cli = self.cli
+        cli.updateRectangle = mock.Mock()
+
+        pump(cli, FakeWholeRect(), 3, 4, 2, 2)
+        cli.dataReceived(b"\x10\x20\x30\x00")
+
+        cli.updateRectangle.assert_called_once_with(
+            3, 4, 2, 2, b"\x10\x20\x30" * 4, TPIXEL
+        )
+        self.assertNotEqual(TPIXEL.bypp, cli.pixel_format.bypp)
+
+    def test_no_buffer_is_allocated(self) -> None:
+        cli = self.cli
+        cli.updateRectangle = mock.Mock()
+
+        pump(cli, FakeWholeRect(), 0, 0, 8, 8)
+        cli.dataReceived(b"\x10\x20\x30\x00")
+
+        cli.updateRectangle.assert_called_once()
+        self.assertEqual(cli._rect_backing, bytearray())
+
+    def test_nothing_is_painted_until_the_rectangle_is_complete(self) -> None:
+        cli = self.cli
+        cli.updateRectangle = mock.Mock()
+
+        pump(cli, FakeWholeRect(), 0, 0, 2, 2)
+        cli.dataReceived(b"\x10\x20\x30")
+
+        cli.updateRectangle.assert_not_called()
+
+        cli.dataReceived(b"\x01")
+
+        cli.updateRectangle.assert_called_once_with(
+            0, 0, 2, 2, b"\xef\xdf\xcf" * 4, TPIXEL
+        )
+
+    def test_the_rectangle_is_recorded_and_the_update_continues(self) -> None:
+        cli = self.cli
+        cli.updateRectangle = mock.Mock()
+        cli.commitUpdate = mock.Mock()
+
+        pump(cli, FakeWholeRect(), 3, 4, 2, 2)
+        cli.dataReceived(b"\x10\x20\x30\x00")
+
+        self.assertEqual(cli.rectanglePos, [(3, 4, 2, 2)])
+        cli.commitUpdate.assert_called_once_with([(3, 4, 2, 2)])
+
+    def test_a_rectangle_larger_than_the_framebuffer_is_refused(self) -> None:
+        cli = self.cli
+        cli.width, cli.height = 64, 48
+        cli.vncProtocolError = mock.Mock()
+        cli.updateRectangle = mock.Mock()
+
+        pump(cli, FakeWholeRect(), 0, 0, 65, 10)
+
+        cli.vncProtocolError.assert_called_once()
+        cli.transport.loseConnection.assert_called_once()
+        cli.updateRectangle.assert_not_called()
+
+    def test_a_decode_error_aborts_rather_than_propagating(self) -> None:
+        cli = self.cli
+        cli.vncProtocolError = mock.Mock()
+        cli.updateRectangle = mock.Mock()
+
+        class Failing(decoders.WholeRectDecoder):
+            def decodeRect(self, width, height, pixel_format):
+                yield 3
+                raise decoders.DecodeError("unknown compression control byte")
+
+        pump(cli, Failing(), 0, 0, 2, 2)
+        cli.dataReceived(b"\x10\x20\x30")
+
+        cli.vncProtocolError.assert_called_once()
+        self.assertIn(
+            "unknown compression control byte", cli.vncProtocolError.call_args.args[0]
+        )
+        cli.transport.loseConnection.assert_called_once()
+        cli.updateRectangle.assert_not_called()
+
+
+class TestWholeRectLength(TestCase):
+    """Neither a buffer nor a byte count off the wire bounds this path, so
+    the pump measures what the decoder handed back.
+    """
+
+    def _abort_for(self, produced: bytes) -> rfb.RFBClient:
+        cli = make_pump_client()
+        cli.vncProtocolError = mock.Mock()
+        cli.updateRectangle = mock.Mock()
+
+        class WrongLength(decoders.WholeRectDecoder):
+            def decodeRect(self, width, height, pixel_format):
+                yield 1
+                return produced, TPIXEL
+
+        pump(cli, WrongLength(), 0, 0, 2, 2)
+        cli.dataReceived(b"\x00")
+        return cli
+
+    def test_too_few_bytes_is_refused(self) -> None:
+        cli = self._abort_for(bytes(2 * 2 * TPIXEL.bypp - 1))
+
+        cli.vncProtocolError.assert_called_once()
+        cli.transport.loseConnection.assert_called_once()
+        cli.updateRectangle.assert_not_called()
+
+    def test_too_many_bytes_is_refused(self) -> None:
+        cli = self._abort_for(bytes(2 * 2 * TPIXEL.bypp + 1))
+
+        cli.vncProtocolError.assert_called_once()
+        cli.transport.loseConnection.assert_called_once()
+        cli.updateRectangle.assert_not_called()
+
+    def test_the_exact_length_is_accepted(self) -> None:
+        """The refusals above pass just as well against a check that
+        rejects everything.
+        """
+        cli = self._abort_for(bytes(2 * 2 * TPIXEL.bypp))
+
+        cli.vncProtocolError.assert_not_called()
+        cli.updateRectangle.assert_called_once()
+
+
+class TestWholeRectSegmentation(TestCase):
+    """`TestSegmentation` proves this of the buffered pump. The whole-rect
+    path parks its own generator, so it has to be proved again here.
+    """
+
+    def _client(self) -> client.VNCDoToolClient:
+        cli = make_client()
+        decoder = FakeWholeRect()
+        cli._decoders[FakeWholeRect.ENCODING] = (decoder, cli._pumpFor(decoder))
+        cli.dataReceived(gzip.decompress((FIXTURE / "init.bin.gz").read_bytes()))
+        return cli
+
+    def test_byte_at_a_time_matches_a_single_call(self) -> None:
+        update = whole_rect_update(
+            (0, 0, 4, 3, b"\xde\xad\xbe\x00"),
+            (8, 5, 2, 2, b"\x01\x02\x03\x01"),
+        )
+
+        whole = self._client()
+        whole.dataReceived(update)
+
+        trickled = self._client()
+        for i in range(len(update)):
+            trickled.dataReceived(update[i:i + 1])
+
+        assert whole.screen is not None
+        assert trickled.screen is not None
+        self.assertEqual(
+            whole.screen.convert("RGB").getpixel((0, 0)), (0xDE, 0xAD, 0xBE)
+        )
+        self.assertEqual(trickled.screen.tobytes(), whole.screen.tobytes())

--- a/tests/unit/test_pump.py
+++ b/tests/unit/test_pump.py
@@ -10,7 +10,7 @@ from unittest import TestCase, mock
 
 from vncdotool import client, decoders, rfb
 from vncdotool.const import Encoding
-from vncdotool.pixelformat import PixelFormat
+from vncdotool.pixelformat import TPIXEL_FORMAT
 
 FIXTURE = (
     Path(__file__).resolve().parent
@@ -52,10 +52,6 @@ def raw_update(x: int, y: int, width: int, height: int, pixels: bytes) -> bytes:
     return header + rect_header + pixels
 
 
-# Tight's TPIXEL: three bytes, red-green-blue order (rfbproto, Tight Encoding).
-TPIXEL = PixelFormat(24, 24, False, True, 255, 255, 255, 0, 8, 16)
-
-
 class FakeWholeRect(decoders.WholeRectDecoder):
     """Fills the rectangle with one TPIXEL colour, in two reads so the pump
     has to resume the generator.
@@ -68,11 +64,11 @@ class FakeWholeRect(decoders.WholeRectDecoder):
         (invert,) = yield 1
         if invert:
             colour = bytes(byte ^ 0xFF for byte in colour)
-        return colour * (width * height), TPIXEL
+        return colour * (width * height), TPIXEL_FORMAT
 
 
 def whole_rect_update(*rects: tuple[int, int, int, int, bytes]) -> bytes:
-    """A FramebufferUpdate of `FakeWholeRect` rectangles. RFC 6143 7.6.1."""
+    """RFC 6143 7.6.1."""
     out = pack("!BxH", 0, len(rects))
     for x, y, width, height, payload in rects:
         out += pack("!HHHHi", x, y, width, height, FakeWholeRect.ENCODING) + payload
@@ -388,10 +384,6 @@ class TestUnbufferedDecoders(TestCase):
 
 
 class TestWholeRectPump(TestCase):
-    """A `WholeRectDecoder` hands back the whole rectangle's bytes and the
-    format they are in, having filled no `RectBuffer`.
-    """
-
     def setUp(self) -> None:
         self.cli = make_pump_client()
 
@@ -403,9 +395,9 @@ class TestWholeRectPump(TestCase):
         cli.dataReceived(b"\x10\x20\x30\x00")
 
         cli.updateRectangle.assert_called_once_with(
-            3, 4, 2, 2, b"\x10\x20\x30" * 4, TPIXEL
+            3, 4, 2, 2, b"\x10\x20\x30" * 4, TPIXEL_FORMAT
         )
-        self.assertNotEqual(TPIXEL.bypp, cli.pixel_format.bypp)
+        self.assertNotEqual(TPIXEL_FORMAT.bypp, cli.pixel_format.bypp)
 
     def test_no_buffer_is_allocated(self) -> None:
         cli = self.cli
@@ -429,7 +421,7 @@ class TestWholeRectPump(TestCase):
         cli.dataReceived(b"\x01")
 
         cli.updateRectangle.assert_called_once_with(
-            0, 0, 2, 2, b"\xef\xdf\xcf" * 4, TPIXEL
+            0, 0, 2, 2, b"\xef\xdf\xcf" * 4, TPIXEL_FORMAT
         )
 
     def test_the_rectangle_is_recorded_and_the_update_continues(self) -> None:
@@ -489,21 +481,21 @@ class TestWholeRectLength(TestCase):
         class WrongLength(decoders.WholeRectDecoder):
             def decodeRect(self, width, height, pixel_format):
                 yield 1
-                return produced, TPIXEL
+                return produced, TPIXEL_FORMAT
 
         pump(cli, WrongLength(), 0, 0, 2, 2)
         cli.dataReceived(b"\x00")
         return cli
 
     def test_too_few_bytes_is_refused(self) -> None:
-        cli = self._abort_for(bytes(2 * 2 * TPIXEL.bypp - 1))
+        cli = self._abort_for(bytes(2 * 2 * TPIXEL_FORMAT.bypp - 1))
 
         cli.vncProtocolError.assert_called_once()
         cli.transport.loseConnection.assert_called_once()
         cli.updateRectangle.assert_not_called()
 
     def test_too_many_bytes_is_refused(self) -> None:
-        cli = self._abort_for(bytes(2 * 2 * TPIXEL.bypp + 1))
+        cli = self._abort_for(bytes(2 * 2 * TPIXEL_FORMAT.bypp + 1))
 
         cli.vncProtocolError.assert_called_once()
         cli.transport.loseConnection.assert_called_once()
@@ -513,7 +505,7 @@ class TestWholeRectLength(TestCase):
         """The refusals above pass just as well against a check that
         rejects everything.
         """
-        cli = self._abort_for(bytes(2 * 2 * TPIXEL.bypp))
+        cli = self._abort_for(bytes(2 * 2 * TPIXEL_FORMAT.bypp))
 
         cli.vncProtocolError.assert_not_called()
         cli.updateRectangle.assert_called_once()

--- a/vncdotool/decoders/__init__.py
+++ b/vncdotool/decoders/__init__.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 from typing import Dict, Type
 
 from ..const import Encoding
-from .base import ClientDecoder, ControlDecoder, Decoder, PixelDecoder, RectDecoder
+from .base import (
+    ClientDecoder,
+    ControlDecoder,
+    Decoder,
+    PixelDecoder,
+    RectDecoder,
+    WholeRectDecoder,
+)
 from .buffer import RectBuffer
 from .control import DesktopSizeDecoder, QemuExtendedKeyDecoder
 from .copyrect import CopyRectDecoder
@@ -58,5 +65,6 @@ __all__ = [
     "PixelDecoder",
     "RectBuffer",
     "RectDecoder",
+    "WholeRectDecoder",
     "for_connection",
 ]

--- a/vncdotool/decoders/base.py
+++ b/vncdotool/decoders/base.py
@@ -1,7 +1,7 @@
 """specs/decoder-architecture.md is the design."""
 from __future__ import annotations
 
-from typing import ClassVar, Iterator
+from typing import ClassVar, Generator, Iterator
 
 from ..const import Encoding
 from ..pixelformat import PixelFormat
@@ -42,6 +42,20 @@ class PixelDecoder(RectDecoder):
         always the negotiated one.
         """
         return pixel_format
+
+
+class WholeRectDecoder(RectDecoder):
+    """Consumes bytes, produces the whole rectangle itself.
+
+    The format it returns need not be the negotiated one: Tight's TPIXEL is
+    three bytes where the negotiated format is four (rfbproto, Tight
+    Encoding).
+    """
+
+    def decodeRect(
+        self, width: int, height: int, pixel_format: PixelFormat
+    ) -> Generator[int, bytes, tuple[bytes, PixelFormat]]:
+        raise NotImplementedError
 
 
 class ClientDecoder(RectDecoder):

--- a/vncdotool/decoders/base.py
+++ b/vncdotool/decoders/base.py
@@ -45,11 +45,8 @@ class PixelDecoder(RectDecoder):
 
 
 class WholeRectDecoder(RectDecoder):
-    """Consumes bytes, produces the whole rectangle itself.
-
-    The format it returns need not be the negotiated one: Tight's TPIXEL is
-    three bytes where the negotiated format is four (rfbproto, Tight
-    Encoding).
+    """Consumes bytes, produces the whole rectangle itself, in whatever
+    pixel format it decoded them to -- not always the negotiated one.
     """
 
     def decodeRect(

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -361,6 +361,8 @@ class RFBClient(Protocol):
             if not decoder.buffered:
                 return self._pumpRectangle
             return self._pumpBufferedRectangle
+        if isinstance(decoder, decoders.WholeRectDecoder):
+            return self._pumpWholeRectangle
         if isinstance(decoder, decoders.ControlDecoder):
             return self._pumpForControl
         return self._pumpForClient
@@ -382,18 +384,41 @@ class RFBClient(Protocol):
             return
         rect = (x, y, width, height)
 
-        def finish_buffered() -> None:
+        def finish_buffered(_result: Any) -> None:
             output_format = decoder.output_format(self.pixel_format)
             self._finishRectangle(target.tobytes(), output_format, rect)
 
         self._pumpGenerator(None, decoder.decodePixels(target, self.pixel_format), finish_buffered)
+
+    def _pumpWholeRectangle(
+        self, decoder: decoders.WholeRectDecoder, x: int, y: int, width: int, height: int
+    ) -> None:
+        if not self._rectFits(width, height):
+            return
+        rect = (x, y, width, height)
+
+        def finish_whole(result: Any) -> None:
+            pixels, output_format = result
+            expected = width * height * output_format.bypp
+            if len(pixels) != expected:
+                self.abortConnection(
+                    f"decoder produced {len(pixels)} bytes for a {width}x{height} "
+                    f"rectangle at {output_format.bypp} bytes per pixel, "
+                    f"which needs {expected}"
+                )
+                return
+            self._finishRectangle(pixels, output_format, rect)
+
+        self._pumpGenerator(
+            None, decoder.decodeRect(width, height, self.pixel_format), finish_whole
+        )
 
     def _pumpForClient(
         self, decoder: decoders.ClientDecoder, x: int, y: int, width: int, height: int
     ) -> None:
         rect = (x, y, width, height)
 
-        def finish_client() -> None:
+        def finish_client(_result: Any) -> None:
             self.rectanglePos.append(rect)
             self._doConnection()
 
@@ -445,15 +470,15 @@ class RFBClient(Protocol):
         self,
         block: bytes | None,
         generator: Iterator[int],
-        on_done: Callable[[], None] | None,
+        on_done: Callable[[Any], None] | None,
     ) -> None:
         try:
             size = generator.send(block)
-        except StopIteration:
+        except StopIteration as stop:
             if on_done is None:
                 self._doConnection()
             else:
-                on_done()
+                on_done(stop.value)
             return
         except (decoders.DecodeError, StructError, MemoryError, zlib.error) as exc:
             generator.close()


### PR DESCRIPTION
## Summary
Tight needs a decoder path that produces a whole rectangle in one call, carrying its own `PixelFormat` (TPIXEL can be 3 bytes/pixel where the negotiated format is 4) instead of writing into a `RectBuffer`. Adds `WholeRectDecoder` and `_pumpWholeRectangle`, and threads the decoder generator's `StopIteration.value` through `on_done` to get the (bytes, PixelFormat) pair out.

Raw is unaffected — it never enters `_pumpGenerator`. No CHANGELOG entry: nothing is registered/selectable yet, so no user-visible change until Tight itself lands (next in the stack).

## Test plan
- [x] `make test` (unit suite)
- Benchmarked on tigervnc-raw-bgrx8888 to confirm no regression on the untouched Raw path (see commit body for numbers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)