### PR TITLE
Fix vnclog swallowing its decoder's failure reason, and ignoring SetPixelFormat

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 2.0.0.dev0 (UNRELEASED)
 ----------------------
+  - Fix ``vnclog`` logging an ``AttributeError`` traceback in place of the reason its own decoder gave up on a session, and then carrying on decoding a stream it had already abandoned (@sibson)
   - Fix a malformed or unsupported server response (bad header, unknown security/auth type, connection refused, unknown message, unrecognized rectangle encoding) parsing further buffered bytes as if they were valid protocol data before the connection closed, instead of stopping immediately (@sibson)
   - Fix ``self.width``/``self.height`` staying at the negotiated size after a server sends ``PSEUDO_DESKTOP_SIZE`` mid-session (@sibson)
   - Fix ``VNCLoggingServerProxy.connectionLost`` rejecting the no-argument call ``Protocol.connectionLost`` promises callers (@sibson)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 2.0.0.dev0 (UNRELEASED)
 ----------------------
+  - Fix ``vnclog`` decoding the session at the pixel format ServerInit announced even after the client asked the server for another one, which desynchronised its log and its ``--capture-raw`` metadata at any non-native format, ``vncdo --pixel-format rgb565`` among them (@sibson)
   - Fix ``vnclog`` logging an ``AttributeError`` traceback in place of the reason its own decoder gave up on a session, and then carrying on decoding a stream it had already abandoned (@sibson)
   - Fix a malformed or unsupported server response (bad header, unknown security/auth type, connection refused, unknown message, unrecognized rectangle encoding) parsing further buffered bytes as if they were valid protocol data before the connection closed, instead of stopping immediately (@sibson)
   - Fix ``self.width``/``self.height`` staying at the negotiated size after a server sends ``PSEUDO_DESKTOP_SIZE`` mid-session (@sibson)

--- a/tests/unit/test_loggingproxy.py
+++ b/tests/unit/test_loggingproxy.py
@@ -1,0 +1,73 @@
+"""Unit coverage for vnclog's proxy halves.
+
+Both protocol classes are driven directly on mocked transports through a
+scripted handshake, so the observer client runs for real without a reactor.
+"""
+
+from __future__ import annotations
+
+import logging
+from struct import pack
+from unittest import TestCase, mock
+
+from vncdotool import pixelformat
+from vncdotool.const import AuthTypes
+from vncdotool.loggingproxy import (
+    VNCLoggingClientProxy,
+    VNCLoggingServerFactory,
+    VNCLoggingServerProxy,
+)
+
+VERSION_38 = b"RFB 003.008\n"
+NATIVE = pixelformat.PIXEL_FORMATS["bgrx8888"]
+
+
+class ProxyPair(TestCase):
+    """A connected pair of proxy halves, taken through the handshake to the
+    point where the observer client is decoding the server stream.
+    """
+
+    def setUp(self) -> None:
+        self.factory = VNCLoggingServerFactory("localhost", 5900)
+        self.factory.password_required = False
+
+        self.server_proxy = VNCLoggingServerProxy()
+        self.server_proxy.transport = mock.Mock()
+        self.server_proxy.factory = self.factory
+        self.client_proxy = VNCLoggingClientProxy()
+        self.client_proxy.transport = mock.Mock()
+        self.server_proxy.peer = self.client_proxy
+        self.client_proxy.peer = self.server_proxy
+
+        self.server_proxy.connectionMade()
+        self.server_proxy.recorder = mock.Mock()
+
+        self.client_proxy.dataReceived(VERSION_38)
+        self.server_proxy.dataReceived(VERSION_38)
+        self.client_proxy.dataReceived(bytes([1, AuthTypes.NONE]))
+        self.server_proxy.dataReceived(bytes([AuthTypes.NONE]))
+        self.client_proxy.dataReceived(b"\x00\x00\x00\x00")
+        self.server_proxy.dataReceived(b"\x01")  # ClientInit: starts the observer
+        self.client_proxy.dataReceived(
+            pack("!HH16sI", 2, 1, NATIVE.to_bytes(), 4) + b"test"
+        )
+
+        self.observer = self.client_proxy.vnclog
+        assert self.observer is not None
+
+
+class TestObserverFailureIsReported(ProxyPair):
+
+    def test_an_unreadable_server_message_is_reported_not_raised(self) -> None:
+        """VNCDoToolClient reports a protocol error to its factory, and the
+        observer's factory is the proxy's own.
+        """
+        unknown_message = bytes([250])
+
+        with self.assertLogs("vncdotool.loggingproxy", level=logging.ERROR) as logged:
+            self.client_proxy.dataReceived(unknown_message)
+
+        self.assertIn("unknown message received", "\n".join(logged.output))
+        self.assertTrue(self.observer._aborted)
+        # The byte still reached the real client: only the observer gave up.
+        self.server_proxy.transport.write.assert_any_call(unknown_message)

--- a/tests/unit/test_loggingproxy.py
+++ b/tests/unit/test_loggingproxy.py
@@ -6,12 +6,13 @@ scripted handshake, so the observer client runs for real without a reactor.
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 from struct import pack
 from unittest import TestCase, mock
 
 from vncdotool import pixelformat
-from vncdotool.const import AuthTypes
+from vncdotool.const import AuthTypes, Encoding, MsgC2S, MsgS2C
 from vncdotool.loggingproxy import (
     VNCLoggingClientProxy,
     VNCLoggingServerFactory,
@@ -20,6 +21,18 @@ from vncdotool.loggingproxy import (
 
 VERSION_38 = b"RFB 003.008\n"
 NATIVE = pixelformat.PIXEL_FORMATS["bgrx8888"]
+RGB565 = pixelformat.PIXEL_FORMATS["rgb565"]
+
+RED_565 = b"\x00\xf8"
+BLUE_565 = b"\x1f\x00"
+
+
+def raw_update(x: int, y: int, w: int, h: int, pixels: bytes) -> bytes:
+    return (
+        pack("!BxH", MsgS2C.FRAMEBUFFER_UPDATE, 1)
+        + pack("!HHHHi", x, y, w, h, Encoding.RAW)
+        + pixels
+    )
 
 
 class ProxyPair(TestCase):
@@ -54,6 +67,50 @@ class ProxyPair(TestCase):
 
         self.observer = self.client_proxy.vnclog
         assert self.observer is not None
+
+    def setPixelFormat(self, pixel_format: pixelformat.PixelFormat) -> None:
+        """Send SetPixelFormat from the real client, through the proxy."""
+        self.server_proxy.dataReceived(
+            pack("!Bxxx16s", MsgC2S.SET_PIXEL_FORMAT, pixel_format.to_bytes())
+        )
+
+
+class TestObserverPixelFormat(ProxyPair):
+
+    def test_observer_starts_at_the_format_serverinit_announced(self) -> None:
+        self.assertEqual(self.observer.pixel_format, NATIVE)
+
+    def test_observer_adopts_a_format_the_client_asks_for(self) -> None:
+        self.setPixelFormat(RGB565)
+
+        self.assertEqual(self.observer.pixel_format, RGB565)
+        self.assertEqual(self.observer._image_mode, pixelformat.raw_mode(RGB565))
+
+    def test_observer_decodes_the_stream_at_the_new_format(self) -> None:
+        """Two updates, so the second only parses if the first consumed the
+        right number of bytes: at the native 4 bytes per pixel the observer
+        eats into the next message and desynchronises for good.
+        """
+        self.setPixelFormat(RGB565)
+
+        self.client_proxy.dataReceived(raw_update(0, 0, 2, 1, RED_565 + BLUE_565))
+        self.client_proxy.dataReceived(raw_update(0, 0, 2, 1, BLUE_565 + RED_565))
+
+        self.assertFalse(self.observer._aborted)
+        assert self.observer.screen is not None
+        self.assertEqual(
+            [self.observer.screen.getpixel((0, 0)), self.observer.screen.getpixel((1, 0))],
+            [(0, 0, 255), (255, 0, 0)],
+        )
+
+    def test_a_format_the_observer_cannot_unpack_fails_it_cleanly(self) -> None:
+        """The real client is free to ask for something vncdotool cannot
+        decode; that must not raise out of the proxy's parser.
+        """
+        with self.assertLogs("vncdotool.loggingproxy", level=logging.ERROR):
+            self.setPixelFormat(dataclasses.replace(RGB565, truecolor=False))
+
+        self.assertTrue(self.observer._aborted)
 
 
 class TestObserverFailureIsReported(ProxyPair):

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -206,6 +206,12 @@ class VNCLoggingClient(VNCDoToolClient):
     capture: CaptureWriter | None = None
     recorder: Callable[[str], int] | None = None
 
+    def vncProtocolError(self, reason: str) -> None:
+        # NullTransport.loseConnection() is a no-op, so the parser has to be
+        # stopped here instead.
+        self._aborted = True
+        super().vncProtocolError(reason)
+
     def _handleRectangle(self, block: bytes) -> None:
         # Tallied off the decoded stream: SetEncodings only says what the
         # client asked for, and a server may ignore it.
@@ -512,6 +518,9 @@ class VNCLoggingServerFactory(portforward.ProxyFactory):
 
     def clientConnectionMade(self, client: VNCLoggingServerProxy) -> None:
         pass
+
+    def clientConnectionFailed(self, client: VNCLoggingClient, reason: object) -> None:
+        log.error("vnclog stopped decoding this session: %s", reason)
 
     def clientConnectionLost(self, client: VNCLoggingServerProxy) -> None:
         if self._out:

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -428,6 +428,14 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):
         RFBServer._handle_clientInit(self)
         self.peer.startLogging(self)
 
+    def handle_setPixelFormat(self, pixel_format: PixelFormat) -> None:
+        # SetPixelFormat is client-to-server (RFC 6143 7.5.1), so nothing in
+        # the stream the observer reads says the server switched layouts.
+        observer = self.vnclog_client
+        if observer is not None:
+            observer.requested_pixel_format = pixel_format
+            observer.setImageMode()
+
     def handle_keyEvent(self, key: int, down: bool) -> None:
         now = time.time()
 


### PR DESCRIPTION
Two vnclog proxy bugs found while capturing Tight fixtures. Independent of the Tight decoder work — touches only `loggingproxy.py` and its tests.

**The failure reason never reached anyone.** The observer client gets handed the proxy's factory, which implements two of the three callbacks `VNCDoToolClient` makes on one. Every failure path ended in `factory.clientConnectionFailed`, so the actual reason was replaced by an `AttributeError` traceback — caught by the observer guard, which is why this went unnoticed. The observer also kept parsing afterwards, since `abortConnection` stops a real client by losing its transport and the observer's `NullTransport.loseConnection` is a no-op.

**SetPixelFormat was dropped.** It is client-to-server (RFC 6143 7.5.1), so the server stream the observer reads never says the layout changed. At bgrx8888 against TigerVNC that is the native format and nothing shows; at rgb565 the observer consumed four bytes per pixel where two arrived and desynchronised on the first rectangle — a capture recorded encoding `-1005009896` for its one rectangle before giving up, and now records `raw x33, last-rect x8`. Routed through `requested_pixel_format`/`setImageMode` rather than assigning `pixel_format`, so the observer rejects an unpackable format on the same path a real client does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
