### PR TITLE
Compare bench rows against their own fixture

### DIFF
--- a/tests/goldens/report.py
+++ b/tests/goldens/report.py
@@ -1,9 +1,10 @@
 """Read bench.jsonl back: a table per machine, or a call-count diff.
 
-Timings only mean anything against timings from the same machine running
-the same interpreter and Pillow, so the table groups by machine and
-leaves the delta column blank across a change in either. The call counts
-carry no such caveat, which is what ``--diff`` reads.
+Timings only mean anything against timings of the same fixture from the
+same machine running the same interpreter and Pillow, so the table groups
+by machine, takes each row's delta against the previous row for its own
+fixture, and blanks that column across a change of interpreter or Pillow.
+The call counts carry no such caveat, which is what ``--diff`` reads.
 """
 from __future__ import annotations
 
@@ -27,6 +28,10 @@ def _comparable(row: Row, previous: Row) -> bool:
     return all(row.get(k) == previous.get(k) for k in ("python", "implementation", "pillow"))
 
 
+def _fixture(row: Row) -> str:
+    return str(row.get("fixture") or "-")
+
+
 def _delta(row: Row, previous: Optional[Row]) -> str:
     if previous is None:
         return ""
@@ -47,16 +52,18 @@ def _table(rows: List[Row]) -> None:
         where = " (CI)" if head.get("ci") else ""
         print(f"machine {machine}  {head.get('cpu')}, {head.get('cores')} cores, "
               f"{head.get('system')}{where}")
-        print(f"  {'commit':9} {'date':11} {'python':8} {'pillow':8} "
+        width = max([len("fixture")] + [len(_fixture(r)) for r in group])
+        print(f"  {'commit':9} {'date':11} {'fixture':{width}} {'python':8} {'pillow':8} "
               f"{'best_us':>9} {'delta':>7} {'calls':>7}")
-        previous: Optional[Row] = None
+        previous: Dict[str, Row] = {}
         for row in group:
             commit = str(row.get("commit") or "-")[:7]
-            print(f"  {commit:9} {str(row['timestamp'])[:10]:11} "
+            fixture = _fixture(row)
+            print(f"  {commit:9} {str(row['timestamp'])[:10]:11} {fixture:{width}} "
                   f"{str(row.get('python') or '-'):8} {str(row.get('pillow') or '-'):8} "
-                  f"{row['best_us']:9.1f} {_delta(row, previous):>7} "
+                  f"{row['best_us']:9.1f} {_delta(row, previous.get(fixture)):>7} "
                   f"{row.get('calls_total', 0):7}")
-            previous = row
+            previous[fixture] = row
         print()
 
 


### PR DESCRIPTION
`tests/goldens/report.py` computed the `delta` column against the immediately preceding row, grouping only by machine/python/pillow. Now that several fixtures are recorded per commit, adjacent rows are usually different encodings, so the number compared workloads rather than code — the Tight JPEG row read as a large regression against the Tight rgb565 row above it. The table also never showed which fixture a row was, so this was invisible.

The previous row is now tracked per fixture, and the fixture name is a column (width sized per machine table). A fixture's first appearance is blank instead of comparing against whatever preceded it; `n/c` still fires on an interpreter or Pillow change. This is what N2 in `specs/decoder-architecture.md` asks for: each encoding measured against its own history.

Tested: `make bench-report` before and after against the checked-in `bench.jsonl` — the bogus cross-fixture deltas are gone and the raw chain now skips over the interleaved rre/corre/zrle rows. `flake8 --count --statistics vncdotool tests` is 0, `make test` 419 OK. No CHANGELOG entry: the bench report is a dev tool, not user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)