### PR TITLE
Refuse a Tight JPEG rectangle nobody asked for

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@
 ----------------------
   - Add ``vncdo stable SECONDS [FUZZ]`` and ``rstable SECONDS X Y W H [FUZZ]``, waiting until the screen stops changing rather than until it matches a reference image (@sibson)
   - Fix ``rexpect`` polling until ``--timeout`` and ``rcapture`` writing black pixels when the region runs off the screen, and ``expect`` doing the same against a target image larger than the screen. All three now fail with a message naming the region and the screen size, exiting 30 (@sibson)
+  - A Tight JPEG rectangle from a server that was never offered a JPEG quality level now ends the session with a named error instead of being decoded. JPEG is lossy, so decoding one nobody asked for made a capture inexact without saying so; pass ``--jpeg-quality`` to ask for them (@sibson)
   - [BREAKING] ``expect`` and ``rexpect`` decide a match pixel by pixel, as a perceived colour difference, rather than by the root-mean-square difference of the two histograms. The number in ``expect FILE N`` is now that per-pixel bound, 0 (exact) to 255, on a scale unrelated to the old one; ``expectScreen`` and ``expectRegion`` take ``fuzz`` and ``blur`` in place of ``maxrms`` (@sibson)
   - Add ``vncdo --expect-fuzz N`` and ``--expect-blur RADIUS``, tuning how near the screen has to be for ``expect`` to call it a match. A blur is what lets ``expect`` match a screen a lossy encoding has moved, and ``--jpeg-quality`` turns one on (@sibson)
   - Fix ``vncdo expect FILE`` and ``rexpect FILE X Y`` crashing when no fuzz was given, the spelling the documentation shows (@sibson)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -137,11 +137,11 @@ ends the session with a message naming what arrived, exiting 20.  The tight
 *security type*, which TightVNC servers want before they will authenticate
 you, is not implemented either.
 
-Some tight rectangles can be JPEG, which is lossy.  vncdo decodes them
-whether or not it asked for them; a conforming server sends them only to a
-client that asked for a JPEG quality level, and vncdo asks for none by
-default, so a capture is exact unless you request otherwise.
-``--jpeg-quality`` asks for one, on the RFB scale of 0 (low) to 9 (high)::
+Some tight rectangles can be JPEG, which is lossy.  vncdo decodes one only
+if it asked for a JPEG quality level; a rectangle arriving when it did not
+ends the session with a message naming it, exiting 20.  A capture is
+therefore exact unless you request otherwise.  ``--jpeg-quality`` makes the
+request, on the RFB scale of 0 (low) to 9 (high)::
 
     > vncdo --encodings tight --jpeg-quality 8 capture screen.png
 

--- a/tests/unit/test_decoder_tight.py
+++ b/tests/unit/test_decoder_tight.py
@@ -17,6 +17,7 @@ from typing import Optional, Sequence, Tuple
 
 from PIL import Image
 
+from vncdotool.const import Encoding
 from vncdotool.decoders import DecodeError
 from vncdotool.decoders.tight import (
     FILL, FILTER_COPY, FILTER_GRADIENT, FILTER_PALETTE, JPEG, MIN_TO_COMPRESS, TightDecoder,
@@ -372,6 +373,15 @@ def gradient_image(width: int, height: int) -> Image.Image:
     )
 
 
+def offering_jpeg(decoder: Optional[TightDecoder] = None) -> TightDecoder:
+    """A decoder told a quality level was offered, as a client asking for JPEG
+    would leave it. Without that it refuses JPEG rectangles outright.
+    """
+    decoder = decoder if decoder is not None else TightDecoder()
+    decoder.encodingsOffered(frozenset({Encoding(Encoding.JPEG_32 + 9)}))
+    return decoder
+
+
 class TestJpeg(unittest.TestCase):
     WIDTH = 16
     HEIGHT = 8
@@ -382,7 +392,7 @@ class TestJpeg(unittest.TestCase):
         self.wire = jpeg_rect(self.payload)
 
     def test_a_compact_length_then_that_many_bytes_of_jfif(self) -> None:
-        _, _, consumed = decode_rect(self.wire, self.WIDTH, self.HEIGHT)
+        _, _, consumed = decode_rect(self.wire, self.WIDTH, self.HEIGHT, offering_jpeg())
 
         self.assertEqual(self.wire[0] >> 4, 0x09)
         self.assertEqual(self.payload[:2], b"\xff\xd8", "a JFIF stream opens with SOI")
@@ -392,14 +402,15 @@ class TestJpeg(unittest.TestCase):
         tiny = jfif(gradient_image(1, 1))
         wire = jpeg_rect(tiny)
 
-        _, _, consumed = decode_rect(wire, 1, 1)
+        _, _, consumed = decode_rect(wire, 1, 1, offering_jpeg())
 
         self.assertEqual(consumed, 1 + len(compact(len(tiny))) + len(tiny))
 
     def test_it_decodes_to_24bpp_rgb_whatever_was_negotiated(self) -> None:
         self.assertEqual(PIXEL_FORMAT.bpp, 32)
 
-        pixels, output_format, _ = decode_rect(self.wire, self.WIDTH, self.HEIGHT)
+        pixels, output_format, _ = decode_rect(
+            self.wire, self.WIDTH, self.HEIGHT, offering_jpeg())
 
         self.assertEqual(output_format, TPIXEL_FORMAT)
         self.assertEqual(len(pixels), self.WIDTH * self.HEIGHT * 3)
@@ -408,13 +419,14 @@ class TestJpeg(unittest.TestCase):
         # At bgrx8888 a TPIXEL is three bytes too, so only a second format separates "JPEG is
         # always 24 bpp RGB" from a coincidence.
         pixels, output_format, _ = decode_rect(
-            self.wire, self.WIDTH, self.HEIGHT, pixel_format=PIXEL_FORMATS["rgb565"])
+            self.wire, self.WIDTH, self.HEIGHT, offering_jpeg(),
+            pixel_format=PIXEL_FORMATS["rgb565"])
 
         self.assertEqual(output_format, TPIXEL_FORMAT)
         self.assertEqual(len(pixels), self.WIDTH * self.HEIGHT * 3)
 
     def test_it_decodes_to_the_image_it_was_encoded_from(self) -> None:
-        pixels, _, _ = decode_rect(self.wire, self.WIDTH, self.HEIGHT)
+        pixels, _, _ = decode_rect(self.wire, self.WIDTH, self.HEIGHT, offering_jpeg())
 
         original = self.image.tobytes()
         worst = max(abs(a - b) for a, b in zip(pixels, original))
@@ -424,7 +436,7 @@ class TestJpeg(unittest.TestCase):
         # Reset bits apply even to a type carrying no zlib data (specs/tight-wire.md section 2).
         payload = bytes(i % 3 for i in range(12))
         palette = [RED, GREEN, BLUE]
-        decoder, stream = TightDecoder(), zlib.compressobj()
+        decoder, stream = offering_jpeg(), zlib.compressobj()
         expected, _ = decode(
             basic(payload, stream=2, filter_id=FILTER_PALETTE, palette=palette, compressor=stream),
             12, 1, decoder)
@@ -442,7 +454,7 @@ class TestJpeg(unittest.TestCase):
 
     def test_a_rectangle_whose_image_is_the_wrong_size_is_refused(self) -> None:
         with self.assertRaises(DecodeError) as caught:
-            decode_rect(self.wire, self.WIDTH + 1, self.HEIGHT)
+            decode_rect(self.wire, self.WIDTH + 1, self.HEIGHT, offering_jpeg())
 
         self.assertIn("JPEG", str(caught.exception))
 
@@ -456,7 +468,7 @@ class TestJpeg(unittest.TestCase):
         payload[offset + 5:offset + 9] = (65500).to_bytes(2, "big") * 2
 
         with self.assertRaises(DecodeError) as caught:
-            decode_rect(jpeg_rect(bytes(payload)), self.WIDTH, self.HEIGHT)
+            decode_rect(jpeg_rect(bytes(payload)), self.WIDTH, self.HEIGHT, offering_jpeg())
 
         self.assertIn("JPEG", str(caught.exception))
 
@@ -466,7 +478,7 @@ class TestJpeg(unittest.TestCase):
         self.assertEqual(len(Image.open(io.BytesIO(payload)).getbands()), 1)
 
         pixels, output_format, consumed = decode_rect(
-            jpeg_rect(payload), self.WIDTH, self.HEIGHT)
+            jpeg_rect(payload), self.WIDTH, self.HEIGHT, offering_jpeg())
 
         self.assertEqual(output_format, TPIXEL_FORMAT)
         self.assertEqual(len(pixels), self.WIDTH * self.HEIGHT * 3)
@@ -475,6 +487,53 @@ class TestJpeg(unittest.TestCase):
             all(triple[0] == triple[1] == triple[2] for triple in triples),
             "one component expanded to three must leave every pixel grey",
         )
+
+
+class TestUnsolicitedJpeg(unittest.TestCase):
+    """A conforming server sends JPEG only to a client that offered a quality
+    level (specs/tight-wire.md section 8). One that sends it anyway would make
+    a capture lossy without the user having asked for that.
+    """
+
+    WIDTH = 16
+    HEIGHT = 8
+
+    def setUp(self) -> None:
+        self.wire = jpeg_rect(jfif(gradient_image(self.WIDTH, self.HEIGHT)))
+
+    def test_it_is_refused_when_nothing_was_offered(self) -> None:
+        with self.assertRaises(DecodeError) as caught:
+            decode_rect(self.wire, self.WIDTH, self.HEIGHT, TightDecoder())
+
+        self.assertIn("JpegCompression", str(caught.exception))
+
+    def test_it_is_refused_when_the_offer_held_no_quality_level(self) -> None:
+        decoder = TightDecoder()
+        decoder.encodingsOffered(frozenset({Encoding.TIGHT, Encoding.RAW}))
+
+        with self.assertRaises(DecodeError) as caught:
+            decode_rect(self.wire, self.WIDTH, self.HEIGHT, decoder)
+
+        self.assertIn("JpegCompression", str(caught.exception))
+
+    def test_any_of_the_ten_levels_allows_it(self) -> None:
+        for level in range(10):
+            with self.subTest(level=level):
+                decoder = TightDecoder()
+                decoder.encodingsOffered(
+                    frozenset({Encoding(Encoding.JPEG_32 + level)}))
+
+                _, output_format, _ = decode_rect(
+                    self.wire, self.WIDTH, self.HEIGHT, decoder)
+
+                self.assertEqual(output_format, TPIXEL_FORMAT)
+
+    def test_a_lossless_rectangle_is_unaffected(self) -> None:
+        wire = basic(RED + GREEN + BLUE + RED)
+
+        pixels, _ = decode(wire, 4, 1)
+
+        self.assertEqual(pixels, RED + GREEN + BLUE + RED)
 
 
 class TestOversizedZlibBlock(unittest.TestCase):

--- a/tests/unit/test_goldens.py
+++ b/tests/unit/test_goldens.py
@@ -75,6 +75,10 @@ class Fixture:
         cli.factory.last_rect = False
         cli.factory.qemu_extended_key = False
         cli.requested_pixel_format = pixelformat.PIXEL_FORMATS[self.conditions["pixel_format"]]
+        # The replay runs the handshake, so it offers what it is configured to
+        # offer. A lossy fixture was captured by a client asking for JPEG, and
+        # the decoder refuses a JPEG rectangle nobody asked for.
+        cli.requested_jpeg_quality = self.conditions.get("jpeg_quality")
         cli.dataReceived(gzip.decompress((self.path / "init.bin.gz").read_bytes()))
         return cli
 

--- a/tests/unit/test_loggingproxy.py
+++ b/tests/unit/test_loggingproxy.py
@@ -113,6 +113,39 @@ class TestObserverPixelFormat(ProxyPair):
         self.assertTrue(self.observer._aborted)
 
 
+class TestObserverEncodingsOffered(ProxyPair):
+
+    def setEncodings(self, *encodings: int) -> None:
+        """Send SetEncodings from the real client, through the proxy."""
+        self.server_proxy.dataReceived(
+            pack("!BxH", MsgC2S.SET_ENCODING, len(encodings))
+            + b"".join(pack("!i", e) for e in encodings)
+        )
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.observer.encodingsOffered = mock.Mock()
+
+    def test_a_pseudo_encoding_reaches_the_observer(self) -> None:
+        """Encoding types are signed on the wire and every pseudo-encoding is
+        negative, so reading them unsigned puts SetEncodings past the end of
+        the enum and takes the proxy down with it.
+        """
+        self.setEncodings(Encoding.TIGHT, Encoding.PSEUDO_CURSOR)
+
+        self.observer.encodingsOffered.assert_called_once_with(
+            frozenset({Encoding.TIGHT, Encoding.PSEUDO_CURSOR})
+        )
+
+    def test_an_encoding_with_no_name_is_dropped_not_raised(self) -> None:
+        """A client may offer a vendor encoding this enum has never heard of."""
+        self.setEncodings(Encoding.RAW, 0x12345678)
+
+        self.observer.encodingsOffered.assert_called_once_with(
+            frozenset({Encoding.RAW})
+        )
+
+
 class TestObserverFailureIsReported(ProxyPair):
 
     def test_an_unreadable_server_message_is_reported_not_raised(self) -> None:

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -20,6 +20,7 @@ from twisted.internet.interfaces import IConnector, ITCPTransport
 from twisted.python.failure import Failure
 
 from . import pixelformat, rfb
+from .const import JPEG_QUALITY_ENCODINGS
 from .keys import KEYMAP
 
 TClient = TypeVar("TClient", bound="VNCDoToolClient")
@@ -65,12 +66,6 @@ class ProtocolError(VNCDoException):
 
 class RegionError(VNCDoException):
     """A region to compare or capture is not on the screen"""
-
-
-# Level 0 is -32 (low) up to level 9 at -23; no offer means no JPEG (specs/tight-wire.md section 8).
-JPEG_QUALITY_ENCODINGS = [
-    rfb.Encoding(rfb.Encoding.JPEG_32 + level) for level in range(10)
-]
 
 
 class _StableWatch:

--- a/vncdotool/const.py
+++ b/vncdotool/const.py
@@ -136,6 +136,13 @@ class Encoding(IntEnumLookup):
     SESSION = 0xFFFF8003
 
 
+# The ten JPEG Quality Level pseudo-encodings, indexed by RFB level: 0 is low
+# at -32, 9 is high at -23 (specs/tight-wire.md section 8).
+JPEG_QUALITY_ENCODINGS = tuple(
+    Encoding(Encoding.JPEG_32 + level) for level in range(10)
+)
+
+
 class HextileEncoding(IntFlag):
     """:rfc:`6143` §7.7.4. Hextile Encoding."""
 

--- a/vncdotool/decoders/base.py
+++ b/vncdotool/decoders/base.py
@@ -52,6 +52,12 @@ class Decoder:
         """
         raise NotImplementedError
 
+    def encodingsOffered(self, encodings: frozenset[Encoding]) -> None:
+        """Every encoding the client asked the server for, before any
+        rectangle arrives. A server may send what was never asked for, so a
+        decoder that treats an unasked-for rectangle differently reads this.
+        """
+
     def decodePixels(
         self, target: RectBuffer, pixel_format: PixelFormat
     ) -> Iterator[int]:

--- a/vncdotool/decoders/tight.py
+++ b/vncdotool/decoders/tight.py
@@ -23,6 +23,11 @@ FILTER_COPY = 0
 FILTER_PALETTE = 1
 FILTER_GRADIENT = 2
 
+# The ten JPEG Quality Level pseudo-encodings (specs/tight-wire.md section 8).
+JPEG_QUALITY_LEVELS = frozenset(
+    Encoding(Encoding.JPEG_32 + level) for level in range(10)
+)
+
 # Below this height*rowSize, data arrives raw (specs/tight-wire.md section 6).
 MIN_TO_COMPRESS = 12
 
@@ -66,6 +71,10 @@ class TightDecoder(WholeRectDecoder):
     def __init__(self) -> None:
         # TigerVNC and TurboVNC use the four streams differently (section 9).
         self._streams: List[Optional["zlib._Decompress"]] = [None] * STREAMS
+        self._jpeg_offered = False
+
+    def encodingsOffered(self, encodings: frozenset[Encoding]) -> None:
+        self._jpeg_offered = bool(encodings & JPEG_QUALITY_LEVELS)
 
     def decodeRect(
         self, width: int, height: int, pixel_format: PixelFormat
@@ -88,6 +97,11 @@ class TightDecoder(WholeRectDecoder):
             )
 
         if comp_ctl == JPEG:
+            if not self._jpeg_offered:
+                raise DecodeError(
+                    "Tight JpegCompression arrived without a JPEG Quality Level "
+                    "offered; it is lossy, so the capture would not be exact"
+                )
             # No filter byte, no zlib and no MIN_TO_COMPRESS rule (specs/tight-wire.md section 4).
             length = yield from self._compactLength()
             return self._decodeJpeg(bytes((yield length)), width, height), TPIXEL_FORMAT

--- a/vncdotool/decoders/tight.py
+++ b/vncdotool/decoders/tight.py
@@ -7,7 +7,7 @@ from typing import ClassVar, Generator, List, Optional, Tuple
 
 from PIL import Image
 
-from ..const import Encoding
+from ..const import JPEG_QUALITY_ENCODINGS, Encoding
 from ..pixelformat import TPIXEL_FORMAT, PixelFormat, tpixel_bytes
 from .base import WholeRectDecoder
 from .errors import DecodeError
@@ -23,10 +23,7 @@ FILTER_COPY = 0
 FILTER_PALETTE = 1
 FILTER_GRADIENT = 2
 
-# The ten JPEG Quality Level pseudo-encodings (specs/tight-wire.md section 8).
-JPEG_QUALITY_LEVELS = frozenset(
-    Encoding(Encoding.JPEG_32 + level) for level in range(10)
-)
+JPEG_QUALITY_LEVELS = frozenset(JPEG_QUALITY_ENCODINGS)
 
 # Below this height*rowSize, data arrives raw (specs/tight-wire.md section 6).
 MIN_TO_COMPRESS = 12

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -445,6 +445,13 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):
             observer.requested_pixel_format = pixel_format
             observer.setImageMode()
 
+    def handle_setEncodings(self, encodings: Sequence[int]) -> None:
+        # SetEncodings is client-to-server too, and the observer refuses a
+        # rectangle the real client never asked for unless it is told.
+        observer = self.vnclog_client
+        if observer is not None:
+            observer.encodingsOffered(frozenset(Encoding(e) for e in encodings))
+
     def handle_keyEvent(self, key: int, down: bool) -> None:
         now = time.time()
 

--- a/vncdotool/loggingproxy.py
+++ b/vncdotool/loggingproxy.py
@@ -120,7 +120,8 @@ class RFBServer(Protocol):
         elif ptype == MsgC2S.SET_ENCODING:
             (nencodings,) = unpack("!xH", block)
             nbytes = 4 * nencodings
-            encodings = unpack_from("!" + "I" * nencodings, self.buffer)
+            # Signed: every pseudo-encoding is negative (:rfc:`6143` 7.5.2).
+            encodings = unpack_from("!" + "i" * nencodings, self.buffer)
             del self.buffer[:nbytes]
             for encoding in encodings:
                 log.debug(f"Client announces {Encoding.lookup(encoding)!r}")
@@ -447,10 +448,14 @@ class VNCLoggingServerProxy(portforward.ProxyServer, RFBServer):
 
     def handle_setEncodings(self, encodings: Sequence[int]) -> None:
         # SetEncodings is client-to-server too, and the observer refuses a
-        # rectangle the real client never asked for unless it is told.
+        # rectangle the real client never asked for unless it is told. A
+        # client may offer an encoding this enum has no name for.
         observer = self.vnclog_client
         if observer is not None:
-            observer.encodingsOffered(frozenset(Encoding(e) for e in encodings))
+            named = (Encoding.lookup(e) for e in encodings)
+            observer.encodingsOffered(
+                frozenset(e for e in named if isinstance(e, Encoding))
+            )
 
     def handle_keyEvent(self, key: int, down: bool) -> None:
         now = time.time()

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -528,6 +528,11 @@ class RFBClient(Protocol):
         for encoding in list_of_encodings:
             log.msg(f"Offering {encoding!r}")
             self.transport.write(pack("!i", encoding))
+        self.encodingsOffered(frozenset(list_of_encodings))
+
+    def encodingsOffered(self, encodings: frozenset[Encoding]) -> None:
+        for decoder in self._decoders.values():
+            decoder.encodingsOffered(encodings)
 
     def framebufferUpdateRequest(
         self,


### PR DESCRIPTION
JPEG is the only lossy thing we decode, and we decoded one whenever it arrived. A server that sends JPEG without ever being offered a quality level would make `vncdo capture` write a lossy screenshot with nothing saying so. The decoder is now told what was offered and refuses what was not.

vnclog's observer runs no handshake and so never calls setEncodings; the proxy now forwards the client's SetEncodings to it, or it would refuse the JPEG rectangles it exists to log.

Step 1 of #462.