### PR TITLE
Skip the OS-native server tests off CI, fail them on it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ Tests are stdlib `unittest`, not pytest. Run the unit suite with `make test`
 (`python -m unittest discover tests/unit`) -- note the path: discovery over
 plain `tests` also collects `tests/functional/`, whose tests need the Docker
 Compose test server fleet (`make servers-up`) and fail loudly without it --
-they never skip, so a down fleet can't pass as green.
+they never skip, so a down fleet can't pass as green. The one exception is
+the OS-hosted servers of `test_server_compat_native.py`, which CI alone sets
+up: those skip off CI and fail on it (`utils.absent_server_skips`).
 Unit tests need no VNC server: protocol classes are driven directly with a
 mocked Twisted transport (see `tests/unit/test_rfb.py` and `test_client.py`
 for the patterns).

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,8 @@ bench-report:
 	uv run python -m tests.goldens.report $(ARGS)
 
 # Needs `make servers-up`: an unreachable server fails its tests rather
-# than skipping them, so a down fleet cannot pass as green.
+# than skipping them, so a down fleet cannot pass as green. The OS-hosted
+# servers are the exception: CI alone sets them up, so off CI they skip.
 .PHONY: test-func
 test-func:
 	uv run python -m unittest discover -s tests/functional -t .

--- a/tests/functional/test_server_compat_native.py
+++ b/tests/functional/test_server_compat_native.py
@@ -8,8 +8,8 @@ notes in tests/servers/ultravnc, tests/servers/screen-sharing, and
 tests/servers/qemu-kvm, and are what CI runs before this module.
 
 On a platform with no native server described there is simply nothing to
-register, and on a platform that has one but hasn't set it up the test
-fails with the command that would set it up.
+register. On a platform that has one but hasn't set it up, these skip off
+CI and fail on it -- see utils.absent_server_skips().
 """
 
 from .utils import os_servers, register_server_tests

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -25,7 +25,7 @@ import tempfile
 import time
 import zipfile
 from pathlib import Path
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple
+from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Tuple
 from unittest import TestCase
 
 from PIL import Image
@@ -81,6 +81,8 @@ class VNCServer(NamedTuple):
     timeout: float = CONNECT_TIMEOUT
     # How to get this server running, quoted when a test fails because it is down.
     how_to_start: str = "start the servers first with `make servers-up`"
+    # Honoured only off CI -- see absent_server_skips().
+    skip_when_down: bool = False
 
 
 # One constant per service in tests/servers/docker-compose.yml, named so a
@@ -121,6 +123,7 @@ def os_server(name: str, how_to_start: str, **overrides: Any) -> VNCServer:
         size=None,
         timeout=OS_SERVER_TIMEOUT,
         how_to_start=how_to_start,
+        skip_when_down=True,
         **overrides,
     )
 
@@ -172,6 +175,19 @@ def select_servers(group: str) -> List[VNCServer]:
     if group not in groups:
         raise ValueError(f"unknown server group {group!r}, expected one of {sorted(groups)} or 'all'")
     return groups[group]
+
+
+CI_ENV_VARS = ("CI", "GITHUB_ACTIONS")
+NOT_CI_VALUES = ("", "0", "false", "no")
+
+
+def running_in_ci(env: Optional[Mapping[str, str]] = None) -> bool:
+    env = os.environ if env is None else env
+    return any(env.get(name, "").strip().lower() not in NOT_CI_VALUES for name in CI_ENV_VARS)
+
+
+def absent_server_skips(server: VNCServer, env: Optional[Mapping[str, str]] = None) -> bool:
+    return server.skip_when_down and not running_in_ci(env)
 
 
 def screenshot_dir() -> Path:
@@ -398,11 +414,15 @@ class _VNCServerTestMixin:
     server: VNCServer
 
     def setUp(self) -> None:
-        if not port_open(HOST, self.server.port):
-            self.fail(
-                f"{self.server.name} not reachable on {HOST}:{self.server.port} -- "
-                f"{self.server.how_to_start}"
-            )
+        if port_open(HOST, self.server.port):
+            return
+        unreachable = (
+            f"{self.server.name} not reachable on {HOST}:{self.server.port} -- "
+            f"{self.server.how_to_start}"
+        )
+        if absent_server_skips(self.server):
+            self.skipTest(unreachable)
+        self.fail(unreachable)
 
     def run_vncdo_ok(self, *args: str) -> subprocess.CompletedProcess:
         result = run_vncdo(self.server, *args)

--- a/tests/unit/test_native_server_gating.py
+++ b/tests/unit/test_native_server_gating.py
@@ -1,0 +1,124 @@
+"""tests.functional.utils is imported for the skip/fail rule alone: it needs
+no server and starts no reactor.
+"""
+from __future__ import annotations
+
+import unittest
+from typing import Dict, List, Mapping, Tuple
+
+from tests.functional.utils import (
+    DOCKER_SERVERS,
+    VNCEV,
+    VNCServer,
+    absent_server_skips,
+    os_servers,
+    running_in_ci,
+)
+
+ENV_SAMPLES: Dict[str, Tuple[Mapping[str, str], bool]] = {
+    "unset": ({}, False),
+    "CI_empty": ({"CI": ""}, False),
+    "CI_false": ({"CI": "false"}, False),
+    "CI_0": ({"CI": "0"}, False),
+    "GITHUB_ACTIONS_false": ({"GITHUB_ACTIONS": "false"}, False),
+    "CI_true": ({"CI": "true"}, True),
+    "CI_1": ({"CI": "1"}, True),
+    "GITHUB_ACTIONS_true": ({"GITHUB_ACTIONS": "true"}, True),
+    "both": ({"CI": "true", "GITHUB_ACTIONS": "true"}, True),
+}
+
+# Linux's OS-hosted server is registered only when the QEMU setup script has
+# exported its opt-in, so os_servers("linux") is empty here and there is
+# nothing to generate a case from.
+NATIVE_PLATFORMS = ("darwin", "win32")
+
+NEVER_SKIPPING = DOCKER_SERVERS + [VNCEV]
+
+
+def native_servers() -> List[Tuple[str, VNCServer]]:
+    return [(platform, server) for platform in NATIVE_PLATFORMS for server in os_servers(platform)]
+
+
+class CIDetection:
+    env: Mapping[str, str]
+    is_ci: bool
+
+    def test_says_whether_this_is_ci(self) -> None:
+        self.assertEqual(running_in_ci(self.env), self.is_ci)  # type: ignore[attr-defined]
+
+
+class NativeServerVerdict:
+    server: VNCServer
+    env: Mapping[str, str]
+    is_ci: bool
+
+    def test_skips_only_off_ci(self) -> None:
+        self.assertEqual(  # type: ignore[attr-defined]
+            absent_server_skips(self.server, self.env),
+            not self.is_ci,
+            f"{self.server.name} absent: a CI run must report a failure, a "
+            "developer's run a skip",
+        )
+
+
+class ContainerServerVerdict:
+    server: VNCServer
+    env: Mapping[str, str]
+
+    def test_never_skips(self) -> None:
+        self.assertFalse(  # type: ignore[attr-defined]
+            absent_server_skips(self.server, self.env),
+            f"{self.server.name} is started by `make servers-up`, so a run "
+            "without it must fail rather than pass as green",
+        )
+
+
+class TestNativeServersAreRegistered(unittest.TestCase):
+    def test_every_supported_platform_has_one(self) -> None:
+        for platform in NATIVE_PLATFORMS:
+            self.assertTrue(
+                os_servers(platform),
+                f"no OS-hosted server registered for {platform}, so the cases "
+                "generated below assert nothing",
+            )
+
+
+def _case(name: str, body: type, attrs: Dict[str, object], method: str) -> unittest.TestCase:
+    return type(name, (body, unittest.TestCase), attrs)(method)
+
+
+def load_tests(loader: unittest.TestLoader, tests: unittest.TestSuite, pattern: object) -> unittest.TestSuite:
+    suite = unittest.TestSuite()
+    suite.addTests(loader.loadTestsFromTestCase(TestNativeServersAreRegistered))
+    for env_name, (env, is_ci) in ENV_SAMPLES.items():
+        suite.addTest(
+            _case(
+                f"TestCIDetection_{env_name}",
+                CIDetection,
+                {"env": env, "is_ci": is_ci},
+                "test_says_whether_this_is_ci",
+            )
+        )
+        for platform, server in native_servers():
+            suite.addTest(
+                _case(
+                    f"TestNativeVerdict_{platform}_{server.name.replace('-', '_')}_{env_name}",
+                    NativeServerVerdict,
+                    {"server": server, "env": env, "is_ci": is_ci},
+                    "test_skips_only_off_ci",
+                )
+            )
+        for server in NEVER_SKIPPING:
+            suite.addTest(
+                _case(
+                    f"TestContainerVerdict_{server.name.replace('-', '_')}_{env_name}",
+                    ContainerServerVerdict,
+                    {"server": server, "env": env},
+                    "test_never_skips",
+                )
+            )
+    return suite
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The OS-native server tests (Screen Sharing, UltraVNC, QEMU) are set up by `os-servers.yml` and nothing else, so they failed on every local `make test-func`. They now skip off CI and fail on it, keyed off `CI`/`GITHUB_ACTIONS` rather than a flag a developer has to remember. The exception is scoped to those servers alone — `skip_when_down` is set only by the `os_server()` factory — so a stopped Docker fleet still fails everywhere.

Not obvious from the diff: a runner setting neither variable never reaches the decision, because the workflow's `wait_for_servers.py` step already exits non-zero when the server isn't serving.

Beyond CI: `make test-func` with the fleet up gives `Ran 72 ... OK (skipped=4)`, and the native module under `CI=true` gives 4 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
