### PR TITLE
Tag the fleet image by everything the Dockerfile copies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         run: uv sync --locked
 
       - name: Resolve the fleet image tag
-        run: echo "FLEET_TAG=$(git rev-parse HEAD:tests/servers)" >> "$GITHUB_ENV"
+        run: echo "FLEET_TAG=$(tests/servers/fleet-tag.sh)" >> "$GITHUB_ENV"
 
       - name: Fetch or build the VNC test servers
         run: |

--- a/tests/servers/fleet-tag.sh
+++ b/tests/servers/fleet-tag.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# A `COPY --from=` source is a path inside that build stage, not in this
+# tree; a leading `--chown=`/`--chmod=` is a flag, not a source.
+paths=(servers)
+while IFS= read -r path; do
+    paths+=("$path")
+done < <(
+    awk '$1 == "COPY" {
+             for (i = 2; i <= NF; i++) if ($i ~ /^--from=/) next
+             for (i = 2; i < NF; i++) if ($i !~ /^--/) print $i
+         }' servers/Dockerfile | sed 's:/*$::' | sort -u
+)
+
+revs=$(git rev-parse "${paths[@]/#/HEAD:./}")
+printf '%s\n' "$revs" | git hash-object --stdin


### PR DESCRIPTION
`FLEET_TAG` was `git rev-parse HEAD:tests/servers`, but the image's build context is `tests/` and the Dockerfile also copies `tests/goldens/`. A scene edit left the tag unchanged, so CI pulled the image published from main and served the old scenes — PR #465 lost 28 functional tests to pixel mismatches that named nothing about a stale image.

`tests/servers/fleet-tag.sh` reads the COPY sources out of the Dockerfile and digests their tree hashes, so a new COPY cannot be added without the tag following it. `make servers-up` still leaves `FLEET_TAG` unset and resolves to `:dev`.

Verified the tag changes for an edit to a scene PNG, to `scene_player.py` and to `tests/servers/`, and is stable otherwise. `make test-func` passes locally against a fleet whose copied files match this checkout (72 tests, the 4 OS-native ones skipped off CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
