### PR TITLE
Dispatch drag on equality, not substring containment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@
   - Fix ``vnclog`` reporting an ``AttributeError`` traceback in place of the reason its own decoder gave up on a session, then carrying on against a stream it had abandoned (@sibson)
   - Fix a malformed or unsupported server response (bad header, unknown security/auth type, connection refused, unknown message, unrecognized rectangle encoding) parsing further buffered bytes as if they were valid protocol data before the connection closed, instead of stopping immediately (@sibson)
   - A ``ServerFence`` no longer ends the session as an unknown message; the client answers it. The ``PSEUDO_FENCE`` encoding is not offered, so a server sends one only unprompted, and ``VNCDoToolFactory.fence = True`` opts in (@sibson, based on @TeofilisMartisius's #323)
+  - Fix any substring of ``drag`` -- ``d``, ``ra``, ``dra`` -- being accepted as the ``drag`` command and consuming its two arguments, instead of being reported as an unknown command (@sibson)
   - Fix ``self.width``/``self.height`` staying at the negotiated size after a server sends ``PSEUDO_DESKTOP_SIZE`` mid-session (@sibson)
   - Fix ``VNCLoggingServerProxy.connectionLost`` rejecting the no-argument call ``Protocol.connectionLost`` promises callers (@sibson)
   - Dependency resolution ignores releases younger than a week, so a compromised upload has to survive public scrutiny before it can reach a build here (@sibson)

--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -174,6 +174,14 @@ class TestBuildCommandList(unittest.TestCase):
         self.call_build_commands_list('drag 100 200')
         self.assertCalled(self.client.mouseDrag, 100, 200)
 
+    def test_drag_rejects_a_prefix_of_itself(self) -> None:
+        with self.assertRaises(command.CommandParseError):
+            self.call_build_commands_list('dra 100 200')
+
+    def test_drag_rejects_an_infix_of_itself(self) -> None:
+        with self.assertRaises(command.CommandParseError):
+            self.call_build_commands_list('ra 100 200')
+
     def test_insert_delay(self) -> None:
         self.call_build_commands_list('click 1 key a', delay=100)
         expected = [

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -302,7 +302,7 @@ def build_command_list(
         elif cmd in ("pause", "sleep"):
             duration = float(args.pop(0)) / warp
             factory.deferred.addCallback(client.pause, duration)
-        elif cmd in "drag":
+        elif cmd == "drag":
             x, y = int(args.pop(0)), int(args.pop(0))
             factory.deferred.addCallback(client.mouseDrag, x, y)
         elif os.path.isfile(cmd):


### PR DESCRIPTION
`elif cmd in "drag"` was a substring test, not an equality test, so `vncdo d 10 10`, `vncdo ra 10 10` and `vncdo dra 10 10` all ran a mouse drag and swallowed two arguments instead of reporting an unknown command. `git log -S` shows the line was born that way in 198a4bc; black only reformatted it, and the usage text documents only `drag X Y`, so no alias was intended.

Two regression tests in `test_command.py` cover a prefix and an infix of `drag`; both fail against the old line with "CommandParseError not raised". Every other `in` in `command.py` is a real tuple or a genuine membership test.

The CHANGELOG entry carries no issue number — say the word if one exists and I will add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
