### PR TITLE
Name the checkout a fleet container was built from

### DIFF
--- a/specs/testing-framework.md
+++ b/specs/testing-framework.md
@@ -55,6 +55,18 @@ matrix. A reduced capability model survives on the server descriptors
 (`renders_desktop`, `known_size`, auth fields) to drive honest skips —
 e.g. macOS Screen Sharing's black framebuffer.
 
+**Fleet identity**: the fleet is machine-global — fixed ports 5931-5935 and
+one compose project — while checkouts are many, and the Dockerfile bakes
+committed files (the scene PNGs, `scene_player.py`, the entrypoints) into
+its images. So a checkout that never ran `make servers-up` tests against
+whichever checkout did, reading that checkout's baked files back off the
+wire as if they were its own. `tests/servers/fleet-tag.sh` hashes the
+Dockerfile's COPY inputs; `servers.mk` tags the images with it, and
+`fleet_mismatch()` in `tests/functional/utils.py` reads the tag back off
+the running container, so the mismatch fails by name in `servers-up` and in
+the tests that depend on baked content. The hash is of `HEAD`, so a fleet
+built from uncommitted edits to those files tags as the commit it sits on.
+
 **Execution model**: every fleet scenario runs the real CLI via
 `subprocess.run(["vncdo", ...], timeout=N)`.
 

--- a/tests/functional/test_scene_player.py
+++ b/tests/functional/test_scene_player.py
@@ -9,13 +9,14 @@ from PIL import Image
 
 from tests.goldens import scenes
 
-from .utils import TIGERVNC, port_open, HOST, run_vncdo
+from .utils import TIGERVNC, assert_fleet_current, port_open, HOST, run_vncdo
 
 
 class TestScenePlayer(TestCase):
     def setUp(self) -> None:
         if not port_open(HOST, TIGERVNC.port):
             self.fail(f"{TIGERVNC.name} is not listening on {TIGERVNC.port}; {TIGERVNC.how_to_start}")
+        assert_fleet_current(self, TIGERVNC)
 
     def _capture(self, *args: str) -> Image.Image:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -56,6 +56,12 @@ VNCLOG_CAPTURE_DEADLINE = 60.0
 
 DEFAULT_SCREENSHOT_DIR = Path(__file__).resolve().parents[1] / "servers" / "screenshots"
 
+# `name:` in tests/servers/docker-compose.yml, and so the prefix compose
+# gives every container it starts from that file.
+FLEET_PROJECT = "vncdo-test-servers"
+FLEET_TAG_SCRIPT = Path(__file__).resolve().parents[1] / "servers" / "fleet-tag.sh"
+FLEET_PROBE_TIMEOUT = 30.0
+
 PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 # getcolors() returns None above this many distinct colours, which is itself
 # proof the capture isn't a flat colour, so the cap only needs to be cheap.
@@ -188,6 +194,57 @@ def running_in_ci(env: Optional[Mapping[str, str]] = None) -> bool:
 
 def absent_server_skips(server: VNCServer, env: Optional[Mapping[str, str]] = None) -> bool:
     return server.skip_when_down and not running_in_ci(env)
+
+
+def fleet_tag() -> Optional[str]:
+    """The tag this checkout's fleet images are built under, or None.
+
+    fleet-tag.sh reads the git object store, so a tree unpacked without
+    one has no tag to give.
+    """
+    try:
+        result = subprocess.run(
+            [str(FLEET_TAG_SCRIPT)], capture_output=True, text=True, timeout=FLEET_PROBE_TIMEOUT
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return result.stdout.strip() or None if result.returncode == 0 else None
+
+
+def running_fleet_tag(server: VNCServer) -> Optional[str]:
+    """The tag of the image `server`'s container was started from, or None."""
+    container = f"{FLEET_PROJECT}-{server.name}-1"
+    try:
+        result = subprocess.run(
+            ["docker", "inspect", "--format", "{{.Config.Image}}", container],
+            capture_output=True,
+            text=True,
+            timeout=FLEET_PROBE_TIMEOUT,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    _, _, tag = result.stdout.strip().rpartition(":")
+    return tag or None
+
+
+def fleet_mismatch(server: VNCServer) -> Optional[str]:
+    """Why `server` is not this checkout's fleet, or None if it is or may be."""
+    expected, running = fleet_tag(), running_fleet_tag(server)
+    if expected is None or running is None or expected == running:
+        return None
+    return (
+        f"{server.name} is running image tag {running!r}, but this checkout's server sources "
+        f"hash to {expected!r}: the fleet was started from a different checkout and serves "
+        f"that checkout's files. Run `make servers-down && make servers-up`."
+    )
+
+
+def assert_fleet_current(test: TestCase, server: VNCServer) -> None:
+    mismatch = fleet_mismatch(server)
+    if mismatch is not None:
+        test.fail(mismatch)
 
 
 def screenshot_dir() -> Path:

--- a/tests/functional/wait_for_servers.py
+++ b/tests/functional/wait_for_servers.py
@@ -14,7 +14,7 @@ _HERE = Path(__file__).resolve().parent
 # script works from a checkout without vncdotool having been pip installed.
 sys.path[:0] = [str(_HERE), str(_HERE.parents[1])]
 
-from utils import select_servers, wait_until_ready  # noqa: E402
+from utils import fleet_mismatch, select_servers, wait_until_ready  # noqa: E402
 
 from vncdotool import api  # noqa: E402
 
@@ -23,11 +23,16 @@ DEFAULT_GROUP = "os"
 
 def main(argv: List[str]) -> int:
     group = argv[1] if len(argv) > 1 else DEFAULT_GROUP
-    ready = [wait_until_ready(server) for server in select_servers(group)]
+    servers = select_servers(group)
+    ready = [wait_until_ready(server) for server in servers]
 
     api.shutdown()  # the reactor thread outlives its clients; this script hangs without it
 
-    return 0 if all(ready) else 1
+    mismatches = [message for message in (fleet_mismatch(server) for server in servers) if message]
+    for message in mismatches:
+        print(message)
+
+    return 0 if all(ready) and not mismatches else 1
 
 
 if __name__ == "__main__":

--- a/tests/servers/servers.mk
+++ b/tests/servers/servers.mk
@@ -5,6 +5,11 @@ SCREENSHOT_DIR?=tests/servers/screenshots
 # tests/functional/utils.py.
 SCREENSHOT_GROUP?=docker
 
+# Per-checkout image tags, so a container another checkout started is visibly
+# not this one's -- see "Fleet identity" in specs/testing-framework.md.
+FLEET_TAG?=$(shell tests/servers/fleet-tag.sh)
+servers-up servers-down: export FLEET_TAG:=$(FLEET_TAG)
+
 # `up --wait` only gets as far as the containers' HEALTHCHECK, which is
 # liveness: the port is bound. wait_for_servers.py is the readiness gate --
 # it captures until each server serves the content it should, the same


### PR DESCRIPTION
`test_scene_player.py` failed with `read_patch()` returning None for every scene key, against a fleet whose player process was alive and responding. The container was serving scene PNGs from an image built before 9608b55 swapped the colour patch for a glyph.

One machine has one fleet — fixed ports, one compose project — and many worktrees: whichever last ran `make servers-up` bakes its own files into the images, and every other checkout reads them back off the wire as its own.

`fleet-tag.sh` already hashes the Dockerfile's COPY inputs, but only CI used it. `servers.mk` now tags local images with it too, so the running container's tag is an assertion about its contents; `utils.py` reads it back and fails by name instead of as an unreadable patch.

Tested locally, which CI does not do: the full functional suite (76 OK) and 300 scene keys with the player surviving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
