### PR TITLE
Add Vale prose linting for docs and specs

### DIFF
--- a/.claude/skills/writing-code-comments/SKILL.md
+++ b/.claude/skills/writing-code-comments/SKILL.md
@@ -293,13 +293,13 @@ to "why isn't it the other way" is journey, not documentation.
 Watch the line count across a branch. A doc that doubles while the code it
 describes gets simpler is recording the work, not the result.
 
-**Run `make prose-lint` first.** It checks `docs/*.rst` and `README.rst` with
-Vale — sentence mechanics a content sweep won't catch on its own: doubled
-spaces, missing Oxford commas, first-person plural ("we"/"us"), "will"-future
-tense, and a project word-list (say "app", not "application"). Fix what it
-flags before running the judgement sweep below; Vale doesn't know which facts
-are load-bearing, so it can't replace Mode B, only clear the mechanical noise
-out of its way.
+**Run the repo's prose linter first, if it has one.** Check for a `.vale.ini`
+or a `make`/CI target that runs it before sweeping docs. A linter like Vale
+catches sentence mechanics a content sweep won't: doubled spaces, missing
+Oxford commas, first-person plural ("we"/"us"), "will"-future tense, a
+project word-list. Fix what it flags before the judgement sweep below — it
+doesn't know which facts are load-bearing, so it clears mechanical noise out
+of Mode B's way, not a substitute for it.
 
 **A doc gets the same verdicts as a comment.** Sweep it with Mode B, including
 step 0, and read every row of the Quick reference against it: a paragraph that

--- a/.claude/skills/writing-code-comments/SKILL.md
+++ b/.claude/skills/writing-code-comments/SKILL.md
@@ -293,6 +293,14 @@ to "why isn't it the other way" is journey, not documentation.
 Watch the line count across a branch. A doc that doubles while the code it
 describes gets simpler is recording the work, not the result.
 
+**Run `make prose-lint` first.** It checks `docs/*.rst` and `README.rst` with
+Vale — sentence mechanics a content sweep won't catch on its own: doubled
+spaces, missing Oxford commas, first-person plural ("we"/"us"), "will"-future
+tense, and a project word-list (say "app", not "application"). Fix what it
+flags before running the judgement sweep below; Vale doesn't know which facts
+are load-bearing, so it can't replace Mode B, only clear the mechanical noise
+out of its way.
+
 **A doc gets the same verdicts as a comment.** Sweep it with Mode B, including
 step 0, and read every row of the Quick reference against it: a paragraph that
 narrates the code is a delete in `specs/` exactly as it is in the file it

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ combined/
 .tox
 docs/_build
 docs/rfbproto/
+docs/vale/styles/
 .venv/
 .vncdo/
 

--- a/.vale.ini
+++ b/.vale.ini
@@ -10,3 +10,8 @@ Google.Headings = NO
 [README.rst]
 BasedOnStyles = Google
 Google.Headings = NO
+
+[specs/*.md]
+BasedOnStyles = Google
+Google.Headings = NO
+Google.Colons = NO

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,12 @@
+StylesPath = docs/vale/styles
+MinAlertLevel = warning
+
+Packages = Google
+
+[docs/*.rst]
+BasedOnStyles = Google
+Google.Headings = NO
+
+[README.rst]
+BasedOnStyles = Google
+Google.Headings = NO

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ help:
 	@echo "bench-report:	tabulate bench.jsonl, or diff two runs' call counts"
 	@echo "coverage:	run both suites under coverage and report"
 	@echo "docs:		build documentation"
+	@echo "prose-lint:	check docs/*.rst and README.rst with vale"
 	@echo "release:	tag and push current version to trigger PyPI release"
 
 VERSION := $(shell uv version --bump stable --dry-run --short --no-sync 2>/dev/null)
@@ -72,6 +73,11 @@ test-func:
 .PHONY: typecheck
 typecheck:
 	uv run mypy vncdotool
+
+.PHONY: prose-lint
+prose-lint:
+	vale sync
+	uv run vale docs/*.rst README.rst
 
 include tests/servers/servers.mk
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ help:
 	@echo "bench-report:	tabulate bench.jsonl, or diff two runs' call counts"
 	@echo "coverage:	run both suites under coverage and report"
 	@echo "docs:		build documentation"
-	@echo "prose-lint:	check docs/*.rst and README.rst with vale"
+	@echo "prose-lint:	check docs, README, and specs with vale"
 	@echo "release:	tag and push current version to trigger PyPI release"
 
 VERSION := $(shell uv version --bump stable --dry-run --short --no-sync 2>/dev/null)
@@ -77,7 +77,7 @@ typecheck:
 .PHONY: prose-lint
 prose-lint:
 	vale sync
-	uv run vale docs/*.rst README.rst
+	uv run vale docs/*.rst README.rst specs/*.md
 
 include tests/servers/servers.mk
 

--- a/README.rst
+++ b/README.rst
@@ -34,8 +34,8 @@ It's under active development and seems to be working, but please report any pro
 
 Quick Start
 --------------------------------
-To use vncdotool you will need a VNC server.
-Most virtualization products include one, or use RealVNC, TightVNC or clone your Desktop using x11vnc.
+To use vncdotool you need a VNC server.
+Most virtualization products include one, or use RealVNC, TightVNC, or clone your Desktop using x11vnc.
 
 Once, you have a server running you can install vncdotool from pypi::
 

--- a/docs/capture.rst
+++ b/docs/capture.rst
@@ -1,8 +1,8 @@
 Capturing a session for a bug report
 =====================================
 
-vncdotool is tested against the servers we can run ourselves (see
-``tests/servers/``). If you hit a bug against a server we can't host --
+vncdotool is tested against the servers that can be run locally (see
+``tests/servers/``). If you hit a bug against a server that can't be hosted --
 RealVNC, Proxmox, a vendor's embedded VNC implementation, whatever -- the
 most useful thing you can attach to the issue is a *capture*: a recording of
 the raw bytes vncdotool exchanged with that server while reproducing the

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -2,67 +2,67 @@ Command Reference
 ====================
 
 A ``vncdo`` invocation is a list of commands, run in order against one
-connection.  Each command consumes the arguments that follow it, so several
+connection. Each command consumes the arguments that follow it, so several
 can be written on a single line::
 
     > vncdo move 100 100 click 1 type hello key enter
 
 ``--delay MILLISECONDS`` pauses between commands, and between the individual
-keypresses of ``type`` and ``typefile``.  ``--warp FACTOR`` divides the
-duration of every ``pause``.  A command that fails ends the session at that
+keypresses of ``type`` and ``typefile``. ``--warp FACTOR`` divides the
+duration of every ``pause``. A command that fails ends the session at that
 point; see :ref:`the exit status table <exit-status>` for what the codes mean.
 
 capture FILENAME
 ----------------------
 
-Save the whole screen to FILENAME.  The extension chooses the image format
+Save the whole screen to FILENAME. The extension chooses the image format
 and must be one of ``png``, ``jpg``, ``jpeg``, ``gif`` or ``bmp``; anything
-else is rejected before connecting, exit 2.  A path that cannot be written
-exits 30.  Needs Pillow_.
+else is rejected before connecting, exit 2. A path that cannot be written
+exits 30. Needs Pillow_.
 
 click BUTTON
 --------------
 
 Press and release mouse BUTTON, a number from 1, at the pointer's current
-position.  The position is whatever a previous ``move`` set, and starts at
+position. The position is whatever a previous ``move`` set, and starts at
 (0, 0): a ``click`` with no ``move`` before it clicks the top-left corner.
 
 drag X Y
 -----------
 
 Move the pointer to X,Y one pixel at a time, pausing 0.2 seconds between
-steps, so a server sees a drag rather than a jump.  The pause is not scaled by
+steps, so a server sees a drag rather than a jump. The pause is not scaled by
 ``--warp``, so a long drag takes a long time -- 200 pixels is 40 seconds.
 
 expect FILENAME [FUZZ]
 ----------------------------
 
-Wait until the screen matches the image in FILENAME.  Only screens the same
+Wait until the screen matches the image in FILENAME. Only screens the same
 size as the image can match.
 
 FUZZ is how far any one pixel may sit from the target, a whole number from 0
-(exact, the common case) to 255, measured as a perceived colour difference
-where 255 is the furthest two pixels can be apart.  Left out, the bound is
+(exact, the common case) to 255, measured as a perceived color difference
+where 255 is the furthest two pixels can be apart. Left out, the bound is
 whatever the negotiated pixel format cannot express, so a server sending
-5-bit red is not waited on to reproduce an 8-bit value.  ``--expect-fuzz``
-sets the same bound for every ``expect``.  A FUZZ that is not a whole number
+5-bit red is not waited on to reproduce an 8-bit value. ``--expect-fuzz``
+sets the same bound for every ``expect``. A FUZZ that is not a whole number
 in 0..255 exits 2; a trailing argument that is not a number at all is read as
 the next command rather than reported.
 
 Without ``--timeout`` a screen that never matches waits forever; with one,
-the wait ends at ``TIMEOUT`` seconds, exit 40.  A target image larger than
-the screen can never match and fails immediately, exit 30.  Needs Pillow_.
+the wait ends at ``TIMEOUT`` seconds, exit 40. A target image larger than
+the screen can never match and fails immediately, exit 30. Needs Pillow_.
 
 key KEY
 ---------
 
-Press and release KEY.  A single character is sent as itself; longer names
-come from the keysym table -- ``enter``, ``tab``, ``del``, ``f1``.  ``-``
+Press and release KEY. A single character is sent as itself; longer names
+come from the keysym table -- ``enter``, ``tab``, ``del``, ``f1``. ``-``
 joins modifiers to a key: ``ctrl-c``, ``shift-a``, ``ctrl-alt-del``.
 
 Because ``-`` is the separator, a hyphen as part of a combination has to be
 written ``minus``: ``key -`` sends a hyphen, but ``key ctrl--`` is an error
-and ``key ctrl-minus`` is what to write.  An unrecognised name is not
+and ``key ctrl-minus`` is what to write. An unrecognised name is not
 reported; each part of it is sent as a literal character.
 
 ``--force-caps`` sends capitals as ``shift-LETTER``, for servers that
@@ -71,73 +71,73 @@ otherwise type them lowercase.
 keydown KEY, kdown KEY
 --------------------------
 
-Press KEY and leave it held.  Nothing releases it but a matching ``keyup``
+Press KEY and leave it held. Nothing releases it but a matching ``keyup``
 or the end of the session, so a held modifier applies to every command after
-it.  ``kdown`` is an alias.
+it. ``kdown`` is an alias.
 
 keyup KEY, kup KEY
 -----------------------
 
-Release KEY.  Releasing a key that was never pressed is sent to the server
-like any other event, and most servers ignore it.  ``kup`` is an alias.
+Release KEY. Releasing a key that was never pressed is sent to the server
+like any other event, and most servers ignore it. ``kup`` is an alias.
 
 mousedown BUTTON, mdown BUTTON
 ----------------------------------
 
 Press mouse BUTTON at the current position and leave it held, for dragging or
-for chording with ``drag``.  ``mdown`` is an alias.
+for chording with ``drag``. ``mdown`` is an alias.
 
 mouseup BUTTON, mup BUTTON
 --------------------------------
 
-Release mouse BUTTON at the current position.  ``mup`` is an alias.
+Release mouse BUTTON at the current position. ``mup`` is an alias.
 
 move X Y, mousemove X Y
 --------------------------
 
-Move the pointer to X,Y in one step.  This is the position ``click``,
-``mousedown``, ``mouseup`` and ``drag`` work from.  ``mousemove`` is an alias.
+Move the pointer to X,Y in one step. This is the position ``click``,
+``mousedown``, ``mouseup`` and ``drag`` work from. ``mousemove`` is an alias.
 
 pastefile FILENAME
 ----------------------
 
 Send the contents of FILENAME to the server's clipboard in one message,
 rather than as keypresses -- much faster than ``typefile`` for a large body of
-text, and it needs the far side to paste.  CRLF line endings are converted to
-LF.  The text is encoded Latin-1, as RFB requires, so a character outside it
-fails.  ``-`` reads from stdin.  A server is free to ignore the message, and
+text, and it needs the far side to paste. CRLF line endings are converted to
+LF. The text is encoded Latin-1, as RFB requires, so a character outside it
+fails. ``-`` reads from stdin. A server is free to ignore the message, and
 nothing reports that it did.
 
 pause SECONDS, sleep SECONDS
 --------------------------------
 
-Wait SECONDS, which may be fractional, before the next command.  ``--warp
+Wait SECONDS, which may be fractional, before the next command. ``--warp
 FACTOR`` divides it, so ``--warp 2`` halves every pause in a script.
 ``sleep`` is an alias.
 
 rcapture FILENAME X Y W H
 ------------------------------
 
-Save the W by H region of the screen at X,Y to FILENAME.  Formats and write
-failures are as for ``capture``.  The region must lie on the screen: one that
+Save the W by H region of the screen at X,Y to FILENAME. Formats and write
+failures are as for ``capture``. The region must lie on the screen: one that
 runs off an edge, or that a mid-session desktop resize leaves off the screen,
-fails with a message naming the region and the screen size, exit 30.  Needs
+fails with a message naming the region and the screen size, exit 30. Needs
 Pillow_.
 
 rexpect FILENAME X Y [FUZZ]
 --------------------------------
 
 Wait until the region of the screen at X,Y matches the image in FILENAME.
-The region is the size of that image, so only X and Y are given.  FUZZ, the
+The region is the size of that image, so only X and Y are given. FUZZ, the
 default bound and the timeout behaviour are as for ``expect``, and an
-off-screen region fails as for ``rcapture``, exit 30.  Needs Pillow_.
+off-screen region fails as for ``rcapture``, exit 30. Needs Pillow_.
 
 rstable SECONDS X Y W H [FUZZ]
 ------------------------------------
 
-Wait until the W by H region of the screen at X,Y stops changing.  SECONDS,
+Wait until the W by H region of the screen at X,Y stops changing. SECONDS,
 FUZZ and the timeout behaviour are as for ``stable``, and an off-screen
-region fails as for ``rcapture``, exit 30.  Needs Pillow_.
+region fails as for ``rcapture``, exit 30. Needs Pillow_.
 
 Waiting on a region is the way past a server that never goes quiet: exclude
 the clock or the blinking cursor, and the rest of the screen can settle.
@@ -145,35 +145,35 @@ the clock or the blinking cursor, and the rest of the screen can settle.
 stable SECONDS [FUZZ]
 ---------------------------
 
-Wait until the screen has gone SECONDS without changing.  Each framebuffer
+Wait until the screen has gone SECONDS without changing. Each framebuffer
 update is compared against the one before it, and one that differs by more
 than FUZZ starts the wait again.
 
-FUZZ is the bound ``expect`` takes, on the same scale and with the same
-default, measured here between successive frames rather than against a file;
-``--expect-fuzz`` and ``--expect-blur`` apply to both.
+FUZZ uses the same scale and default as ``expect``, measured here between
+successive frames rather than against a file; ``--expect-fuzz`` and
+``--expect-blur`` apply to both.
 
 The wait takes at least SECONDS, because the absence of a change cannot be
 observed before the window has passed, and longer whenever a late update
-restarts it.  A screen that changes more often than that never settles: with
+restarts it. A screen that changes more often than that never settles: with
 ``--timeout`` the run ends at ``TIMEOUT`` seconds, exit 40, and without one it
-waits forever.  Needs Pillow_.
+waits forever. Needs Pillow_.
 
 type TEXT
 --------------
 
-Send TEXT as one keypress per character, with ``--delay`` between them.  Only
+Send TEXT as one keypress per character, with ``--delay`` between them. Only
 characters that stand for themselves are sent: there is no way to write a
-newline or a tab, and a literal ``-`` is sent as ``minus``.  Use ``key`` for
+newline or a tab, and a literal ``-`` is sent as ``minus``. Use ``key`` for
 anything else, or ``typefile`` for text that has line breaks in it.
 
 typefile FILENAME
 ----------------------
 
 Type out the contents of FILENAME as keypresses, as ``type`` does, with
-``--delay`` between them.  Newlines are sent as ``enter``, tabs as ``tab``,
+``--delay`` between them. Newlines are sent as ``enter``, tabs as ``tab``,
 ``-`` as ``minus``, and carriage returns are dropped, so a CRLF file types the
-same as an LF one.  ``-`` reads from stdin.  Slow for anything large;
+same as an LF one. ``-`` reads from stdin. Slow for anything large;
 ``pastefile`` sends the same text in one message.
 
 Reading commands from a file or stdin
@@ -186,7 +186,7 @@ commands on the same line::
     > vncdo login.vdo capture after-login.png
 
 The file is split like a shell command line: quotes group an argument, and
-``#`` begins a comment that runs to the end of the line.  Line breaks are
+``#`` begins a comment that runs to the end of the line. Line breaks are
 whitespace, so a script may be written one command per line or all on one.
 
 A lone ``-`` reads commands from stdin instead::

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,7 +1,7 @@
 Contributing
 =============
 
-Code and Issue tracking is provided by Github_.  There is also a mailing list setup via `Google Groups`_.
+Code and Issue tracking is provided by Github_. There is also a mailing list setup via `Google Groups`_.
 
 
 .. _Github: https://github.com/sibson/vncdotool

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -16,20 +16,20 @@ If you are not familiar with Python, the most reliable way to install vncdotool 
 
 
     1. Download Python, current 64-bit Windows Version, from `Official Python`_ website https://www.python.org/downloads/
-    2. Start the installation > On the first screen of the installer...
+    2. Start the installation > On the first screen of the installer:
 
-        - Check the box for "Add Python to PATH", 
+        - Check the box for "Add Python to PATH,"
         - Any other check boxes can be left checked or unchecked per their default
         - Click "Customize installation"
         - On the Optional Features install page, no changes are needed
-        - On the Advanced Options page...
+        - On the Advanced Options page:
             - Make sure the boxes for "Install for all users" and "Add Python to environment variables" are checked
-            - Uncheck "Precompile standard library" unless needed for other projects
+            - Clear "Precompile standard library" unless needed for other projects
             - Any other check boxes can be left checked or unchecked per their default
         - Click "Install" at the bottom
     3. Open an elevated Windows PowerShell console:
         - Type "PowerShell" (without quotes) in the search field of the Windows taskbar
-        - Click "Run as administrator" in the right pane above the search field
+        - Click "Run as administrator" in the right pane preceding the search field
         - Type or paste each of the following lines below, pressing Enter after each line and waiting for each line to process (change “Python39” to different version as applicable)::
 
             [Environment]::SetEnvironmentVariable("Path", "$env:Path;C:\Program Files\Python39\;C:\Program Files\Python39\Scripts\", "User")

--- a/docs/library.rst
+++ b/docs/library.rst
@@ -1,26 +1,26 @@
 Embedding in Python Applications
 ===================================
 vncdotool is built with the Twisted_ framework, as such it best integrates with other Twisted Applications.
-Rewriting your application to use Twisted may not be an option, so vncdotool provides a compatibility layer.
+Rewriting your app to use Twisted may not be an option, so vncdotool provides a compatibility layer.
 It uses a separate thread to run the Twisted reactor and communicates with the main program using a thread-safe Queue.
 
 ..  note::
 
     The compatibility layer is designed for exactly two threads: one
-    application thread holding one client, and the single reactor thread
+    app thread holding one client, and the single reactor thread
     vncdotool starts for it.
-    Using clients from more than one application thread, or sharing one
+    Using clients from more than one app thread, or sharing one
     client between threads, is not supported -- see `issue #192
     <https://github.com/sibson/vncdotool/issues/192>`_.
 
 ..  warning::
 
-    While the Twisted reactor runs as a *daemon* thread, the reactor itself will start additional *worker threads*, which are *no daemon threads*.
+    While the Twisted reactor runs as a *daemon* thread, the reactor itself starts additional *worker threads*, which are *no daemon threads*.
     Therefore the Reactor must be shut down explicitly by calling :func:`vncdotool.api.shutdown`.
-    Otherwise your application will not terminate as those worker threads remain running in the background.
+    Otherwise your app does not stop, as those worker threads remain running in the background.
 
     This also applied when using the API as a context manager:
-    As the reactor cannot be restarted, it is a design decision to not shut it down as the end of the context.
+    as the reactor cannot be restarted, it is a design decision to not shut it down as the end of the context.
     That would prevent the API from being used multiple times in the same process.
 
 To use the synchronous API you can do the following::
@@ -41,7 +41,7 @@ For example::
     client = api.connect('myvncserver.com::5902', password=None)
 
 You can then call any of the methods available on
-:class:`vncdotool.client.VNCDoToolClient` and they will block until completion.
+:class:`vncdotool.client.VNCDoToolClient` and they block until completion.
 For example::
 
     client.captureScreen('screenshot.png')
@@ -67,8 +67,7 @@ The :class:`vncdotool.client.VNCDoToolClient` supports the context manager proto
     with api.connect('vnchost:display') as client:
         client.captureScreen('screenshot.png')
 
-
-The synchronous API can be used to automate the starting of a Virtual Machine or other application::
+The synchronous API can be used to automate the starting of a Virtual Machine or other app::
 
     vmtool.start('myvirtualmachine.img')
     client.connect('vmaddress::5950')

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,11 +1,10 @@
 Usage
 ==============
 
-
 Basic Usage
 -------------
 Once installed you can use the vncdotool command to send key-presses.
-Alphanumerics are straightforward just specify the character.  For other
+Alphanumerics are straightforward just specify the character. For other
 keys longer names are used::
 
     > vncdo key a
@@ -75,17 +74,17 @@ scale, so an old one cannot be converted and has to be picked again.
 16 is a reasonable place to start for anything else.
 
 Expect the new bound to be stricter than the old number suggests. A 2x2 patch
-of the screen changing colour scores 126, where the old measurement scored
-0.4 -- histograms record that colours moved, not where or how far.
+of the screen changing color scores 126, where the old measurement scored
+0.4 -- histograms record that colors moved, not where or how far.
 
 Putting it all together you can specify multiple actions on a single
-command line.  You could automate a login with the following::
+command line. You could automate a login with the following::
 
     > vncdo type username key enter expect password_prompt.png
     > vncdo type password move 100 150 click 1 expect welcome_screen.png
 
 When you have no reference image -- because you do not yet know what the
-screen will look like -- wait for the screen to stop changing instead.
+screen looks like -- wait for the screen to stop changing instead.
 ``stable`` takes the length of the quiet window, and returns once the screen
 has gone that long without changing by more than the fuzz::
 
@@ -97,11 +96,11 @@ rather than against a file.
 
 It always takes at least the window you ask for, since there is no way to
 observe the absence of a change early, and longer whenever a late update
-restarts the window.  A screen that never goes quiet -- a clock, a blinking
+restarts the window. A screen that never goes quiet -- a clock, a blinking
 cursor -- never satisfies it, and the run ends when ``--timeout`` fires.
 
 Sometimes you only care about a portion of the screen, in which case you can
-use rcapture, rexpect and rstable. For instance, if your login window appears
+use rcapture, rexpect, and rstable. For instance, if your login window appears
 at x=100, y=200 and is 400 pixels wide by 250 high you could do::
 
     > vncdo rcapture region.png 100 200 400 250
@@ -114,43 +113,41 @@ region that excludes whatever is animating.
 The region has to lie on the screen; :doc:`commands` says what each command
 does with its arguments and how it fails.
 
-
 Encodings
 -------------------
 By default vncdo asks the server for raw pixels: every server can send
-them, and they cost the most bandwidth.  ``--encodings`` offers others, most
+them, and they cost the most bandwidth. ``--encodings`` offers others, most
 preferred first, and the server picks from what you offered::
 
     > vncdo --encodings tight,hextile,raw capture screen.png
 
 Listing several is the usual case, since not every server speaks every
-encoding.  The order is a preference, not an instruction: a server may send
+encoding. The order is a preference, not an instruction: a server may send
 any encoding on your list, and one that has none of them sends raw::
 
     > vncdo --encodings tight capture screen.png
 
 The names are ``raw``, ``copyrect``, ``rre``, ``corre``, ``hextile``,
-``zrle`` and ``tight``.  Tight sends less than raw on ordinary screen
-content.  Three parts of tight are not implemented: the gradient filter,
-TightPNG, and Tight Encoding Without Zlib.  A rectangle using any of them
-ends the session with a message naming what arrived, exiting 20.  The tight
-*security type*, which TightVNC servers want before they will authenticate
+``zrle`` and ``tight``. Tight sends less than raw on ordinary screen
+content. Three parts of tight are not implemented: the gradient filter,
+TightPNG, and Tight Encoding Without Zlib. A rectangle using any of them
+ends the session with a message naming what arrived, exiting 20. The tight
+*security type*, which TightVNC servers want before they authenticate
 you, is not implemented either.
 
-Some tight rectangles can be JPEG, which is lossy.  vncdo decodes one only
+Some tight rectangles can be JPEG, which is lossy. vncdo decodes one only
 if it asked for a JPEG quality level; a rectangle arriving when it did not
-ends the session with a message naming it, exiting 20.  A capture is
-therefore exact unless you request otherwise.  ``--jpeg-quality`` makes the
+ends the session with a message naming it, exiting 20. A capture is
+therefore exact unless you request otherwise. ``--jpeg-quality`` makes the
 request, on the RFB scale of 0 (low) to 9 (high)::
 
     > vncdo --encodings tight --jpeg-quality 8 capture screen.png
-
 
 .. _exit-status:
 
 Exit Status
 -------------------
-vncdo exits 0 when every action completed.  Failures are grouped by cause, so
+vncdo exits 0 when every action completed. Failures are grouped by cause, so
 a script can tell a server that is down from one that rejected the password::
 
     > vncdo -s $HOST -p $PASSWORD type hello
@@ -170,16 +167,15 @@ Code  Meaning
 3     authentication failed, usually a wrong password
 10    could not connect: refused, unreachable, or name lookup failed
 11    connection closed before the actions finished
-20    server spoke something we could not understand
+20    server spoke something vncdo could not understand
 30    an action failed, such as writing a capture to an unwritable path
 40    ``--timeout`` elapsed before the actions finished
 ===== ==================================================================
 
-Single digits are for things you told us: the command line and the
-credentials.  Failures out on the wire are grouped in tens by cause, so
-new codes can be added to a group later.  Match on the group when you
+Single digits are for things you supplied: the command line and the
+credentials. Failures out on the wire are grouped in tens by cause, so
+new codes can be added to a group later. Match on the group when you
 only care about the category.
-
 
 Running Scripts
 -------------------
@@ -200,14 +196,13 @@ You could run it with the following command::
 
     > vncdo login.vdo
 
-
 Creating Scripts
 ------------------
 While you can create scripts by hand it can often be a time consuming process.
 To make the process easier vncdotool provides a log mode that allows a user to 
-record a VNC session to a script which is playable by vncdo.  vnclog act as a
-man-in-the-middle to record the VNC commands you issue with a client. So you
-will have your vnclog connect to your server and your viewer connect to vnclog
+record a VNC session to a script which is playable by vncdo. vnclog act as a
+man-in-the-middle to record the VNC commands you issue with a client. So your
+vnclog connects to your server, and your viewer connects to vnclog
 
     vncviewer ---> vnclog ---> vncserver
 
@@ -225,8 +220,8 @@ to the correct ports::
     > vncviewer localhost:2  # do something and then exit viewer
     > vncdo keylog.vdo
 
-By running with --file-per-client vnclog will create a new file for every
-client connection and record each clients activity.
+By running with --file-per-client, vnclog creates a new file for every
+client connection and records each clients activity.
 This can be useful for quickly recording a number of testcases.::
 
     > vnclog --file-per-client --listen 6000 /tmp

--- a/specs/decoder-architecture.md
+++ b/specs/decoder-architecture.md
@@ -1,14 +1,14 @@
 # Pluggable Decoders
 
 `vncdotool/rfb.py` is 1229 lines and roughly half of it decodes encodings. Every
-encoding we add makes that worse, and Tight is the one users ask for (#264).
+encoding added makes that worse, and Tight is the one users ask for (#264).
 This document proposes an architecture that moves decoders out of `rfb.py`,
 makes each one testable, and lays out the order to build it in.
 
 ## Only Raw works today
 
 `VNCDoToolClient.vncConnectionMade` offers the server `[RAW]` plus the pseudo-encodings, there is no
-CLI flag to change that (#167, #168), and a server may only use an encoding the
+command-line flag to change that (#167, #168), and a server may only use an encoding the
 client asked for. So CopyRect, RRE, CoRRE, Hextile and ZRLE are unreachable in
 normal use. They are compiled, not run.
 
@@ -16,9 +16,9 @@ This shapes everything below:
 
 - The migration is far lower risk than the file size suggests. Only Raw and the
   pseudo-encodings have behaviour worth preserving.
-- Their known defects — CoRRE's missing `f` prefix and `sz`/`end` loop bound,
-  CopyRect's docstring-only `copyRectangle` stub, ZRLE's hardcoded pixel layout
-  — cost users nothing today and fixing them in isolation wins nothing. The win
+- Their known defects (CoRRE's missing `f` prefix and `sz`/`end` loop bound,
+  CopyRect's docstring-only `copyRectangle` stub, ZRLE's hardcoded pixel layout)
+  cost users nothing today and fixing them in isolation wins nothing. The win
   arrives only when an encoding becomes selectable.
 - Therefore selectable encodings, not bug fixes, is the milestone that makes
   this work user-visible.
@@ -32,8 +32,8 @@ arguments. Hextile is six mutually recursive `_handleDecodeHextile*` methods
 passing `(bg, color, x, y, width, height, tx, ty)` between them.
 
 The consequence is that a decoder cannot be driven without an `RFBClient` and a
-working `expect`, so nothing gets tested, so the unreachable code above rotted
-undisturbed. Splitting the file without changing the interface preserves all of
+working `expect`, so nothing gets tested, so the preceding unreachable code
+rotted undisturbed. Splitting the file without changing the interface preserves all of
 that. The interface is the design decision; file layout follows.
 
 ## Requirements
@@ -56,7 +56,7 @@ Stated independently of how. Each design decision should trace to one.
 - **R4** The user can choose which encodings are offered (#167, #168). Without
   this, every encoding except Raw is dead code and none of it can be tested
   end-to-end.
-- **R5** Raw and the pseudo-encodings — the only paths in live use — behave
+- **R5** Raw and the pseudo-encodings, the only paths in live use, behave
   exactly as they do today. The other encodings are carried across as-is,
   bug-for-bug, with no claim that they work; they are not in use, so there is no
   behaviour to regress.
@@ -80,8 +80,8 @@ Stated independently of how. Each design decision should trace to one.
   specified. Render time is recorded per encoding in `bench.jsonl` and must not
   regress against that encoding's own last measurement. It is not compared
   against Raw: the server picks the encoding, and every compressing one costs
-  more than a blit by construction, so the only speed question that is ours is
-  whether our implementation of it got slower.
+  more than a blit by construction, so the only speed question left is whether
+  vncdotool's implementation of it got slower.
 
 **Inherited constraints**
 
@@ -108,7 +108,7 @@ class RawDecoder:
         target.blit(0, 0, target.width, target.height, data)
 ```
 
-`RFBClient` keeps one adapter — the pump — that drives the generator against
+`RFBClient` keeps one adapter, the pump, that drives the generator against
 `expect`: send it bytes, take the yielded count, park with `expect`, repeat until
 `StopIteration`.
 
@@ -126,7 +126,7 @@ Two alternatives rejected. Keeping continuation-passing and merely moving method
 into decoder classes is a file split dressed as an architecture: the tangle
 survives and decoders still reach into `client.bypp`, `client._zlib_stream` and
 `client._doConnection`. Handing a decoder the whole buffer and letting it raise
-`NeedMoreData(n)` to be re-run works until zlib — ZRLE and Tight streams live for
+`NeedMoreData(n)` to be re-run works until zlib: ZRLE and Tight streams live for
 the whole connection and cannot be replayed.
 
 ## Four decoder base classes, one entry point
@@ -136,7 +136,7 @@ describes what it produces, and overrides that base class' one method:
 
 | Base class | Produces | Method it overrides | Encodings |
 |---|---|---|---|
-| `PixelDecoder` | fills a `RectBuffer` the pump allocates and pastes | `decodePixels` | RRE, CoRRE, Hextile, ZRLE, and Raw, which skips the buffer — see below |
+| `PixelDecoder` | fills a `RectBuffer` the pump allocates and pastes | `decodePixels` | RRE, CoRRE, Hextile, ZRLE, and Raw, which skips the buffer (see below) |
 | `WholeRectDecoder` | the whole rectangle, in its own pixel format | `decodeRect` | Tight |
 | `ClientDecoder` | calls `copyRectangle` or `updateCursor` | `decodeForClient` | CopyRect, Cursor |
 | `ControlDecoder` | a side effect, and no screen change | `decodeForControl` | DesktopSize, QEMU extended key |
@@ -158,30 +158,30 @@ hand-written mapping, so a key cannot drift from the class it points at.
 ### One pump path, whatever the decoder produces
 
 What the four differ in is what the pump feeds the generator and what it does
-with the result — not how the bytes are pumped. So each base class implements
+with the result, not how the bytes are pumped. So each base class implements
 `decode(client, rect, pixel_format)`, the one entry point the pump calls, in
 terms of the method its subclasses override, and returns an `Outcome`: whether
-the rectangle counts as a screen change, and the `Paste` — pixels and the format
-they are in — the pump is left to make, or none. Pixels the pump cannot size
+the rectangle counts as a screen change, and the `Paste` (pixels and the format
+they are in) the pump is left to make, or none. Pixels the pump cannot size
 would be a rectangle recorded but never painted, so the two travel as one value
 rather than as two fields that can disagree. A rectangle costs one dict lookup
 and one call; the pump asks nothing about the class it holds.
 
 That is what makes an encoding whose framing is new cost no `rfb.py` edit. The
 earlier design gave each base class its own pump method and picked between them
-with an `isinstance` chain at connect time, so `WholeRectDecoder` — a decoder
-that hands over its own bytes in its own format — could not be added without one
+with an `isinstance` chain at connect time, so `WholeRectDecoder`, a decoder
+that hands over its own bytes in its own format, could not be added without one
 (specs/tight-encoding.md, R1).
 
 Decoders import nothing from `rfb.py`: driving generators, advancing the
 connection and turning a failure into a disconnect stay with the pump. What a
 decoder is handed is the client, and what it may ask of it is the vocabulary the
-codebase already uses — `updateRectangle`, `copyRectangle`, `updateCursor`,
-`updateDesktopSize` — plus `rectBuffer` and `requireFits`, which are the two
+codebase already uses: `updateRectangle`, `copyRectangle`, `updateCursor`,
+`updateDesktopSize`, plus `rectBuffer` and `requireFits`, which are the two
 things only the pump can answer: a rectangle-sized buffer, reused across
 rectangles, and whether a rectangle fits the framebuffer at all. Both raise
 `DecodeError` rather than reporting a failure the caller has to check, so the
-pump has one place that turns a bad rectangle into an abort.
+pump has one place that stops the connection on a bad rectangle.
 
 There is no separate sink object.
 
@@ -192,7 +192,7 @@ inventing a fake buffer or reading the framebuffer back.
 
 Cursor is otherwise an ordinary decoder. Its payload is `width * height` pixel
 values followed by a bitmask of left-to-right, top-to-bottom scanlines, each
-padded to a whole number of bytes — `floor((width + 7) / 8)` — with the most
+padded to a whole number of bytes (`floor((width + 7) / 8)`) with the most
 significant bit of each byte representing the leftmost pixel and a 1-bit meaning
 the corresponding cursor pixel is valid.
 
@@ -218,14 +218,14 @@ motivated the shortcut.
 Almost nothing about pixel format varies between decoders, so it lives once in
 `vncdotool/pixelformat.py`: the negotiated PIXEL width and its Pillow raw mode,
 CPIXEL's three-byte rule and its two placements (RFC 6143 §7.7.5), TPIXEL's
-narrower and differently-ordered one (rfbproto §Tight), and colour-map
+narrower and differently ordered one (rfbproto §Tight), and color-map
 indirection. [pixel-format.md](pixel-format.md) is the design.
 
 ZRLE's `cpixel()` in `rfb.py` gets both CPIXEL cases wrong in one line: `next(i), next(i),
 next(i)` implements the low placement, silently mis-decodes the high one, and
 appends a fabricated fourth byte.
 
-What varies per decoder is pixel *layout in the stream* — palettes, RLE runs,
+What varies per decoder is pixel *layout in the stream*: palettes, RLE runs,
 subrect coordinates. That is decoding, not formatting.
 
 ### Decoders emit the bytes they were sent, and say what they are
@@ -234,16 +234,16 @@ A decoder returns pixel bytes in whatever layout it produced them, tagged with
 the `PixelFormat` that describes it. `client.py` resolves that to a Pillow raw
 mode and materializes each rectangle with one `Image.frombytes(..., "raw",
 mode)`. Most decoders tag the negotiated format; Tight's JPEG and TPIXEL tag
-24 bpp RGB, a colour-mapped decoder tags the colour-mapped format.
+24 bpp RGB, a color-mapped decoder tags the color-mapped format.
 
 The tag is a `PixelFormat`, not a Pillow mode string: decoders implement a
 specification written in shifts and maxima, so Pillow stays in `client.py` and
 in `pixelformat.raw_mode`, and a decoder unit test needs no rendering library
 (R2).
 
-So a decoder never interprets a pixel. A background colour, a Hextile
+So a decoder never interprets a pixel. A background color, a Hextile
 foreground, a ZRLE palette entry are opaque `bypp`-sized byte strings and a fill
-is one repeated — no shifts, no masks, no endianness, so that class of bug
+is one repeated: no shifts, no masks, no endianness, so that class of bug
 cannot be written. `client.PF2IM` goes with it: a computed raw
 mode covers every layout Pillow can unpack, which is the bound this accepts.
 
@@ -282,8 +282,8 @@ Tests improve correspondingly: one expected byte array replaces an ordered log o
 callbacks with absolute coordinates, which is a test that breaks when tile
 iteration order changes even though the rendered result is identical.
 
-The buffer is `w*h*bypp` — 8.3MB for full-screen 1080p at the 32 bpp every
-measured server sends — and is sized from
+The buffer is `w*h*bypp`, 8.3 MB for full-screen 1080p at the 32 bpp every
+measured server sends, and is sized from
 server-declared dimensions, so the pump validates those against
 `MAX_DESKTOP_SIZE` before allocating. That is R6, not a separate concern: an
 unhandled `MemoryError` is as undiagnosed a failure as an indefinite wait. The
@@ -325,9 +325,10 @@ out-of-tree VNC encodings; the registry is a dict.
 ## Subclass compatibility: find out before deciding
 
 `api.connect(..., factory_class=...)` and `RFBFactory.protocol` are a supported
-extension point, so `CustomClient(VNCDoToolClient)` subclasses *may* exist. We
-have no evidence that any do. Building compatibility machinery for a population
-we cannot observe is speculative, and so is breaking it silently.
+extension point, so `CustomClient(VNCDoToolClient)` subclasses *may* exist.
+There is no evidence that any do. Building compatibility machinery for a
+population that cannot be observed is speculative, and so is breaking it
+silently.
 
 Two hooks change:
 
@@ -345,7 +346,7 @@ named `_handleDecode*` is private and disappears without replacement.
 
 So Phase -1 ships a **survey, not a deprecation**, and ships it publicly before
 anything else changes. At that point nothing has changed yet, so the warning
-cannot say a method is no longer called — it says the contract will change, and
+cannot say a method is no longer called; it says the contract is changing, and
 asks the reader to say so on a tracking issue:
 
 ```python
@@ -360,10 +361,10 @@ def __init_subclass__(cls, **kwargs) -> None:
                           stacklevel=2)
 ```
 
-Testing `__module__` rather than comparing against `RFBClient.<method>` keeps our
-own subclasses quiet — `VNCDoToolClient` overrides `updateRectangle` and
-`updateCursor`, and `loggingproxy` subclasses that in turn — with no allowlist to
-maintain. Only the two changing hooks are listed: warning on unaffected ones
+Testing `__module__` rather than comparing against `RFBClient.<method>` keeps
+vncdotool's own subclasses quiet (`VNCDoToolClient` overrides `updateRectangle`
+and `updateCursor`, and `loggingproxy` subclasses that in turn) with no
+allowlist to maintain. Only the two changing hooks are listed: warning on unaffected ones
 trains users to filter the category wholesale. The category is `FutureWarning`,
 not `DeprecationWarning`, because the latter is hidden by default outside
 `__main__`, which would leave a mechanism that looks implemented and does
@@ -373,7 +374,7 @@ once per call.
 
 Class-definition time beats connect time: it fires for a subclass that is never
 connected, and `stacklevel` points at the definition. A decorator on the base
-method cannot work, since an overridden method means the base is never invoked —
+method cannot work, since an overridden method means the base is never invoked,
 which is the failure mode being detected.
 
 `self.image_mode` is the one break `__init_subclass__` cannot see, since reading
@@ -384,42 +385,42 @@ a warning no-op.
 
 **This machinery is temporary.** Once the contracts have actually changed the
 warnings are false, and they are removed. If the survey turns up nobody, they are
-removed having cost one release. If it turns up someone, we have a named user to
-design compatibility with rather than a hypothetical one.
+removed having cost one release. If it turns up someone, there is a named user
+to design compatibility with rather than a hypothetical one.
 
 ## Build order
 
-**Phase -1 — survey release.** The `__init_subclass__` warning, the `image_mode`
+**Phase -1: survey release.** The `__init_subclass__` warning, the `image_mode`
 property, and a tracking issue. No other change. Ship it and wait.
 *Done when:* released publicly and enough time has passed to hear from users.
 This is the only phase whose completion is measured in elapsed time rather than
-code, and the only one that gates on information we do not have.
+code, and the only one that gates on information not yet available.
 
-**Phase 0 — capture tooling and harness.** A `DecoderTestCase` driving a decoder
+**Phase 0: capture tooling and harness.** A `DecoderTestCase` driving a decoder
 with no reactor, and the capture tooling described under Testing. Discharges R2,
 C1.
 
-**Phase 1 — pixel format.** `pixelformat.py`: a negotiated format resolved to a
+**Phase 1: pixel format.** `pixelformat.py`: a negotiated format resolved to a
 Pillow raw mode, both CPIXEL placements, TPIXEL's narrower rule, and the
 `--pixel-format` flag that makes a second format reachable. `PF2IM` removed.
 Designed in [pixel-format.md](pixel-format.md).
 *Done when:* the same scene, captured at two negotiated formats, decodes to the
 same framebuffer within the reduced format's quantization. Discharges R3 for
-those two; colour map and the formats Pillow cannot unpack follow with the
+those two; color map and the formats Pillow cannot unpack follow with the
 servers that need them. This comes before any decoder migrates so no decoder is
 written twice.
 
-**Phase 2 — pump, Raw, CopyRect.** The pump lands with `DecodeError` handling and
+**Phase 2: pump, Raw, CopyRect.** The pump lands with `DecodeError` handling and
 `MAX_DESKTOP_SIZE` validation. Raw and CopyRect move; everything else stays on
 the existing path behind the registry.
 *Done when:* the functional suite is green, the pump's segmentation test passes,
 and Raw has a recorded render-time baseline. Discharges R6, R7, N1; establishes
 R1's shape.
 
-**Phase 3 — selectable encodings, proven on the two simplest.** `--encodings`
+**Phase 3: selectable encodings, proven on the two simplest.** `--encodings`
 lands, and RRE and CoRRE are migrated and verified end-to-end against the fleet.
-They are the simplest decoders we have — a subrectangle count, a background
-pixel, then a flat list of coloured subrectangles — and CoRRE is RRE with U8
+They are the simplest decoders available: a subrectangle count, a background
+pixel, then a flat list of colored subrectangles, and CoRRE is RRE with U8
 coordinates in place of U16, so the pair shares almost all its code. That makes
 them the cheapest possible second exercise of the registry path, which is the
 point: prove the architecture before investing in a hard decoder.
@@ -429,28 +430,28 @@ any server's preferred encoding and their bandwidth advantage is narrow. The
 user-visible payoff starts at Phase 4.
 
 The encoding probe lands here too, as a loop over the new flag, filling in the
-UltraVNC and Screen Sharing columns of the support table above. Whether it stays
-in CI or runs once and leaves its results in that table is the same question the
-pixel-format probe answered by leaving: a measurement that only moves when a
-runner image does is a record, not a test.
+UltraVNC and Screen Sharing columns of the preceding support table. Whether it
+stays in CI or runs once and leaves its results in that table is the same
+question the pixel-format probe answered by leaving: a measurement that only
+moves when a runner image does is a record, not a test.
 
 *Done when:* both render identically to Raw against every fleet server that
 supports them, and `--encodings` can select them. Discharges R4.
 
-**Phase 4 — Hextile.** The first phase with a user-visible result: Hextile is
+**Phase 4: Hextile.** The first phase with a user-visible result: Hextile is
 near-universally supported and wins substantially on real screen content.
 *Done when:* it renders identically to Raw against every fleet server and meets
 N2.
 
-**Phase 5 — ZRLE, Cursor, and the control encodings.** ZRLE carries the largest
-bandwidth win and the CPIXEL defect we now understand precisely, which is why it
+**Phase 5: ZRLE, Cursor, and the control encodings.** ZRLE carries the largest
+bandwidth win and the CPIXEL defect now understood precisely, which is why it
 comes after the architecture is proven rather than before. Its fix happens here,
 as part of proving the encoding rather than as a standalone repair to
 unreachable code.
 *Done when:* no `_handleDecode*` remains in `rfb.py` and every migrated encoding
 meets N2. Discharges R5.
 
-**Phase 6 — Tight.** A new encoding as new files plus tests.
+**Phase 6: Tight.** A new encoding as new files plus tests.
 *Done when:* it is added with a zero-line diff to `rfb.py`. The one line that
 registers it goes in `decoders/__init__.py`, and `Encoding.TIGHT` already exists
 in `const.py`, so `rfb.py` and `const.py` are both untouched. That is the test of
@@ -468,6 +469,7 @@ finding a server that emits it.
 
 Phase -1 can ship immediately and runs concurrently with Phases 0 and 1, which
 touch no client callback. It must land publicly before Phase 2, which is where
+
 `updateRectangle`'s contract first changes.
 
 ## Fleet encoding support
@@ -494,8 +496,8 @@ sub-regions: every rectangle came back Raw. The same probe against x11vnc
 returned CoRRE, so it can see a CoRRE rectangle when one arrives, and offering
 RRE alone to tigervnc returned RRE, so tigervnc is not answering everything
 with Raw. Upstream agrees: `EncodeManager::supported()` in TigerVNC 1.12.0
-(`common/rfb/EncodeManager.cxx`) accepts Raw, RRE, Hextile, ZRLE and Tight and
-nothing else. Every other cell predates this pass and remains uncited. The
+(`common/rfb/EncodeManager.cxx`) accepts Raw, RRE, Hextile, ZRLE, and Tight,
+and nothing else. Every other cell predates this pass and remains uncited. The
 probe itself was committed and then removed within #417, so `git show` against
 that PR's history recovers the script without it living in the tree ahead of
 the Phase 3 tooling below.
@@ -509,7 +511,7 @@ the probe is what is missing, not access.
 Read these asymmetrically. A "yes" is proof: the server really emitted that
 encoding. A "no" is strong evidence but not certainty, because servers choose
 per-rectangle and the probe reads only the first rectangle of a full-screen
-update — a server could in principle pick Raw for that one rectangle while
+update. A server could in principle pick Raw for that one rectangle while
 supporting the encoding elsewhere. Do not delete an encoding on a "no" alone.
 The tigervnc CoRRE "no" is the exception: [1] read four separate updates and
 found upstream source saying the same thing.
@@ -519,7 +521,7 @@ is safe; CoRRE survives on two of three servers, TigerVNC having dropped it;
 Hextile and ZRLE are universal; TRLE is emitted by nothing and is therefore out
 of scope entirely.
 
-The probe is not in the repository — the table came from a throwaway that no
+The probe is not in the repository: the table came from a throwaway that no
 longer exists, which is why two columns are blank. Building it waits for Phase 3
 rather than being Phase 0 tooling: `--encodings` lands there, so the probe is
 then a loop over a flag instead of a script reaching into `client.encoding`, and
@@ -530,9 +532,9 @@ images update.
 ## Testing
 
 Fixtures are **captured from real servers**, never hand-assembled from the
-specification. Hand-built bytes encode our reading of the spec, so a
+specification. Hand-built bytes encode a particular reading of the spec, so a
 misunderstanding produces a fixture and a decoder that agree with each other and
-with nothing else — the test then pins the misunderstanding. This is the same
+with nothing else: the test then pins the misunderstanding. This is the same
 trap as reading goldens off the implementation.
 
 **Capture tooling (Phase 0), built.** `loggingproxy.py` sits between client and
@@ -543,29 +545,29 @@ fixtures under `tests/unit/fixtures/goldens/`.
 
 **The oracle is the committed PNG the server was shown**, not a Raw replay. An
 earlier revision proposed replaying each script with Raw negotiated and treating
-that render as ground truth, which makes the oracle a second capture — subject
+that render as ground truth, which makes the oracle a second capture, subject
 to the same server, the same session, and its own decode. Comparing against the
 file that was displayed removes the server from the oracle entirely, and there
 is nothing to keep in sync because the fixture names the scene and the scene is
 the file. [decoder-goldens.md](decoder-goldens.md) has the scene source, the
-capture path, the fixture format and the matrix.
+capture path, the fixture format, and the matrix.
 
-**Tier 1 — unit, offline.** Captured wire bytes into the decoder, compare the
+**Tier 1: unit, offline.** Captured wire bytes into the decoder, compare the
 resulting framebuffer against the scene PNG. Fast, no fleet, no reactor. The
 comparison is on the framebuffer after the client's paste, which is what makes
 it hold across captures from servers that negotiated different formats.
 
-**Tier 2 — live, against the fleet.** Force `--encodings` to one encoding, drive
+**Tier 2: live, against the fleet.** Force `--encodings` to one encoding, drive
 the same scene script, compare the captured screen to the same PNGs. Catches
 everything the capture missed: negotiation, ordering, zlib stream continuity
 across rectangles.
 
-**Tier 3 — screen-change stress.** Fixtures are only as good as the screen
+**Tier 3: screen-change stress.** Fixtures are only as good as the screen
 changes that produced them, and a decoder that passes Tier 1 and Tier 2 on a
 blank-ish screen has been barely tested. The scene catalogue in
 [decoder-goldens.md](decoder-goldens.md) is this tier: solid fills for RRE and
-ZRLE's single-colour palette, dense detail for raw-tile fallback, scattered
-rects for ordering and R7's stream continuity, a scrolled region for CopyRect —
+ZRLE's single-color palette, dense detail for raw-tile fallback, scattered
+rects for ordering and R7's stream continuity, a scrolled region for CopyRect:
 the one encoding whose correctness depends on prior framebuffer contents.
 
 Mid-session desktop resize is the case the catalogue cannot reach, since the
@@ -620,13 +622,13 @@ the same 87 rectangles, and that is the whole of the difference.
 **Each new encoding (N2).** Bytes over the wire against Raw on identical screen
 content, which should drop substantially, and that encoding's own render time,
 which must not regress between runs. The bandwidth number is the reason users
-want these encodings; the render-time number tracks our implementation of one,
-which is the only part of its cost we control.
+want these encodings; the render-time number tracks vncdotool's implementation
+of one, which is the only part of its cost vncdotool controls.
 
-Single paste is expected to help, but that expectation is arithmetic — 8,100 PIL
-round-trips becoming one — not measurement. Readability and testability justify
-the change on their own; if the benchmark comes back flat we should know it from
-a number.
+Single paste is expected to help, but that expectation is arithmetic (8,100 PIL
+round-trips becoming one), not measurement. Readability and testability justify
+the change on their own; if the benchmark comes back flat, that shows up as a
+number.
 
 **Where ZRLE's cost was.** ZRLE decoded at 33,000 us against
 `tigervnc-zrle-bgrx8888` while Tight, at bandwidth identical to a tenth of a
@@ -640,8 +642,9 @@ from the raw-tile branch, which expanded one pixel per iteration.
 Reading by index and widening whole runs of CPIXELs with one strided slice
 assignment per byte lane took the fixture to 2,900 us, about 12x. The packed
 palette went the same way Tight's `_unpalette` had: a cached 256-entry table per
-`(palette, bits)`, one `bytes.join` per row. After it, no single line dominates —
-`zlib.decompress` is the second-largest at 10% — so this is now spread cost
+`(palette, bits)`, one `bytes.join` per row. After it, no single line dominates:
+`zlib.decompress` is the second-largest at 10%, so this is now spread cost
+
 rather than a hot spot.
 
 The fixture contains no RLE tiles at all: TigerVNC encoded it as 70 solid, 39
@@ -660,7 +663,7 @@ single-zlib-stream-per-connection rule and the strict ordering it implies; ZRLE'
 followed by four U16 coordinates; ZRLE palette limits of 16 packed and 127
 run-length.
 
-**Verified against rfbproto:** the Cursor pseudo-encoding payload — pixel values
+**Verified against rfbproto:** the Cursor pseudo-encoding payload: pixel values
 followed by a byte-padded, MSB-first scanline bitmask.
 
 **Checked against the implementation while validating:** RRE parses
@@ -668,10 +671,10 @@ pixel-then-coordinates correctly (`_handleRRESubRectangles`) and the ZRLE run-le
 already permits palettes to 127 (`subencoding & 127`). Neither needs changing;
 the packed-palette cap of 16 is in the correct branch.
 
-**Verified against rfbproto, since:** Tight's TPIXEL rule — narrower than
-CPIXEL, fixed in red-green-blue order — and its four zlib streams; CPIXEL's
+**Verified against rfbproto, since:** Tight's TPIXEL rule (narrower than
+CPIXEL, fixed in red-green-blue order) and its four zlib streams; CPIXEL's
 tie-break at depth ≤ 16, absent from RFC 6143; and that *bits-per-pixel* must be
-8, 16 or 32. Detail in [pixel-format.md](pixel-format.md).
+8, 16, or 32. Detail in [pixel-format.md](pixel-format.md).
 
 Per `DEVELOP.rst`, rfbproto is a living document with no releases, so any comment
 or test depending on its wording cites a commit permalink rather than `master`.

--- a/specs/decoder-goldens.md
+++ b/specs/decoder-goldens.md
@@ -1,4 +1,4 @@
-# Decoder Golden Fixtures — Design
+# Decoder Golden Fixtures: Design
 
 Status: scaffold built; Raw at 32bpp against tigervnc. Later matrix values are
 TDD entry points, see Phasing. Builds the fixture half of
@@ -7,11 +7,11 @@ TDD entry points, see Phasing. Builds the fixture half of
 
 ## Problem
 
-Decoder goldens need wire bytes from a real server, produced by screen changes
-we chose, verified against something that is not our own decoder. The fleet
-offered none of the three: `draw-content.sh` painted once at start-up, nothing
-could ask a server for a particular update, and the only image to compare
-against was one our own decoder had produced.
+Decoder goldens need wire bytes from a real server, produced by deliberately
+chosen screen changes, and verified against something other than the decoder
+itself. The fleet offered none of the three: `draw-content.sh` painted once at
+start-up, nothing could ask a server for a particular update, and the only
+image to compare against was one the decoder itself had produced.
 
 ## What reproducible means here
 
@@ -23,7 +23,7 @@ A capture *run* only has to be re-derivable and labelled. It records the
 conditions that produced it so a person can rebuild an equivalent fixture when
 an image updates, re-verify it against the oracle, and commit the replacement.
 Nothing needs a byte-identical rerun, which is what lets the fixture source be a
-server we do not control.
+server outside vncdotool's control.
 
 The high-order bit is exercising the decoders with many values in a way that is
 reproducible and debuggable. Everything below serves that; where a choice made
@@ -44,18 +44,18 @@ The scenes themselves are generated offline by `tests/goldens/scenes.py`'s own
 images rather than drawing them in the container is what lets the same file be
 both what was displayed and what a golden is checked against.
 
-Keys select behaviour. There is no step counter and no notion of "next", so a
+Keys select behaviour. There is no step counter and no notion of "next," so a
 dropped or mistranslated keysym cannot silently shift every later fixture into
-the wrong label — the c2s stream names the scene that was asked for.
+the wrong label: the c2s stream names the scene that was asked for.
 
 | Key | Draws | Exercises |
 |---|---|---|
 | `0` | reset to a known base screen | isolation between cases |
-| `s` | large solid fill | RRE fill path, ZRLE single-colour palette |
+| `s` | large solid fill | RRE fill path, ZRLE single-color palette |
 | `d` | dense pseudo-random detail | raw-tile fallback, worst-case bandwidth |
 | `x` | many small scattered rects | many-rectangle updates, decode ordering |
 | `g` | smooth gradient | quantization under reduced-depth formats |
-| `p` | 2, 4 and 16-colour regions | ZRLE packed-palette branches |
+| `p` | 2, 4 and 16-color regions | ZRLE packed-palette branches |
 | `c` | scroll a region by N pixels | CopyRect, if the server emits one |
 | `f` | full-screen repaint | single large rect, encoder size chunking |
 
@@ -75,7 +75,7 @@ step at all, since the frame carries it and the c2s stream cannot be aligned
 against s2c.
 
 The patch is the key's glyph, drawn from a 5x7 table in `scenes.py` at four
-pixels a cell, black on white, in a 26x34 box at the centre of the frame.
+pixels a cell, black on white, in a 26x34 box at the center of the frame.
 `read_patch` samples one pixel per cell, thresholds it, and matches the
 bitmap against the table whole: a frame either carries a glyph or does not,
 with no tolerance anywhere.
@@ -83,7 +83,7 @@ with no tolerance anywhere.
 The table is literal rather than rendered because Pillow's default font is an
 implementation detail that has changed shape across releases, and a fixture
 labelled by a rendered glyph would be invalidated by an upgrade. The glyphs
-are the uppercase forms — 5x7 lowercase needs descenders for `g` and `p` —
+are the uppercase forms (5x7 lowercase needs descenders for `g` and `p`),
 so the player folds an incoming keysym to lower case and `C` and `c` select
 the same scene.
 
@@ -92,16 +92,16 @@ channel's extremes, and a pixel format reproduces its extremes exactly
 however few bits it keeps, so the patch reaches the client unquantized at
 rgb565 as much as at rgbx8888. The earlier patch instead carried the key as
 `ord(key)` in the red channel, which assumed an 8-bit red without saying so:
-at rgb565 `c`, `d`, `f` and `g` — 99, 100, 102 and 103 — landed on one 5-bit
+at rgb565 `c`, `d`, `f` and `g` (99, 100, 102 and 103) landed on one 5-bit
 value, and a step could only be narrowed to a set of keys and then guessed at
 by which scene the frame most resembled.
 
 The base screen is non-black so the existing screenshot smoke tests, which only
 assert that a capture is not flat, stay green.
 
-The `tigervnc` service serves **256x192**. Raw at 1024x768 is 3MB per
+The `tigervnc` service serves **256x192**. Raw at 1024x768 is 3 MB per
 full-screen update, which the repository should not carry; at 256x192 it is
-192KB, about 40KB gzipped. Nothing else in the fleet needs a large desktop, so
+192 KB, about 40 KB gzipped. Nothing else in the fleet needs a large desktop, so
 this is the one service's geometry rather than a second service beside it.
 
 ## Driving
@@ -175,7 +175,7 @@ A fixture is a whole capture session, not a single update:
       conditions.json
 
 A fixture holds no images. The step filename ends in the scene key, and the
-oracle is `tests/goldens/scenes/<key>.png` — the same file the server was
+oracle is `tests/goldens/scenes/<key>.png`, the same file the server was
 shown, so there is nothing to keep in sync.
 
 Session-level is the only granularity that can test R7, the decoder
@@ -197,14 +197,14 @@ opening anything.
 ## conditions.json
 
 `--pixel-format` is required, so `pixel_format` always names a format rather
-than recording "the server's own". Nothing on the wire would correct it — the
-server never acknowledges `SetPixelFormat` — so a fixture that does not say
+than recording "the server's own." Nothing on the wire would correct it: the
+server never acknowledges `SetPixelFormat`, so a fixture that does not say
 what it asked for cannot be replayed at the format its pixels are in.
 
 Written by the harness from what happened, never from what was intended: the
-compose service, the geometry, and vnclog's own `meta` — protocol version,
+compose service, the geometry, and vnclog's own `meta` (protocol version,
 security types, the encodings the server actually used, and the capture
-timestamp. The comparison tolerance lives here too, as the three per-channel
+timestamp). The comparison tolerance lives here too, as the three per-channel
 bounds `pixelformat.channel_tolerance` computes from the requested format:
 `[0, 0, 0]` at 32bpp, `[7, 3, 7]` at rgb565.
 
@@ -214,17 +214,17 @@ already is it, and a second copy is a second thing to keep true.
 ## Oracles
 
 Ground truth is the committed PNG the scene player pushed to X. It is
-independent of our decoder and of our reading of the specification, and it
-needs no copying out of a container: the file the test compares against is the
-file the server was shown.
+independent of the decoder under test and of any reading of the specification,
+and it needs no copying out of a container: the file the test compares against
+is the file the server was shown.
 
-At reduced depth the server quantizes, so a decoded frame will not equal that
-image, and modelling the rounding ourselves would put our reading of the spec
-back into the oracle. The comparison instead allows per-channel error bounded
-by the format's step, which bounds the server's rounding without modelling it
-and still catches channel swaps, wrong shifts, endianness errors and colour-map
-misindexing — the whole defect class R3, the framebuffer not depending on the
-negotiated format, is about. Every fixture is checked this way at the format it
+At reduced depth the server quantizes, so a decoded frame does not equal that
+image, and modelling the rounding independently would put a particular reading
+of the spec back into the oracle. The comparison instead allows per-channel
+error bounded by the format's step, which bounds the server's rounding without
+modelling it and still catches channel swaps, wrong shifts, endianness errors
+and color-map misindexing: the whole defect class R3, the framebuffer not
+depending on the negotiated format, is about. Every fixture is checked this way at the format it
 was captured at, and that is where R3 is checked.
 
 The bound is `pixelformat.channel_tolerance`, and it falls out of the format
@@ -253,8 +253,8 @@ The lossy bound is not a per-channel triple at all. Nothing in the wire format
 implies one, and a per-channel maximum stops separating a correct frame from a
 wrong one as soon as the quality drops: at level 5 the correct scene sits 229
 away while the nearest wrong scene sits at 180. A `jpeg-lossy` fixture records
-a fuzz and a blur instead — the perceived-difference bound of
-[expect-matching.md](expect-matching.md), which holds from level 9 to level 0 —
+a fuzz and a blur instead: the perceived-difference bound of
+[expect-matching.md](expect-matching.md), which holds from level 9 to level 0,
 and `test_goldens.py` reads whichever pair of numbers the kind calls for.
 
 The recorded fuzz is measured from the capture itself: the furthest any of its
@@ -273,17 +273,17 @@ The quality level is recorded too, because how far a frame may sit from its
 oracle depends on it: at level 9 the worst frame is 1 from its scene, at level
 5 it is 14, at level 0 it is 46, against a nearest wrong scene of 87.
 
-The keysym patch keeps a per-channel triple, which is a different question --
+The keysym patch keeps a per-channel triple, which is a different question:
 whether a flat 48x48 block still reads back as the value that was stamped on
 it. It does, at every quality level tigervnc offers.
 
-**Cross-format self-consistency** — decode one scene at two formats, assert the
-framebuffers agree — is not used, though it reads like R3 stated directly. It
+**Cross-format self-consistency** (decode one scene at two formats, assert the
+framebuffers agree) is not used, though it reads like R3 stated directly. It
 cannot fail alone: every fixture is pinned to the PNG, so one member of a pair
 equals the PNG exactly and comparing the other against it is the comparison
-above at a looser bound. Reduced depth does not change that. The version with
-independent power — quantize the PNG onto the reduced grid, demand exact
-equality — is the rounding model this section rejects.
+described earlier at a looser bound. Reduced depth does not change that. The
+version with independent power (quantize the PNG onto the reduced grid, demand
+exact equality) is the rounding model this section rejects.
 
 ## The unit test
 
@@ -297,8 +297,8 @@ first differing pixel with coordinates and both values, and writes the decoded
 frame beside the expected one. When the bytes themselves are in doubt, the
 source archive replays through `vncdo-replay --server`.
 
-`make goldens` — bring the fleet up, run vnclog, drive the script, distill,
-write fixtures — is a manual target. It never runs in CI; the committed
+`make goldens` (bring the fleet up, run vnclog, drive the script, distill,
+write fixtures) is a manual target. It never runs in CI; the committed
 fixtures do.
 
 ## The matrix
@@ -320,7 +320,7 @@ Raw exercises as well as anything; the scene axis tests rect logic, which one
 format exercises as well as anything. The exception is CPIXEL: ZRLE and Tight
 do not use the ordinary pixel layout, and CPIXEL's byte width depends on the
 negotiated format (RFC 6143 §7.7.6). Testing them only at 32bpp exercises the
-one case where CPIXEL and pixel coincide — and that is precisely where the
+one case where CPIXEL and pixel coincide, and that is precisely where the
 known ZRLE hardcoded-layout defect lives.
 
 **Servers.** TigerVNC is primary. x11vnc is not a second copy of everything: it
@@ -349,11 +349,11 @@ the same way.
 
 Recorded so they are not rediscovered as new ideas.
 
-- The **pnm-server** — a libvncserver example that declares its own rects — and
+- The **pnm-server** (a libvncserver example that declares its own rects) and
   the rect pathologies that need it (hundreds of tiny rects, mid-session
   resize).
 - **CopyRect**, which appears only if Xvnc turns the scene player's scroll into
-  one. We find out by reading a capture, not by asserting it in advance.
+  one. That is found out by reading a capture, not by asserting it in advance.
 
 ## Risks
 

--- a/specs/expect-matching.md
+++ b/specs/expect-matching.md
@@ -1,4 +1,4 @@
-# What `expect` Compares — Design
+# What `expect` Compares: Design
 
 Status: built. What a `jpeg-lossy` fixture records is in
 [decoder-goldens.md](decoder-goldens.md).
@@ -32,7 +32,7 @@ not mention. The documented metric serves the exact-match case alone.
 
 ## The comparison
 
-Per pixel, the perceived colour difference in YIQ, from pixelmatch (Kotsarenko
+Per pixel, the perceived color difference in YIQ, from pixelmatch (Kotsarenko
 & Ramos 2010):
 
     dY, dI, dQ  from the usual RGB -> YIQ matrix
@@ -46,7 +46,7 @@ spends least of its error budget and where the eye resolves most detail.
 not one, so a percentage was considered; it buys nothing, because nothing
 useful lives below 1. Shifting every pixel by one unit on every channel scores
 0.97, and the tightest bound anyone needs under that is 0, which already means
-exact. The score itself stays a float — a screen differing in one blue bit
+exact. The score itself stays a float: a screen differing in one blue bit
 scores 0.44, and rounding it would make `expect FILE 0` accept a screen that is
 not the target.
 
@@ -80,7 +80,7 @@ exact-match case, which is most of them, never enters the float path.
 ## Measurements
 
 Worst accepted (a settled frame against its own scene) against best rejected (a
-settled frame against the seven other scenes, plus every partially-drawn frame
+settled frame against the seven other scenes, plus every partially drawn frame
 against the scene it was still drawing). Partial frames come from feeding each
 step's bytes in 4 KB chunks and sampling the framebuffer between them; they are
 the "do not unblock on a half-painted screen" case. Every candidate rejected
@@ -122,7 +122,7 @@ it back off for anyone who wants the strictness.
 
 **Fuzz, not tolerance.** `fuzz` is already the word in vncdo's own help text
 (`expect FILE FUZZ`) and ImageMagick's for the same quantity, a per-pixel
-colour-distance allowance. `tolerance` is spoken for in this repository: it is
+color-distance allowance. `tolerance` is spoken for in this repository: it is
 the RGB quantization triple in `pixelformat.channel_tolerance` and in a
 fixture's `conditions.json`, a different number on a different scale, and
 overloading it would leave `tolerance_kind` ambiguous.
@@ -139,7 +139,7 @@ default; the token tunes one wait. One script can wait on a smooth login dialog
 and then on a desktop playing video, which the option alone cannot express.
 
 `expect somescreen.png 0` -- the spelling in `docs/usage.rst` and in every
-script that copied it -- goes on meaning "exact". A script passing a large RMS
+script that copied it -- goes on meaning "exact." A script passing a large RMS
 number gets a lax match rather than the tight one it asked for; the number is
 on a different scale now. That is a breaking change, taken deliberately while
 the version is `2.0.0.dev0`.
@@ -198,7 +198,9 @@ is meant to be heading. Rejected for that.
 **Per-pixel threshold plus a count allowance**, as Playwright and pixelmatch do
 (`threshold` with `maxDiffPixels`), and as ImageMagick does (`-fuzz` with the
 `AE` metric, the only fuzz-affected one). The per-pixel half is what this design
-takes, name included; what it rejects is the count allowance on top. That
+takes, name included; what it rejects is the count allowance on top.
+
+That
 allowance survives every encoding measured, but it goes blind on noisy
 content, because the count absorbing the compression noise absorbs a small
 change with it. It suits whole-page screenshots over a lossless transport,
@@ -247,7 +249,7 @@ Six tests in `tests/unit/test_client.py` assert on `cli.expected` as a
 histogram and are rewritten against the new comparison. `CHANGELOG.rst` gets the
 entry for the breaking change, under `(UNRELEASED)`.
 
-**3. The CLI surface.** `--expect-fuzz` and `--expect-blur` parsed and
+**3. The command-line surface.** `--expect-fuzz` and `--expect-blur` parsed and
 validated (fuzz 0..255, blur non-negative), onto the factory. `expect` and
 `rexpect` take their trailing number only when the next token parses as one,
 which incidentally fixes a live bug: `docs/usage.rst` documents `expect
@@ -266,7 +268,7 @@ keysym-patch read in `distill.split`, the bound the driver runs under, and the
 fixture's recorded bound; those are three different questions. The patch read
 keeps its RGB triple, proven to work at level 0. The driver runs at a fuzz of
 64, which has to be wide enough for the worst quality level anyone captures.
-The recorded bound is measured from the capture itself — the furthest any of
+The recorded bound is measured from the capture itself: the furthest any of
 its own frames landed from its scene, plus a margin of 4 for the decode
 drifting under another libjpeg. Level 9 records 6 and level 5 records 19,
 against the 64 they were driven at.

--- a/specs/pixel-format.md
+++ b/specs/pixel-format.md
@@ -1,4 +1,4 @@
-# Pixel Format — Design
+# Pixel Format: Design
 
 Status: draft, under review. The first slice of
 [decoder-architecture.md](decoder-architecture.md) Phase 1, and the `rgb565`
@@ -8,9 +8,9 @@ entry point [decoder-goldens.md](decoder-goldens.md) names in its phasing.
 
 `client.PF2IM` is a five-entry dict keyed on the whole
 `PixelFormat` dataclass, valued with a Pillow raw mode. A format outside those
-five raises `LookupError`, and `setImageMode` guesses —
-`BGR16` if the server announced 3.889, `RGB32` otherwise — sends
-`SetPixelFormat`, and assumes it was obeyed. A server that ignores it keeps
+five raises `LookupError`, and `setImageMode` guesses (`BGR16` if the server
+announced 3.889, `RGB32` otherwise), sends `SetPixelFormat`, and assumes it
+was obeyed. A server that ignores it keeps
 sending its own format, decoded as the requested one: #90 and #275.
 
 Nothing can request a format from the command line (#167, #168), so the golden
@@ -22,7 +22,7 @@ The `pixelformat.py` machinery: computing a Pillow mode from any byte-aligned
 truecolor `PixelFormat` instead of a five-entry lookup table, plus the CPIXEL
 functions ZRLE needs at Phase 5. `rgb565` is in the registry as a second
 requestable format, but verifying it end-to-end is deferred (see below).
-Colour map, and the layouts Pillow cannot unpack, wait for a server that
+Color map, and the layouts Pillow cannot unpack, wait for a server that
 needs them.
 
 ## What servers actually send
@@ -33,13 +33,13 @@ Tier 2 from run
 which ran a probe test that has since been removed: this table is the record, and
 nothing re-derives it. It goes stale when a runner image changes its display
 depth, and `vncdo -v` against any server reprints both the native format and the
-one we request.
+one requested.
 
 | Server | ServerInit format | Wire | In `PF2IM`? |
 |---|---|---|---|
 | tigervnc, x11vnc, ultravnc, screen-sharing | 32 bpp, depth 24, LE, max 255, shifts 16/8/0 | BGRX | yes |
 | libvncserver-example | 32 bpp, **depth 32**, LE, max 255, shifts 0/8/16 | RGBX | **no** |
-| vncev | 8 bpp, depth 8, **colour-mapped** | index | **no** |
+| vncev | 8 bpp, depth 8, **color-mapped** | index | **no** |
 
 The two misses are libvncserver's example programs, in the fleet because they
 are scriptable, not because anyone runs them. **Every server anyone runs sends
@@ -51,9 +51,9 @@ Three consequences:
 
 - **`PF2IM` misses on `depth`, which does not affect byte layout.**
   libvncserver-example's format *is* the layout `PF2IM` calls `RGBX`, differing
-  only by declaring depth 32 — the historical quirk rfbproto warns about — so we
-  renegotiate to a format byte-identical to the one already arriving. Computing
-  the mode from the fields removes the failure mode.
+  only by declaring depth 32 (the historical quirk rfbproto warns about), so
+  vncdotool renegotiates to a format byte-identical to the one already
+  arriving. Computing the mode from the fields removes the failure mode.
 - **The version-3.889 special case (request `BGR;16` for Apple Remote
   Desktop) is dropped, not carried forward.** It traced to PR #243 fixing
   issue #205, a generic 16bpp black-screen report with no confirmation the
@@ -72,12 +72,12 @@ A decoder returns bytes in the layout it produced them, tagged with the
 `PixelFormat` describing that layout. `client.py` resolves the tag with
 `raw_mode()` and materializes each rectangle with one `Image.frombytes(...,
 "raw", mode)`. Raw, RRE, CoRRE, Hextile and ZRLE tag the negotiated format;
-Tight's JPEG and TPIXEL tag 24 bpp RGB; a colour-mapped decoder tags the
-colour-mapped format and the client resolves indices through the palette it
+Tight's JPEG and TPIXEL tag 24 bpp RGB; a color-mapped decoder tags the
+color-mapped format and the client resolves indices through the palette it
 already holds.
 
 The tag is a `PixelFormat` and not a Pillow mode string so that decoders speak
-only RFB — they implement a specification written in shifts and maxima, and
+only RFB: they implement a specification written in shifts and maxima, and
 naming `BGRX` there would put the rendering library inside code that has no
 other reason to know it exists. Pillow stays in `client.py` and in `raw_mode`,
 which is also the single place to change if the unsupported layouts below
@@ -89,14 +89,14 @@ does not permit on the wire. Internally that is the honest description of three
 packed bytes, and the negotiation registry still refuses to ask a server for it.
 
 Converting inside each decoder to one canonical layout was designed first and
-dropped. It materializes every rectangle twice — bytes, image, bytes, image, for
-~1.2 ms per 1080p frame of copying — and forces JPEG, TPIXEL and colour map to
+dropped. It materializes every rectangle twice (bytes, image, bytes, image, for
+~1.2 ms per 1080p frame of copying) and forces JPEG, TPIXEL, and color map to
 produce a layout that then has to be undone.
 
-Tagging means **a decoder never interprets a pixel**. A background colour, a
+Tagging means **a decoder never interprets a pixel**. A background color, a
 Hextile foreground, a ZRLE palette entry are opaque `bypp`-sized byte strings,
 and a fill is one repeated. No shifts, no masks, no endianness in any decoder,
-so that class of bug cannot be written — including the live one, ZRLE's
+so that class of bug cannot be written, including the live one, ZRLE's
 `cpixel()` reading three bytes least-significant-first and appending `0xFF`
 (`rfb.py`).
 
@@ -115,14 +115,14 @@ def cpixel_offset(pixel_format: PixelFormat) -> int: ... # 0 or bypp - 3
 def channel_tolerance(pf: PixelFormat) -> tuple[int, int, int]:  # 8-bit error per channel
 ```
 
-`raw_mode` ignores `depth` — it does not affect where the channels sit.
+`raw_mode` ignores `depth`: it does not affect where the channels sit.
 `cpixel_bytes` must obey it, since the encoder used the same declaration.
 
 `UnsupportedPixelFormat` rather than a guess, though under the policy below a
-caller only reaches it when a server ignores what we asked for.
+caller only reaches it when a server ignores what was requested.
 
-**CPIXEL** (RFC 6143 §7.7.5) is three bytes when true colour, 32 bpp, depth ≤ 24
-and every colour bit sits in either the low or the high three bytes; which
+**CPIXEL** (RFC 6143 §7.7.5) is three bytes when true color, 32 bpp, depth ≤ 24
+and every color bit sits in either the low or the high three bytes; which
 placement is a function of the shifts. rfbproto adds a tie-break the RFC omits:
 at depth ≤ 16 both placements fit, and the low three bytes are sent.
 
@@ -130,8 +130,8 @@ Placement is in value space and `cpixel_offset` is in byte space, so big-endian
 reverses which end of the pixel they sit at. Slicing at the wrong end takes the
 pad byte and drops a channel.
 
-**TPIXEL** is narrower and fixed — depth exactly 24, all channels exactly 8
-bits, bytes red, green, blue — so a Tight rect tags 24 bpp RGB whatever was
+**TPIXEL** is narrower and fixed (depth exactly 24, all channels exactly 8
+bits, bytes red, green, blue), so a Tight rect tags 24 bpp RGB whatever was
 negotiated. It arrives with Tight at decoder Phase 6.
 
 This pass writes the CPIXEL functions and their tests; ZRLE keeps its current
@@ -150,16 +150,16 @@ Probed by feeding known words through each mode:
 
 `rgb565` is `BGR;16`: `0x00F8` little-endian yields `(255, 0, 0)`, so it is
 red-in-the-high-bits 565, matching `PixelFormat(16, 16, False, True, 31, 63, 31,
-11, 5, 0)` — the constant `client.py` calls `BGR16`.
+11, 5, 0)`, the constant `client.py` calls `BGR16`.
 
 Five layouts fall outside: **big-endian 16 bpp** (big-endian 32 bpp is another
 byte permutation, covered); **channel widths outside 8/8/8, 5/6/5, 5/5/5,
 4/4/4**; **non-byte-aligned shifts at 32 bpp**; **444 with red in the high
-nibble**, since Pillow has `RGB;4B` and no mirror of it; and **colour-mapped**,
+nibble**, since Pillow has `RGB;4B` and no mirror of it; and **color-mapped**,
 which is `P` plus `putpalette` rather than a raw mode.
 
 None needs a converter, because none is reachable while a server honours
-`SetPixelFormat` — an unreadable native means we ask for `bgrx8888`. A converter
+`SetPixelFormat`: an unreadable native means requesting `bgrx8888`. A converter
 is for a server that sends an exotic native *and* ignores the request, which no
 capture has shown. Measured for whenever one does: a 2^16-entry lookup table
 converts a 1080p frame in 23.7 ms, per-pixel Python in 160 ms.
@@ -173,7 +173,7 @@ The replacement runs at `vncConnectionMade`, before the first
 `FramebufferUpdateRequest`. Required, not tidy: rfbproto states a client **must
 not** have an outstanding request when it sends `SetPixelFormat`, since the next
 update would be undecidable between formats. There is no acknowledgement and no
-fence, so `--pixel-format` is connect-time only — a later switch needs the
+fence, so `--pixel-format` is connect-time only: a later switch needs the
 request drained, or a `SyncNext` fence around it. The client answers fences
 but does not offer the encoding or send one, so nothing yet drives that.
 
@@ -188,28 +188,28 @@ need not send one. #90 and #275 are servers that keep sending native after being
 asked otherwise; a client that never asked cannot be bitten by them. Step 3 has
 no measured caller.
 
-Nothing detects a server ignoring the request — the protocol offers no way. What
+Nothing detects a server ignoring the request: the protocol offers no way. What
 changes is that an unreadable native is a diagnosed error rather than a silent
 guess.
 
-A colour-mapped request leaves the map empty until `SetColourMapEntries`
-arrives, whatever the server set before; that lands with the colour-map slice.
+A color-mapped request leaves the map empty until `SetColourMapEntries`
+arrives, whatever the server set before; that lands with the color-map slice.
 
 ## Command line
 
     vncdo --pixel-format rgb565 capture screen.png
 
 Names from a registry, not a ten-field tuple: `bgrx8888`, `rgbx8888`, `rgb565`.
-Channel order as the bytes arrive, per-channel widths, `x` for a pad byte —
+Channel order as the bytes arrive, per-channel widths, `x` for a pad byte,
 naming the pad because it distinguishes the 32 bpp formats every server sends
 from the 24 bpp ones the specification does not allow. Fixtures use the same
 vocabulary, which is why `tigervnc-raw-rgb888` became `tigervnc-raw-bgrx8888`:
 a fixture is named for the format it holds, never for how that format was
 chosen.
 
-Every requestable name is 8, 16 or 32 bpp, all the specification permits. The
-24 bpp modes stay reachable by `raw_mode` and out of the registry — reading one
-is tolerance for an out-of-spec server, never something we ask for.
+Every requestable name is 8, 16, or 32 bpp, all the specification permits. The
+24 bpp modes stay reachable by `raw_mode` and out of the registry: reading one
+is tolerance for an out-of-spec server, never something vncdotool requests.
 
 `api.connect` gains a `pixel_format=` keyword taking the same names. `vnclog`
 gets no flag: the client negotiates, the proxy records what it saw.
@@ -219,16 +219,16 @@ gets no flag: the client negotiates, the proxy records what it saw.
 **Unit.** `raw_mode` over a table of formats, including pairs differing only by
 `depth` and only by endianness, plus `UnsupportedPixelFormat` for each uncovered
 layout. Then, per mode, known bytes through `Image.frombytes` to
-known RGB pixels — the mode string is a claim about Pillow, and that is the
+known RGB pixels: the mode string is a claim about Pillow, and that is the
 claim that can be wrong. CPIXEL gets both placements, the depth ≤ 16 tie-break,
 and the negative cases falling back to PIXEL width.
 
 **Negotiation.** Mocked transport asserting the `SetPixelFormat` bytes, or their
 absence, which is step 2 and the case a test would otherwise skip.
 
-`conditions.json` grows the pixel format, both the ServerInit one and any we
-requested. They are different facts and the interesting fixtures are where they
-differ.
+`conditions.json` grows the pixel format, both the ServerInit one and any that
+was requested. They are different facts and the interesting fixtures are where
+they differ.
 
 Golden and functional coverage at a second, reduced-precision format
 (`rgb565`) is deferred (see below).
@@ -243,7 +243,6 @@ Golden and functional coverage at a second, reduced-precision format
 ## Validated against the specs
 
 C2. Read from a local rfbproto clone (`DEVELOP.rst` says where) and RFC 6143.
-
 - **Format fields** (rfbproto §ServerInit, RFC 6143 §7.4): bpp must be 8, 16 or
   32 and ≥ depth; big-endian is meaningless at 8 bpp; each max is 2^n - 1, each
   shift brings its channel to the least significant bit. Also that "some servers
@@ -251,47 +250,48 @@ C2. Read from a local rfbproto clone (`DEVELOP.rst` says where) and RFC 6143.
 - **SetPixelFormat** (rfbproto §SetPixelFormat and §Client to Server Messages,
   RFC 6143 §7.5.1): optional for clients, mandatory for servers to support;
   absent it the ServerInit format applies; no acknowledgement; no outstanding
-  `FramebufferUpdateRequest` when sent; colour map empty immediately after.
+  `FramebufferUpdateRequest` when sent; color map empty immediately after.
 - **CPIXEL** (rfbproto §ZRLE, RFC 6143 §7.7.5): the four conditions, both
   placements, the low-three-bytes tie-break at depth ≤ 16.
 - **TPIXEL** (rfbproto §Tight): narrower, fixed RGB order. Corrects a "believed
   to follow the same rule" note in `decoder-architecture.md`.
 
 Unverified: how a real server behaves when asked for a format it dislikes. No
-document covers it; a capture will.
+document covers it; only a capture settles it.
 
 ## Deferred
 
 - **`rgb565` fleet coverage.** `tigervnc-tight-rgb565` is captured, so the
   golden half is done; no fleet case runs at the format yet. The diagnosis
-  recorded here — that `scene.vdo`'s exact-histogram `expect` cannot pass at
-  5-bit quantization — held, but the prescription did not: a per-format
+  recorded here (that `scene.vdo`'s exact-histogram `expect` cannot pass at
+  5-bit quantization) held, but the prescription did not: a per-format
   `maxrms` is the hand-tuned constant [decoder-goldens.md](decoder-goldens.md)
   warns against, and what it actually needed was for `expect` to read the
   tolerance off the format it negotiated.
 - The four layouts Pillow cannot unpack, each waiting for a capture from a
   server that sends one and ignores `SetPixelFormat`.
-- Colour map: `P` plus a palette, and the `SetColourMapEntries` ordering above.
-  vncev is the server to build it against once a real one turns up behind it.
+- Color map: `P` plus a palette, and the `SetColourMapEntries` ordering
+  described earlier. vncev is the server to build it against once a real one
+  turns up behind it.
 - The CPIXEL functions' use, which lands with ZRLE at decoder Phase 5.
 - A raw-tuple form of `--pixel-format`.
 
 ## Risks
 
 - A tolerance wide enough for 5-bit quantization can hide a real defect, and
-  nothing compensates — a cross-format comparison does not, for the reason in
+  nothing compensates: a cross-format comparison does not, for the reason in
   [decoder-goldens.md](decoder-goldens.md). What hides is narrower than the
-  whole class: a channel swap moves a coloured pixel much further than 255/31,
+  whole class: a channel swap moves a colored pixel much further than 255/31,
   so the tolerant comparison still fails on it, and what survives is a shift or
   rounding error smaller than one quantization step. Measured against the
   captured `tigervnc-tight-rgb565`: swapping the decoder's red and blue fails
   it on the first pixel of the first step, as does forcing TPIXEL to three
   bytes at a 16 bpp format.
-- Tagging moves the trust from our arithmetic to Pillow's mode strings. A mode
-  meaning something other than we think decodes silently wrong, where a bad
-  shift would at least be ours to read — hence unit tests asserting Pillow's
-  behaviour per mode, not only which mode we picked.
+- Tagging moves the trust from decoder arithmetic to Pillow's mode strings. A
+  mode meaning something other than expected decodes silently wrong, where a
+  bad shift would at least be visible on inspection, hence unit tests
+  asserting Pillow's behaviour per mode, not only which mode was picked.
 - Dropping the version-3.889 special case rests on one macOS version on a
   hosted runner. If an older ARD server announces something unreadable, it
-  now gets a `SetPixelFormat` for `rgbx8888` — the correct fallback, untested
+  now gets a `SetPixelFormat` for `rgbx8888`, the correct fallback, untested
   against that server.

--- a/specs/screen-stability.md
+++ b/specs/screen-stability.md
@@ -1,7 +1,7 @@
-# Screen Stability — Design
+# Screen Stability Design
 
 Status: draft, under review. Sibling of the `expect` matching design; this is
-the "Not in scope" item from it — blocking until the screen stops changing,
+the "Not in scope" item from it: blocking until the screen stops changing,
 with no reference image.
 
 ## Problem
@@ -15,12 +15,12 @@ plus throwaway `capture step.png` calls, from when no fuzz separated a JPEG
 rendering of the right scene from the wrong one. The metric that fixed that is
 in [expect-matching.md](expect-matching.md), but a pause is still a guess: too
 short and the capture tears, too long and the golden run pays for it eight
-times over — and neither is a question about a reference image.
+times over. Neither is a question about a reference image.
 
 The stronger case is outside the test suite. An agent driving `vncdo` captures
 a PNG and inspects it out of process; it cannot sit inside the reactor's
 `expect` poll loop, because each turn through that loop costs it a model call.
-What it needs before looking is "the screen has settled", which is a question
+What it needs before looking is "the screen has settled," which is a question
 `expect` cannot ask without already knowing the answer.
 
 ## Command
@@ -29,7 +29,7 @@ What it needs before looking is "the screen has settled", which is a question
     rstable SECONDS X Y W H [FUZZ]
 
 FUZZ is optional and trails, as it does for `expect FILE [FUZZ]`, and is read
-by the same `_trailing_fuzz` — a whole number in 0..255, or the next command
+by the same `_trailing_fuzz`: a whole number in 0..255, or the next command
 if it is not a number at all.
 
 `SECONDS` is **the length of the trailing window during which the framebuffer
@@ -47,8 +47,8 @@ Two properties follow, and both belong in the user documentation:
   `pause 1.5` it replaces.
 - **There is no upper bound.** Each qualifying change restarts the window, so
   the win over `pause` is at the top end, not the bottom: `pause 1.5` returns at
-  1.5s whether or not the repaint finished, where `stable 1.5` waits out however
-  long the repaint actually takes and then proves 1.5s of quiet.
+  1.5 s whether or not the repaint finished, where `stable 1.5` waits out however
+  long the repaint actually takes and then proves 1.5 s of quiet.
 
 ### Why a region variant is not speculative
 
@@ -71,7 +71,7 @@ about — `rcapture` appends its geometry after the base command's arguments,
 
 ## What "unchanged" compares
 
-`imagematch.matches(frame, baseline, fuzz, blur)` — the comparison `expect`
+`imagematch.matches(frame, baseline, fuzz, blur)` is the comparison `expect`
 uses, run against the previous frame instead of against a file. See
 [expect-matching.md](expect-matching.md) for the metric and the measurements
 behind it.
@@ -91,7 +91,7 @@ is worth more than the two or three units this gives away.
 
 ## How the window is driven
 
-Event-driven, on `commitUpdate` — the point where every rectangle of one
+Event-driven, on `commitUpdate`: the point where every rectangle of one
 `FramebufferUpdate` message has been applied (`rfb.py:338`, `client.py:456`).
 Nothing samples on a timer.
 
@@ -111,7 +111,7 @@ Rectangle-level completeness needs no work here. One update message may carry
 many rects, but `rfb.py:329` reads the count, calls `beginUpdate()`, consumes
 that many, and only then commits, so no consumer ever observes a half-applied
 message. What no message boundary marks is the end of a *logical* redraw, which
-may span several updates — that is the gap `stable` fills, and RFB offers no
+may span several updates. That is the gap `stable` fills, and RFB offers no
 marker for it.
 
 ### Keeping a request outstanding
@@ -127,7 +127,7 @@ The client holds a single `self.deferred` slot, fired by `commitUpdate`, so
 `stable` re-arms the same way `_expectCompare` does rather than holding a
 deferred of its own across rounds.
 
-With no baseline — `self.screen` is `None` on a fresh connection — the first
+With no baseline (`self.screen` is `None` on a fresh connection), the first
 request is non-incremental to establish one, and the window starts after it
 lands. `_expectCompare` already carries this shape.
 
@@ -149,9 +149,9 @@ argument.
 
 A screen that changes more often than every SECONDS never satisfies the window
 and hangs until that fires. There is deliberately **no "quietest window seen"
-fallback** — a command that sometimes returns a frame it knows to be unstable
+fallback**: a command that sometimes returns a frame it knows to be unstable
 gives the caller no way to tell the two outcomes apart, and the caller in the
-motivating case is an agent that will believe it. Fail loudly; the recovery is
+motivating case is an agent that believes it. Fail loudly; the recovery is
 `rstable` over a calmer region, or a longer `--timeout`.
 
 ## Python API
@@ -171,7 +171,7 @@ library. `waitStableScreen` reads better in isolation and breaks that mapping.
 
 State for one call lives in a `_StableWatch`, not on the client: a baseline
 frame, a timer and a settled flag outgrow the single `self.deferred` slot
-`_expectCompare` threads its state through. The flag is load-bearing — after
+`_expectCompare` threads its state through. The flag is load-bearing: after
 the window fires, a commit can still arrive against the last armed deferred,
 and without it the watch would re-arm and request forever.
 
@@ -179,7 +179,7 @@ and without it the watch would re-arm and request forever.
 
 **Fence (-312) and ContinuousUpdates (-313).** Fence is a barrier, not an idle
 detector: it reports that everything queued before it has been delivered, and
-says nothing about future updates. It could tighten the window's start — do not
+says nothing about future updates. It could tighten the window's start: do not
 begin counting until a fence returns.
 
 `rfb.py` now answers a server-initiated fence and can send a `ClientFence`, but
@@ -193,7 +193,7 @@ test could not depend on them in any case.
 Unit, `tests/unit/test_client.py`: drive the protocol class with the mocked
 transport the file already uses, and a `twisted.internet.task.Clock` for the
 window, calling `commitUpdate` directly with prepared frames. Never start the
-reactor. Cases worth one test each — window restarts on a change beyond FUZZ,
+reactor. Cases worth one test each: window restarts on a change beyond FUZZ,
 survives a repaint within FUZZ, a request stays outstanding across the window,
 no baseline means a non-incremental first request.
 

--- a/specs/server-compatibility-plan.md
+++ b/specs/server-compatibility-plan.md
@@ -1,11 +1,11 @@
 # Server Compatibility Plan
 
 Compatibility with the many VNC server implementations in the wild is an
-ongoing challenge for vncdotool. This document takes stock of where we are,
-maps the gaps to the failures users actually report, and lays out a phased
-plan to close them.
+ongoing challenge for vncdotool. This document takes stock of the current
+state, maps the gaps to the failures users actually report, and lays out a
+phased plan to close them.
 
-## Where we are today
+## Current state
 
 **Protocol surface implemented in `vncdotool/rfb.py`:**
 
@@ -24,38 +24,39 @@ installed. No other server implementation is exercised anywhere.
 
 ## What actually breaks, per the issue tracker
 
-- **Unsupported security types** — RealVNC-flavoured servers (Raspberry Pi
+- **Unsupported security types**: RealVNC-flavoured servers (Raspberry Pi
   OS default) offer only RA2/RA2ne/etc.: #310. Proxmox and other
   TLS-fronted servers need VeNCrypt: #138.
-- **Unsupported encodings** — servers that assume Tight support: #264.
-- **Pixel-format assumptions** — black or corrupted captures when a server
-  ignores our `SetPixelFormat` or uses a format outside what
+- **Unsupported encodings**: servers that assume Tight support: #264.
+- **Pixel-format assumptions**: black or corrupted captures when a server
+  ignores the client's `SetPixelFormat` or uses a format outside what
   `vncdotool/pixelformat.py` maps: #90, #275. The ZRLE decoder (still on
   the old `rfb.py` path, not yet migrated to `vncdotool/decoders/`) hard-codes
-  3-byte compressed pixels (32bpp/depth-24/little-endian only) — this part
+  3-byte compressed pixels (32bpp/depth-24/little-endian only). This part
   is still open. The rest of this bullet is resolved: the decoder refactor
   (#402–#430) fixed both CoRRE bugs and implemented real `CopyRect` as part
   of moving RRE/CoRRE/CopyRect onto the `vncdotool/decoders/` registry
   (#405); the pinned-failure tests that tracked them
   (`tests/unit/test_decoder_bugs.py`) were retired in the same change. Raw
   now blits its bytes directly (#430) with no pixel-format conversion step
-  and no TODO marking the gap — conversion is still unimplemented, just no
+  and no TODO marking the gap. Conversion is still unimplemented, just no
   longer flagged in a comment.
-- **Hangs instead of errors** — when negotiation or decoding goes wrong the
+- **Hangs instead of errors**: when negotiation or decoding goes wrong the
   reactor keeps waiting forever and the API never returns: #322 (silent
   disconnect/hang against shared TigerVNC), #284 ("Stopping factory" with
   no diagnosis), #262, #146. One concrete suspect: `ServerCutText` length
   is parsed as *unsigned* (`!xxxI`), but TigerVNC's Extended Clipboard
-  sends a *negative* length, which we then treat as a gigantic read that
-  never completes.
-- **Missing protocol features users need** — SetDesktopSize (#301),
+  sends a *negative* length, which vncdotool then treats as a gigantic read
+  that never completes.
+- **Missing protocol features users need**: SetDesktopSize (#301),
   ContinuousUpdates/Fence for sync and capture performance (#66, #201,
-  #273), WebSocket transport (#259), choosing depth/encoding from the CLI
-  (#167, #168), QEMU keysym gaps for symbol characters (#269).
+  #273), WebSocket transport (#259), choosing depth/encoding from the
+  command-line tool (#167, #168), QEMU keysym gaps for symbol characters
+  (#269).
 
 Two structural problems underlie all of these:
 
-1. **We can't see regressions.** Only LibVNCServer is in CI, so a change
+1. **Regressions go unseen.** Only LibVNCServer is in CI, so a change
    that breaks TigerVNC or QEMU ships silently, and a fix for one server
    can't be verified against the others.
 2. **Failures are silent.** The protocol layer's default response to
@@ -65,7 +66,7 @@ Two structural problems underlie all of these:
 
 ## The plan
 
-### Phase 0 — Measure: a server compatibility matrix in CI
+### Phase 0, Measure: a server compatibility matrix in CI
 
 Goal: every change runs the same scenario suite against a fleet of real
 servers, and the results are visible.
@@ -75,7 +76,7 @@ The framework itself is designed in
 supersedes this section's original sketch on several points. Summary:
 
 - **Unit tests are the regression layer; live servers are for smoke and
-  discovery.** Recorded traffic never replays in CI — bugs found live or
+  discovery.** Recorded traffic never replays in CI. Bugs found live or
   via capture are distilled into byte-level unit tests, and per-encoding
   decoder golden tests (crafted/captured FBU bytes → pixel-exact
   framebuffer assertions) replace live golden-PNG comparisons.
@@ -90,28 +91,29 @@ supersedes this section's original sketch on several points. Summary:
   wayvnc. The native libvncserver source build and the pexpect harness
   are retired.
 - The capture kit (`vnclog --capture-raw`, strip-at-capture) plus an
-  in-repo replay tool cover servers we cannot host — discovery evidence,
-  not CI fixtures.
+  in-repo replay tool cover servers that cannot be hosted, providing
+  discovery evidence, not CI fixtures.
 - A generated `docs/compatibility.rst` is **not** a requirement; the CI
   grid is the matrix, plus a hand-maintained caveats table here.
 
-How the servers themselves are obtained, pinned, and kept current — for
-local dev, CI, and gold-file creation — is covered in
+How the servers themselves are obtained, pinned, and kept current (for
+local dev, CI, and gold-file creation) is covered in
 [Acquiring and maintaining server access](#acquiring-and-maintaining-server-access).
 
 Acceptance: CI shows a per-server pass/fail grid driven by the Tier 1
-compose fleet; the proxy CLI has a `--capture` mode; decoder golden unit
-tests exist for at least the encodings LibVNCServer and TigerVNC
-negotiate.
+compose fleet; the proxy command-line tool has a `--capture` mode;
+decoder golden unit tests exist for at least the encodings LibVNCServer
+and TigerVNC negotiate.
 
-### Phase 1 — Robustness: fail loudly, never hang
+### Phase 1, Robustness: fail loudly, never hang
 
 Goal: an incompatible server produces a clear, specific error in seconds,
 not an infinite hang. This converts every future compatibility gap from a
 debugging session into a good bug report.
 
 - Add a negotiation timeout and surface **structured exceptions** through
-  both `api.connect()` and the CLI: `UnsupportedSecurityTypes(types)`,
+  both `api.connect()` and the command-line tool:
+  `UnsupportedSecurityTypes(types)`,
   `UnsupportedEncoding(enc)`, `AuthenticationError` (exists), each naming
   the server version string and what it offered. (#262, #284, #322, #146)
 - Accept any server protocol version: per RFC 6143 §7.1.1, treat anything
@@ -121,7 +123,7 @@ debugging session into a good bug report.
 - Handle `ServerCutText` with a signed length and ignore Extended
   Clipboard payloads gracefully instead of misreading them as a huge
   unsigned read (prime suspect for #322).
-- ~~Fix the CoRRE decoder bugs~~ — done in #405. Still open: enable
+- ~~Fix the CoRRE decoder bugs~~: done in #405. Still open: enable
   `PixelFormat.VALIDATE` in tests.
 - On unknown rectangle encodings, include the encoding name/number and the
   negotiated list in the error so reports like #264 arrive pre-diagnosed.
@@ -130,7 +132,7 @@ Acceptance: killing/misbehaving the server in any functional scenario
 fails the API call with a descriptive exception within the timeout; new
 unit tests cover version quirks, signed cut-text lengths, and CoRRE.
 
-### Phase 2 — Cover the servers people actually run
+### Phase 2, Cover the servers people actually run
 
 Goal: the default configurations of TigerVNC, TightVNC, UltraVNC, QEMU,
 and TLS-fronted servers work out of the box. Ordered by expected impact:
@@ -149,17 +151,17 @@ and TLS-fronted servers work out of the box. Ordered by expected impact:
    discarded by the client layer). Property-based tests render reference
    images through every decoder × pixel-format combination. (#90, #275,
    #168)
-4. **UltraVNC MS-Logon II (113/116)** — documented, implemented in other
+4. **UltraVNC MS-Logon II (113/116)**: documented, implemented in other
    open clients; moderate effort.
-5. **RealVNC RA2/RA2ne (5/6/13)** — partially reverse-engineered in other
-   clients; spike first, and if infeasible, detect it and print exact
+5. **RealVNC RA2/RA2ne (5/6/13)**: partially reverse-engineered in other
+   clients; spike first, and if infeasible, detect it, and print exact
    instructions for switching the server to "VNC password" mode. (#310)
 
 Acceptance: the Phase 0 matrix gains passing columns for TigerVNC (TLS),
 TightVNC (Tight encoding negotiated), and QEMU; screenshots verified
 pixel-exact against reference images for every supported pixel format.
 
-### Phase 3 — Protocol features that modern servers expect
+### Phase 3, Protocol features that modern servers expect
 
 - **ExtendedDesktopSize** pseudo-encoding + **SetDesktopSize** client
   message (#301), replacing the legacy DesktopSize-only path.
@@ -174,7 +176,7 @@ pixel-exact against reference images for every supported pixel format.
 - **Keysym audit** against QEMU/KVM for symbol characters and layouts
   (#269, #65).
 
-### Phase 4 — Keep it working
+### Phase 4, Keep it working
 
 - Maintain the hand-written caveats table in this doc; revisit
   auto-generation only if someone asks for it.
@@ -184,25 +186,25 @@ pixel-exact against reference images for every supported pixel format.
   closed.
 - Add `server:<name>` issue labels and a `vncdo probe`-style diagnostic
   command that connects, prints the server version string, offered
-  security types, and negotiated encodings, then exits — the first thing
-  to ask any reporter to run.
+  security types, and negotiated encodings, then exits: it is the first
+  thing to ask any reporter to run.
 - Slower matrix jobs (QEMU with a real guest image, the Tier 2 OS
-  runners) run change-triggered behind path filters — never on a
-  schedule — keeping PR CI fast and idle-repository cost zero.
+  runners) run change-triggered behind path filters (never on a
+  schedule), keeping PR CI fast and idle-repository cost zero.
 
 ## Acquiring and maintaining server access
 
 The matrix, the gold files, and every phase after them depend on one
-operational question: how do we get — and keep — access to the servers we
-claim to support? The answer is three tiers with different acquisition
-models, plus a shared reproducibility discipline.
+operational question: how does vncdotool get and keep access to the
+servers it claims to support? The answer is three tiers with different
+acquisition models, plus a shared reproducibility discipline.
 
 **Guiding principle: live servers beat recordings, always.** A recorded
-capture proves we *once* interoperated with one version of a server; a
-live test proves we *still* do. Captures are therefore discovery
-evidence for servers we cannot run — never a substitute where live
-access is possible, and never CI fixtures: the durable regression floor
-is the unit test distilled from them
+capture proves vncdotool *once* interoperated with one version of a
+server; a live test proves it *still* does. Captures are therefore
+discovery evidence for servers that cannot be run live. They are never a
+substitute where live access is possible, and never CI fixtures: the
+durable regression floor is the unit test distilled from them
 (see [testing-framework.md](testing-framework.md)).
 Concretely:
 
@@ -210,8 +212,8 @@ Concretely:
   assignment is revisited as circumstances change: a new container image,
   a licensing change, or emulation making a Tier 3 server runnable
   promotes it to Tier 1/2.
-- We actively invest in promotions. For example, RealVNC on Raspberry Pi
-  OS — today's canonical Tier 3 case — is a candidate for a live CI job
+- Promotions are actively pursued. For example, RealVNC on Raspberry Pi
+  OS (today's canonical Tier 3 case) is a candidate for a live CI job
   via a QEMU-emulated Pi OS image on an ubuntu runner; if that works it
   leaves Tier 3 entirely.
 - Where both exist, the live run is the source of truth for the
@@ -219,22 +221,23 @@ Concretely:
   for unit-level decoder golden bytes, refreshed *from* live runs where
   possible rather than treated as an independent authority.
 
-### Tier 1 — Containerized Linux fleet (we own it, fully reproducible)
+### Tier 1, Containerized Linux fleet (fully owned, fully reproducible)
 
 TigerVNC, TightVNC, x11vnc, QEMU, LibVNCServer examples, and later
-websockify/noVNC are all runnable on Linux, so we own them outright as a
-**Docker Compose fleet**. (QEMU here is a containerized guest for local-dev
-convenience — Docker Desktop has no `/dev/kvm`, so it runs TCG-only and
-boots slower; the CI-real, KVM-accelerated QEMU coverage lives in Tier 2
-below, run raw on the runner rather than in a container.)
+websockify/noVNC are all runnable on Linux, so vncdotool owns them
+outright as a **Docker Compose fleet**. (QEMU here is a containerized
+guest for local-dev convenience: Docker Desktop has no `/dev/kvm`, so it
+runs TCG-only and boots slower; the CI-real, KVM-accelerated QEMU
+coverage lives in Tier 2 below, run raw on the runner rather than in a
+container.)
 
 - One `tests/servers/docker-compose.yml` defines a service per
   server × configuration (`tigervnc`, `tigervnc-auth`, `tigervnc-tls`,
   `x11vnc`, `qemu`, …), each on a distinct localhost port, each **pinned by
   image digest**. Where no trustworthy upstream image exists, a small
   in-repo Dockerfile under `tests/servers/<name>/` pins the package or
-  source-tarball version instead — we prefer vendored Dockerfiles over
-  third-party desktop images we don't control.
+  source-tarball version instead: vendored Dockerfiles are preferred over
+  third-party desktop images that aren't under vncdotool's control.
 - `make servers-up`, `make servers-down`, and `make server-<name>` wrap
   compose so contributors never need to learn the fleet's internals; the
   same compose file is what the CI matrix jobs run. **Local dev and CI use
@@ -244,26 +247,26 @@ below, run raw on the runner rather than in a container.)
   compose services, built in-container and pinned like the rest. No host
   toolchain requirement remains.
 
-### Tier 2 — OS-bound live servers on hosted runners (change-triggered)
+### Tier 2, OS-bound live servers on hosted runners (change-triggered)
 
 UltraVNC only runs on Windows; Apple Screen Sharing/ARD only on macOS.
 Windows *containers* don't solve this: they exist
-(`mcr.microsoft.com/windows/servercore` etc.) but are GUI-less — there is
+(`mcr.microsoft.com/windows/servercore` etc.) but are GUI-less (there is
 no desktop session for a VNC server to share, so a screen-sharing server
-has nothing to serve — and they only run on Windows hosts anyway (no help
+has nothing to serve), and they only run on Windows hosts anyway (no help
 for local dev on Linux/macOS, and no such thing as a macOS container at
 all). So these two stay on full GitHub-hosted `windows-latest` /
-`macos-latest` VMs, which are free for public repositories — but we only
-spin them up when something relevant changes.
+`macos-latest` VMs, which are free for public repositories, but they are
+only spun up when something relevant changes.
 
 **QEMU/KVM joins this tier too, but for a different reason.** It's not a
-necessity — a container with `--device /dev/kvm` passed through works fine,
+necessity: a container with `--device /dev/kvm` passed through works fine,
 and that's exactly what Tier 1's `qemu` service is for local dev. It's here
 by choice: GitHub-hosted `ubuntu-latest` runners have had `/dev/kvm` since
 2023 (enabled for the Android emulator action's nested virtualization), so a
-raw `qemu-system-x86_64 -enable-kvm -vnc :0` on the bare runner — no
-container, no guest OS even, the BIOS/firmware framebuffer alone is enough
-to exercise QEMU's own RFB server — matches how real users actually meet
+raw `qemu-system-x86_64 -enable-kvm -vnc :0` on the bare runner (no
+container, no guest OS even; the BIOS/firmware framebuffer alone is enough
+to exercise QEMU's own RFB server) matches how real users actually meet
 this server (a cloud provider's VM console, `virt-manager`, a bare `qemu`
 invocation) more closely than a Dockerized one would. Same rationale as
 Windows/macOS being untouched by a Python display driver: the server under
@@ -272,7 +275,7 @@ test should look like what a user's server actually looks like. It runs on
 than the other two Tier 2 jobs, but it follows the same change-triggered
 trigger policy and setup/diagnostics script pattern below.
 
-For all three jobs, we only spin them up when something relevant changes:
+For all three jobs, each is only spun up when something relevant changes:
 
 - The workflow triggers on `pull_request`/`push` **path-filtered to code
   that can affect server compatibility** (`vncdotool/**`, the workflow
@@ -286,13 +289,13 @@ For all three jobs, we only spin them up when something relevant changes:
 - Each successful run can upload a wire capture as an artifact for
   offline debugging.
 
-### Tier 3 — Capture-only servers (community-sourced evidence)
+### Tier 3, Capture-only servers (community-sourced evidence)
 
 RealVNC (Raspberry Pi OS), VMware/ESXi consoles, Proxmox, MobaXterm, and
 anything else licensing or hardware puts out of CI's reach are covered by
-community-recorded captures — but per the guiding principle, Tier 3 is
-the tier of **last resort**: membership means "we have not yet found a
-way to run this server live", and each Tier 3 server carries a note on
+community-recorded captures. But per the guiding principle, Tier 3 is
+the tier of **last resort**: membership means "a way to run this server
+live has not yet been found," and each Tier 3 server carries a note on
 what its promotion path would be (emulation, a licensing change, a
 self-hosted runner). Until promoted, the supply chain for these is the
 community, so contributing a capture must be a paved road (detailed in
@@ -300,7 +303,7 @@ community, so contributing a capture must be a paved road (detailed in
 
 1. **Record**: `vncdolog --capture DIR` sits between the reporter's
    client (or a `vncdo` script) and their server; out comes a capture
-   directory — `session.vdo`, raw `s2c.bin`/`c2s.bin` streams, and
+   directory: `session.vdo`, raw `s2c.bin`/`c2s.bin` streams, and
    `meta.json` (server version string, security types offered, geometry).
    The proxy removes secrets by construction: the auth exchange is stripped
    at capture time and a `none`-auth handshake recorded in its place, never
@@ -309,7 +312,7 @@ community, so contributing a capture must be a paved road (detailed in
    report" issue. Captures are issue-thread evidence, not repo fixtures.
 3. **Distill**: a maintainer replays the capture at the real client with
    the in-repo replay tool (`vncdo-replay`), finds the
-   bug, and lands a byte-level unit test — that test, not the capture,
+   bug, and lands a byte-level unit test; that test, not the capture,
    is the permanent regression guard.
 
 Golden bytes for decoder unit tests follow the same discipline at Tier 1:
@@ -324,9 +327,9 @@ reviewable PR diffs.
   `tests/servers/versions.md` table that CI, make, and manifests all
   reference.
 - **Pinned on PRs, latest on schedule**: PR CI always runs the pinned
-  fleet. A weekly scheduled job — Tier 1 containers only, cheap ubuntu
+  fleet. A weekly scheduled job (Tier 1 containers only, cheap ubuntu
   minutes; OS runners are exercised solely by change-triggered runs and
-  manual dispatch — re-runs the matrix against `:latest` images / newest
+  manual dispatch) re-runs the matrix against `:latest` images / newest
   packages and *files an issue* on failure instead of breaking PRs, so
   upstream drift becomes a tracked task, not a fire.
 - Version-bump PRs (Dependabot/Renovate on image digests, or the weekly
@@ -334,12 +337,12 @@ reviewable PR diffs.
   server in the same PR, so pins and fixtures always move together.
 - Ownership is explicit per tier: Tier 1 is maintainable by anyone with
   Docker; Tier 2 needs no hardware, only workflow upkeep; Tier 3 is
-  honestly documented as "we do not own this access" and lives or dies by
-  the recording pipeline — which is why the paved road above matters.
+  honestly documented as "this access is not owned" and lives or dies by
+  the recording pipeline, which is why the preceding paved road matters.
 
 ### Spike results (Tier 1 / Tier 2 viability)
 
-**Tier 1 — VIABLE.** Branch `claude/spike-server-fleet` (commit
+**Tier 1: VIABLE.** Branch `claude/spike-server-fleet` (commit
 `bbfd188`) holds a working proof: three in-repo Dockerfile-based services
 (`tigervnc` no-auth, `tigervnc-auth` VNC-password, `x11vnc` over Xvfb)
 defined in `tests/servers/docker-compose.yml` with `nc`-based
@@ -348,23 +351,23 @@ a parameterized `tests/functional/test_server_compat_docker.py` that connects, t
 and captures against each server. GitHub Actions run
 [31729730724](https://github.com/sibson/vncdotool/actions/runs/31729730724)
 is green end-to-end: image builds + healthcheck-gated `up --wait` in
-~39s, all three per-server tests pass, non-black screenshots uploaded as
-artifacts, clean teardown — ~70s total, no flakiness observed. Local
-verification ran the identical test module against natively-started
+~39 s, all three per-server tests pass, non-black screenshots uploaded as
+artifacts, clean teardown, ~70 s total, no flakiness observed. Local
+verification ran the identical test module against natively started
 servers on the same ports (3/3 pass; the dev sandbox's egress policy
-blocks registry pulls, a sandbox limitation, not a design one — the
+blocks registry pulls, a sandbox limitation, not a design one: the
 maintainer's machine with normal Docker Hub access runs the compose path
 directly).
 
 Findings worth keeping:
 - `api.connect()` leaves the Twisted reactor thread running until
-  `api.shutdown()` — without it, test processes and CI steps hang forever
+  `api.shutdown()`: without it, test processes and CI steps hang forever
   after passing. Any harness built on the API needs a
   `tearDownModule`-style shutdown. (Also more evidence for the Phase 1
   "hangs instead of errors" theme.)
 - Debian/Ubuntu split TigerVNC packaging: `vncpasswd` lives in
   `tigervnc-tools`, needed alongside `tigervnc-standalone-server`.
-- Images stay small and layer-cached (~15–20s builds); healthchecks make
+- Images stay small and layer-cached (~15–20 s builds); healthchecks make
   `up --wait` a reliable barrier.
 
 **Graduated:** this spike's workflow has been folded into the `servers` job
@@ -376,7 +379,7 @@ Tier 1 follow-ups:
   reach the web only as a zipped artifact: the job summary carries a
   server/port/resolution table, but seeing the pixels means download →
   unzip → open `index.html`. Actions has no inline preview for artifact
-  contents, and inlining the PNGs as `data:` URIs doesn't help — the
+  contents, and inlining the PNGs as `data:` URIs doesn't help: the
   markdown sanitizer strips them. Deploying the generated gallery to
   Pages gives a stable URL to link from the job summary (and outlives
   artifact expiry, which matters once fixtures reference these images).
@@ -385,10 +388,10 @@ Tier 1 follow-ups:
   option if Pages is unwanted: push captures to an orphan branch and have
   the workflow post/update a PR comment with `raw.githubusercontent.com`
   image links, so they render inline where review happens.
-- **Image build tax — done.** The `servers` job in `ci.yml` pulls the fleet
+- **Image build tax: done.** The `servers` job in `ci.yml` pulls the fleet
   from GHCR, tagged with the `tests/servers` tree hash, instead of
   rebuilding it. A miss falls back to building, so a PR that edits the
-  fleet — and any fork PR — behaves as it did before the registry existed,
+  fleet (and any fork PR) behaves as it did before the registry existed,
   and a `main` push that built publishes what it built once the suite is
   green. Publishing lives in that same job because a separate workflow
   raced it: on the one push where the tag was new, both started together
@@ -400,11 +403,11 @@ Tier 1 follow-ups:
 
   Not `type=gha` layer caching: it was measured on this fleet and every
   configuration came out slower than the plain `docker compose --build`
-  it replaced (68–106s against ~50s). Two costs sink it. `docker buildx`
+  it replaced (68–106 s against ~50 s). Two costs sink it. `docker buildx`
   needs the `docker-container` driver to export cache at all, and pulling
-  `moby/buildkit` to get one costs 6–11s a run that plain compose never
+  `moby/buildkit` to get one costs 6–11 s a run that plain compose never
   pays; and `--load` then has to copy five finished images back out of
-  that container into the daemon. Restore never made that back — with
+  that container into the daemon. Restore never made that back: with
   correct per-target `scope=` the manifests import, but the expensive
   layers still rebuild, so all five `apt-get install`s and the
   libvncserver compile re-ran on every warm run. GHCR wins even against
@@ -413,7 +416,7 @@ Tier 1 follow-ups:
 - Pin base images by digest.
 - Deepen what the per-server scenario actually asserts (see Phase 0).
 
-**Tier 2 — VIABLE on both OSes**, proven on branch
+**Tier 2: VIABLE on both OSes**, proven on branch
 `claude/spike-os-servers` (commit `2de3252`, workflow
 `spike-os-servers.yml`); final run
 [31730610001](https://github.com/sibson/vncdotool/actions/runs/31730610001)
@@ -427,51 +430,51 @@ scripts under `tests/servers/ultravnc/` and `tests/servers/screen-sharing/`
 description, round trip and screenshot gallery as Tier 1 via
 `tests/functional/utils.py`.
 
-*Windows / UltraVNC — works, full recipe:*
+*Windows / UltraVNC: works, full recipe:*
 - `choco install ultravnc`; `winvnc.exe` lands at the fixed path
   `C:\Program Files\uvnc bvba\UltraVNC\winvnc.exe` (never search
-  `Program Files` recursively — minutes-slow on runner images).
+  `Program Files` recursively: minutes-slow on runner images).
 - UltraVNC refuses all connections until a password is set, regardless of
-  `AuthRequired` — there is no no-auth shortcut. The `ultravnc.ini`
+  `AuthRequired`: there is no no-auth shortcut. The `ultravnc.ini`
   `passwd=` hex uses the classic VNC password-*file* obfuscation (DES
-  with the fixed `vncauth.c` key, bit-reversed) — not the
-  challenge-response transform — and is computable in a few lines of
+  with the fixed `vncauth.c` key, bit-reversed), not the
+  challenge-response transform, and is computable in a few lines of
   Python on the runner.
 - Must run as a Windows service (`winvnc.exe -install` +
   `Start-Service`); `winvnc.exe -run` opens an interactive settings
   dialog instead of serving.
 - `vncdo type` + `capture` succeed with genuine, non-black desktop
-  content — Windows gives us real visual assertions.
+  content: Windows gives real visual assertions.
 
-*macOS / Screen Sharing — works at the protocol level, with one caveat:*
+*macOS / Screen Sharing: works at the protocol level, with one caveat:*
 - `sysadminctl -addUser` a dedicated user, then `kickstart -activate
   -configure -access -on -users … -privs -all -restart -agent`; Screen
   Sharing is socket-activated on port 5900 out of the box.
-- Auth is **ARD/Diffie-Hellman (type 30)** with username+password —
+- Auth is **ARD/Diffie-Hellman (type 30)** with username+password:
   vncdotool's existing ARD support handles it. The legacy VNC-password
   path is confirmed dead on modern macOS: kickstart accepts the flags
   silently but the server still demands ARD auth. (Bonus finding: when
   no username is supplied, `rfb.py` falls into an interactive
   `input("username:")` prompt and crashes with `EOFError` on a TTY-less
-  runner — another Phase 1 fail-loudly item.)
+  runner: another Phase 1 fail-loudly item.)
 - The captured framebuffer is fully black: the runner has no rendered
   desktop to serve. So macOS jobs validate protocol, auth, and input
-  events, but not pixels — visual assertions need a follow-up spike into
+  events, but not pixels: visual assertions need a follow-up spike into
   whether a display can be attached, or must be scoped out for macOS.
   (Later finding, from the job's own `log show` artifacts: the black
   screen was the *dedicated user* rather than the runner. Connecting as
   someone other than the console owner fast-user-switches into that
   account's first login, which sat at Setup Assistant for the rest of
   the job. The setup now authenticates as the console owner instead,
-  recovering its auto-login password from /etc/kcpassword — that account
-  holds a secure token, so the password cannot be set, only read — which
-  took the job from 2m37 to 33s. The black framebuffer survived that
+  recovering its auto-login password from /etc/kcpassword (that account
+  holds a secure token, so the password cannot be set, only read), which
+  took the job from 2m37 to 33 s. The black framebuffer survived that
   change, so it really is a runner with no display: attaching to a live,
-  logged-in session still captures one colour. See
+  logged-in session still captures one color. See
   tests/servers/screen-sharing/README.md.)
 
 *Graduation into Phase 0 proper:* both jobs graduate under the
-change-triggered policy above — Windows as a full type+capture check with
+preceding change-triggered policy: Windows as a full type+capture check with
 real screen content, macOS as a protocol/auth/input check with pixel
 assertions explicitly excluded until the black-framebuffer question is
 answered. Productionizing should keep the dedicated-user and
@@ -479,7 +482,7 @@ service-mode setup steps and move passwords into repository secrets.
 
 **Graduated:** this spike's workflow now lives at
 `.github/workflows/os-servers.yml` (renamed from `spike-os-servers.yml`),
-change-triggered, path-filtered, and PR-blocking per the policy above.
+change-triggered, path-filtered, and PR-blocking per the preceding policy.
 Credentials come from `VNC_OS_SERVER_USERNAME`/`VNC_OS_SERVER_PASSWORD`
 repository secrets, falling back to the spike values when unset.
 
@@ -495,14 +498,14 @@ script already does everything the action needs.
 
 | Phase | Rough size | Depends on |
 |---|---|---|
-| 0 — CI matrix + capture kit + decoder goldens | Medium; pure test/infra, no protocol risk | — |
-| 1 — Robustness/error reporting | Small–medium; touches negotiation paths | 0 (to verify against matrix) |
-| 2 — Tight, VeNCrypt, pixel formats | Large; the core protocol work | 0, 1 |
-| 3 — Desktop size, CU/Fence, WebSocket, clipboard | Medium, parallelizable per feature | 2 |
-| 4 — Docs, templates, diagnostics | Small, ongoing | 0 |
+| 0, CI matrix + capture kit + decoder goldens | Medium; pure test/infra, no protocol risk | none |
+| 1, Robustness/error reporting | Small–medium; touches negotiation paths | 0 (to verify against matrix) |
+| 2, Tight, VeNCrypt, pixel formats | Large; the core protocol work | 0, 1 |
+| 3, Desktop size, CU/Fence, WebSocket, clipboard | Medium, parallelizable per feature | 2 |
+| 4, Docs, templates, diagnostics | Small, ongoing | 0 |
 
 Phases 0 and 1 are deliberately front-loaded: they are cheap, carry no
-protocol-breakage risk, and multiply the value of everything after them —
+protocol-breakage risk, and multiply the value of everything after them:
 every Phase 2/3 feature lands with matrix coverage, and every future user
 report arrives as an actionable error message plus, ideally, a capture.
 
@@ -513,7 +516,7 @@ report arrives as an actionable error message plus, ideally, a capture.
 | #90, #168, #275 | Phase 2.3 pixel formats |
 | #138, #259 | Phase 2.2 VeNCrypt + Phase 3 WebSocket |
 | #146, #262, #284, #322 | Phase 1 timeouts/errors (+ cut-text fix) |
-| #167 | Phase 2.1/2.3 + CLI flag |
+| #167 | Phase 2.1/2.3 + command-line-tool flag |
 | #201, #66, #273 | Phase 3 ContinuousUpdates/Fence |
 | #264 | Phase 2.1 Tight + Phase 1 diagnostics |
 | #269, #65 | Phase 3 keysym audit |
@@ -531,11 +534,11 @@ report arrives as an actionable error message plus, ideally, a capture.
 - **Decoder rewrites regress existing users**: the Phase 0 decoder
   golden unit tests (pixel-exact, per encoding) are the guard rail; land
   them first.
-- **Upstream supply disappears**: a Chocolatey package or base image we
-  pin can vanish or break. Mitigations: vendored in-repo Dockerfiles
+- **Upstream supply disappears**: a Chocolatey package or base image that
+  is pinned can vanish or break. Mitigations: vendored in-repo Dockerfiles
   rather than third-party images, pins with the weekly drift job to catch
-  breakage early, and distilled unit tests as the permanent floor — a
-  server we lose live access to degrades to Tier 3, not to zero coverage.
+  breakage early, and distilled unit tests as the permanent floor: a
+  server that loses live access degrades to Tier 3, not to zero coverage.
 - **Tier 3 evidence goes stale**: a capture records one server version
   at one moment. `meta.json`'s version field makes staleness visible,
   and the paved capture road keeps the cost of a refreshed contribution

--- a/specs/testing-framework.md
+++ b/specs/testing-framework.md
@@ -1,4 +1,4 @@
-# Server Testing Framework — Design
+# Server Testing Framework Design
 
 Status: draft, under review. Companion to
 [server-compatibility-plan.md](server-compatibility-plan.md); this document
@@ -7,20 +7,20 @@ designs the Phase 0 framework that plan calls for.
 ## Problem
 
 vncdotool talks to many VNC server implementations and breaks against them
-invisibly: only LibVNCServer is meaningfully covered today. We need a common
-set of scenarios run against real servers, a road for evidence from servers
-we cannot host, and regression coverage that survives without any server at
-all.
+invisibly: only LibVNCServer is meaningfully covered today. This calls for a
+common set of scenarios run against real servers, a road for evidence from
+servers that cannot be hosted, and regression coverage that survives without
+any server at all.
 
 ## Principle
 
 **Unit tests are the regression layer. Live servers are for smoke and
-discovery. Captures are for discovery against servers we can't run.**
+discovery. Captures are for discovery against servers that can't be run.**
 
 Replay of recorded traffic is inherently flaky and never runs in CI. A bug
 found against a live server or a capture is *distilled* into a byte-level
 unit test (the `test_issue_90` pattern: feed crafted bytes into
-`VNCDoToolClient` with a mocked transport — no socket, no reactor,
+`VNCDoToolClient` with a mocked transport: no socket, no reactor,
 deterministic). The live tier and the capture kit are bug *sources*; the
 unit suite is where bugs stay fixed.
 
@@ -33,7 +33,7 @@ unit suite is where bugs stay fixed.
   (`tests/unit/test_rfb.py`, `test_client.py`) per existing convention;
   `test_issue_NNN.py` remains the triage staging area.
 - **Decoder golden tests**: per-encoding FBU byte sequences (raw, RRE,
-  hextile, ZRLE, Tight, ...) fed to the client, decoded framebuffer
+  hextile, ZRLE, Tight, and so on) fed to the client, decoded framebuffer
   asserted pixel-exactly. Fixture bytes are captured once (via the capture
   tool, against any server that speaks the encoding) and committed. This
   replaces the pexpect golden-PNG tests with a stronger net: deterministic
@@ -46,17 +46,17 @@ unit suite is where bugs stay fixed.
 Tier 1 = the Docker Compose fleet (`tests/servers/`). Tier 2 = OS-hosted
 servers on Windows/macOS runners (`os-servers.yml`).
 
-**Scenario grid**: a small core scenario set crossed with every server —
+**Scenario grid**: a small core scenario set crossed with every server:
 connect, key press, mouse move, screenshot (and expect where a desktop
 renders). Implemented as plain `unittest` test methods on the existing
-server-test mixin — one method per scenario, one subclass per server.
+server-test mixin, one method per scenario, one subclass per server.
 No scenario registry / NamedTuple machinery: the method grid *is* the
 matrix. A reduced capability model survives on the server descriptors
-(`renders_desktop`, `known_size`, auth fields) to drive honest skips —
-e.g. macOS Screen Sharing's black framebuffer.
+(`renders_desktop`, `known_size`, auth fields) to drive honest skips, for
+example, macOS Screen Sharing's black framebuffer.
 
-**Fleet identity**: the fleet is machine-global — fixed ports 5931-5935 and
-one compose project — while checkouts are many, and the Dockerfile bakes
+**Fleet identity**: the fleet is machine-global, fixed ports 5931-5935 and
+one compose project, while checkouts are many, and the Dockerfile bakes
 committed files (the scene PNGs, `scene_player.py`, the entrypoints) into
 its images. So a checkout that never ran `make servers-up` tests against
 whichever checkout did, reading that checkout's baked files back off the
@@ -67,7 +67,7 @@ the running container, so the mismatch fails by name in `servers-up` and in
 the tests that depend on baked content. The hash is of `HEAD`, so a fleet
 built from uncommitted edits to those files tags as the commit it sits on.
 
-**Execution model**: every fleet scenario runs the real CLI via
+**Execution model**: every fleet scenario runs the real command-line tool via
 `subprocess.run(["vncdo", ...], timeout=N)`.
 
 - One hang-containment mechanism for every hang class: the kernel reaps the
@@ -75,10 +75,11 @@ built from uncommitted edits to those files tags as the commit it sits on.
   ordering, no poisoned reactor coupling tests to each other. This is what
   lets the framework cope with a client that (pre-Phase 1) still hangs
   against hostile servers: CI fails on timeout, never hangs.
-- It exercises the CLI surface (arg parsing, exit codes, `--nocursor`, ...)
-  as a side effect, so the old pexpect CLI tests fold in here.
+- It exercises the command-line tool's surface (arg parsing, exit codes,
+  `--nocursor`, and more) as a side effect, so the old pexpect command-line
+  tests fold in here.
 
-**Input verification — event sinks, not pixels**: "did the server process
+**Input verification (event sinks, not pixels)**: "did the server process
 `type foo`" is asserted against an event log, never a screenshot.
 
 - *vncev container* (client conformance): libvncserver's `vncev` as a
@@ -89,33 +90,37 @@ built from uncommitted edits to those files tags as the commit it sits on.
 - *X-side sink* (server processing): X-based fleet containers (x11vnc/Xvfb,
   Xvnc) run `xev`/`xinput test` inside, logging to stdout or a file; tests
   read it via `docker compose logs` / `docker exec`. Verifies the server
-  translated the VNC event into a real X event — the full path. Per-server
+  translated the VNC event into a real X event, the full path. Per-server
   input quirks surface as event-log diffs.
 
 Both are poll-a-log-with-deadline. Tier 2 has no sink yet; see open
 questions.
 
 **In-process API suite** (small, separate): the library API needs live
-coverage of its *lifecycle*, not of server compatibility — `api.connect`,
-error propagation, timeouts, `api.shutdown` cleanliness — against a single
-known-good container. One reactor per process means exactly one module
-(`test_api_lifecycle.py`) may ever touch `vncdotool.api` in-process; it is
-safe inside the shared functional discover because every other module is
-subprocess-only and never touches that reactor, regardless of run order —
-`make test-api` also runs it alone. It does not fan out across the fleet:
+coverage of its *lifecycle*, not of server compatibility. That means
+`api.connect`, error propagation, timeouts, and `api.shutdown` cleanliness,
+tested against a single known-good container. One reactor per process means
+
+exactly one module (`test_api_lifecycle.py`) may ever touch `vncdotool.api`
+in-process; it is safe inside the shared functional discover because every
+other module is subprocess-only and never touches that reactor, regardless
+of run order.
+
+`make test-api` also runs it alone. It does not fan out across
+the fleet:
 server compatibility is already proven by the subprocess grid.
 
 ### 3. Capture kit (discovery for unhosted servers)
 
-For servers we cannot run (RealVNC, Proxmox, ...), contributors submit
-evidence instead of access.
+For servers that cannot be run (RealVNC, Proxmox, and others), contributors
+submit evidence instead of access.
 
 **Capture tool**: a `--capture-raw ARCHIVE.zip` flag on the existing proxy
-CLI (`vnclog`). Contributor pip-installs released vncdotool, points their
-client (or a `vncdo` script) through the proxy at their server, and gets a
-capture archive to attach to an issue. No repo checkout required.
+command-line tool (`vnclog`). Contributor pip-installs released vncdotool,
+points their client (or a `vncdo` script) through the proxy at their server,
+and gets a capture archive to attach to an issue. No repo checkout required.
 
-Capture archive format — bytes stay dumb, parsing happens at
+Capture archive format. Bytes stay dumb, and parsing happens at
 replay/distill time, so the format never needs versioning:
 
     session.vdo   # what was driven (vncdo script / logged commands)
@@ -133,34 +138,34 @@ handshake is not the credential exchange that happened; it is a synthetic
     c2s.bin:  <recorded greeting> [<chosen type: none>]
               <recorded ClientInit onwards>
 
-The bracketed steps depend on the version the original client negotiated —
-pre-3.7 has the server pick the type in a 4-byte field, and pre-3.8 `none`
+The bracketed steps depend on the version the original client negotiated.
+Pre-3.7 has the server pick the type in a 4-byte field, and pre-3.8 `none`
 carries no SecurityResult. Nothing from the real auth exchange is written:
 not zeroed, not shortened, *absent*.
 
 This replaces equal-length zero redaction, and is a stronger guarantee for
-a contributor to reason about — "the archive contains no credential bytes"
-rather than "the credential bytes are zeros". It is also what makes replay
+a contributor to reason about: "the archive contains no credential bytes"
+rather than "the credential bytes are zeros." It is also what makes replay
 a dumb byte-pusher: the archive already describes a session any client can
 connect to without a password, whatever the original server demanded.
 
 **Stripping requires following the handshake.** Skipping the auth exchange
 means knowing where it ends, which needs a grammar for it. vncdotool has
 one for `none`, VNC auth and ARD, and none for tight, vencrypt, rsa-aes or
-MS-Logon — so a session negotiating one of those still aborts the capture
-by default, exactly as the zero-redaction design did, with the reason
-restated: not "we cannot find the secret" but "we cannot find the end of
-it". The escape hatch below is the same one.
+MS-Logon. A session negotiating one of those still aborts the capture by
+default, exactly as the zero-redaction design did, with the reason restated:
+not "the secret can't be found" but "the end of it can't be found." The
+escape hatch below is the same one.
 
 **`--capture-raw-unsafe` records the handshake verbatim**, every auth type
-alike, for the bug that lives in the negotiation itself — and for ARD,
+alike, for the bug that lives in the negotiation itself, and for ARD,
 whose Diffie-Hellman exchange is now removed by stripping along with
 everything else. Its archives carry a real key exchange and whatever credentials it
 protected; the paved-road doc says so, and says to use a disposable
 password and rotate it. It supersedes `--capture-raw-unsafe-auth`, which is
 removed rather than aliased: the kit is unreleased.
 
-**Replay tool** — `vncdo-replay`, a shipped console script, two modes:
+**Replay tool**: `vncdo-replay`, a shipped console script, two modes:
 
     vncdo-replay --server capture.zip    # serve the recorded s2c.bin
     vncdo-replay capture.zip             # run the recorded session.vdo
@@ -192,8 +197,8 @@ Golden fixtures need a VNC server whose screen changes on demand.
 path and the fixtures.
 
 What it cannot do is choose the rectangles: the server decides how a screen
-change becomes rects. Dictating them needs an application that marks its own,
-and only libvncserver can be made to — measured against 0.9.14, it has no
+change becomes rects. Dictating them needs an app that marks its own,
+and only libvncserver can be made to. Measured against 0.9.14, it has no
 framebuffer comparator at all, so `rfbMarkRectAsModified` decides granularity
 exactly, while x11vnc diffs a framebuffer it merely polls. So an example off
 `pnmshow` stays the route to the cases that need a chosen layout: many
@@ -223,15 +228,15 @@ revisit only if someone asks for it.
 ## In-flight PRs
 
 - **#340** (digest pins, versions.md, image build cache): orthogonal and
-  compatible — proceed.
+  compatible; proceed.
 - **#341** (scenario registry framework): closed, superseded by this
   design. Its `Scenario`/`ScenarioContext`/`SCENARIOS` registry, the
   capability-gated `requires` matching, and the generated
   `test_<scenario>` methods all existed to serve the recorder-replay and
   Tier 3 checklist consumers that never landed; nothing else in the fleet
   reads them, so none of it carried forward. The one genuine idea inside
-  it — a server declaring what it can do, so a test can skip a capability
-  it lacks rather than weaken its own assertion — stays deferred rather
+  it (a server declaring what it can do, so a test can skip a capability
+  it lacks rather than weaken its own assertion) stays deferred rather
   than added speculatively: `renders_desktop` and `size` already gate
   inline where the plain-method grid needs it, and a `capabilities`
   property with no caller is exactly the unused abstraction this repo's
@@ -243,9 +248,9 @@ revisit only if someone asks for it.
 
 ## Phasing
 
-1. Fleet smoke grid as subprocess tests + vncev/X event sinks; fold CLI
-   tests in; retire pexpect and the native build. (Reworks #341's branch
-   terrain.)
+1. Fleet smoke grid as subprocess tests + vncev/X event sinks; fold
+   command-line tests in; retire pexpect and the native build. (Reworks
+   #341's branch terrain.)
 2. Decoder golden unit tests: capture per-encoding fixture bytes, commit,
    delete golden-PNG suite. Scaffolded at Raw and one pixel format; the
    remaining matrix values arrive with the client features that can request
@@ -273,15 +278,15 @@ and can proceed while 3–5 follow.
 - **Fleet expansion** (TightVNC, QEMU, more): follows the plan's tier
   process; this framework adds a server as one descriptor + one subclass.
 - **Input-reactive test surface**: nothing in the fleet reacts to input at
-  a known screen position — `tests/servers/draw-content.sh` paints static
-  content once at start-up — so a keyboard/mouse test can only assert "some
+  a known screen position (`tests/servers/draw-content.sh` paints static
+  content once at start-up), so a keyboard/mouse test can only assert "some
   repaint happened" or "the session didn't disconnect," never "the right
   pixels changed." Needs a deterministic reactive surface in the container
-  desktop (e.g. a full-screen `xterm` echoing keystrokes at a fixed
+  desktop (for example, a full-screen `xterm` echoing keystrokes at a fixed
   position, plus a pointer-tracking app), which is image work with real
   flakiness risk (font rendering, timing) and its own spike. The scene player
   does not cover it: it paints the image its key names, whatever that key
-  was, so it cannot answer "which keysym arrived" — which is what the KEYMAP
+  was, so it cannot answer "which keysym arrived," which is what the KEYMAP
   issues need.
 - **Phase 1 interplay**: once "fail loudly, never hang" lands in the
   client, per-test subprocess timeouts can tighten, and the in-process API

--- a/specs/tight-encoding.md
+++ b/specs/tight-encoding.md
@@ -1,4 +1,4 @@
-# Tight Encoding — Build Plan
+# Tight Encoding: Build Plan
 
 Status: draft, under review. Executes
 [decoder-architecture.md](decoder-architecture.md) Phase 6 and the Tight half of
@@ -7,7 +7,7 @@ Status: draft, under review. Executes
 
 ## What Phase 6 assumed, and what is actually missing
 
-Phase 6 reads as "a new encoding as new files plus tests", with the registry
+Phase 6 reads as "a new encoding as new files plus tests," with the registry
 already able to carry it. Three things it does not account for turned up on
 inspection:
 
@@ -53,19 +53,18 @@ rfbproto alone here.
 
 **JPEG is in scope, and Pillow decodes it inside the decoder**, which emits
 24 bpp RGB. This is the one place the architecture's "a decoder unit test needs
-no rendering library" (R2) does not hold; Pillow is already a hard dependency,
-and the alternative — passing JPEG bytes through to `client.py` — changes
-`updateRectangle`'s `(bytes, PixelFormat)` contract for every encoding to serve
-one.
+no rendering library" (R2) does not hold; Pillow is already a hard dependency. The alternative, passing JPEG bytes
+through to `client.py`, changes `updateRectangle`'s `(bytes, PixelFormat)`
+contract for every encoding to serve one.
 
 The decode path is unconditional: nothing in the wire format stops a
 non-conforming server from sending `0x9_`, and a client that cannot read it
-fails in the field. What is conditional is whether we *invite* JPEG.
+fails in the field. What is conditional is whether the client *invites* JPEG.
 
 **`--jpeg-quality N` offers a quality level; the default offers none.** A
 conforming server sends JPEG only to a client that advertised -23..-32, so the
 default keeps captures lossless, which is what a screenshot tool should do, and
-the flag is what makes a JPEG rectangle capturable at all — which is what makes
+the flag is what makes a JPEG rectangle capturable at all: that is what makes
 the decode path testable rather than dead. The level is the RFB quality level
 0–9 the wire carries, not a percentage: the protocol has ten values and every
 viewer's own control is that same 0–9 scale, so a percentage would invent a
@@ -81,7 +80,7 @@ bound, where it came from and the mutations that show it can still fail.
 **The gradient filter raises `DecodeError`, naming what arrived.** No encoder in
 the fleet emits one, so no fixture can cover it, and the brief records an
 unresolved disagreement between LibVNCServer and TigerVNC about its behaviour at
-non-888 formats — precisely because there is no live encoder to settle it
+non-888 formats, precisely because there is no live encoder to settle it
 against. Failing loudly beats shipping a branch that is a guess at a spec
 ambiguity.
 
@@ -89,7 +88,7 @@ ambiguity.
 one compression type covering the whole rectangle, so Tight never writes a
 partial rectangle and never needs the shared `RectBuffer`. Its generator returns
 `(bytes, PixelFormat)` and the pump hands both straight to `updateRectangle`.
-No buffer is allocated, so the format mismatch above cannot arise, and
+No buffer is allocated, so the preceding format mismatch cannot arise, and
 `output_format` stays a per-decoder answer for the decoders that have one.
 Rejected: repacking every pixel into the negotiated layout in the decoder
 (per-pixel Python on JPEG rectangles, against N2), and letting `RectBuffer`
@@ -117,30 +116,30 @@ Two additions:
 
 ## Build order
 
-A stack: each stage is a branch on the one below it, reviewed and merged on its
-own, and the next rebases onto what landed. Every stage is green on `make test`
+A stack: each stage is a branch on the one below it, reviewed, and merged on
+its own, and the next rebases onto what landed. Every stage is green on `make test`
 and on `flake8 --count --statistics vncdotool tests`, and adds no new
 `make typecheck` error, before it is offered for review.
 
-**Stage 0 — wire brief. Done**, committed as [tight-wire.md](tight-wire.md).
+**Stage 0: wire brief. Done**, committed as [tight-wire.md](tight-wire.md).
 
-**Stage 1 — TPIXEL. Done.** `pixelformat.tpixel_bytes` and the 24 bpp RGB output
+**Stage 1: TPIXEL. Done.** `pixelformat.tpixel_bytes` and the 24 bpp RGB output
 format a 3-byte TPIXEL implies, with unit tests beside the CPIXEL ones in
-`test_pixelformat.py`. The condition is narrow and exact — true colour, 32 bpp,
-depth 24, three 8-bit channels — and the byte order is a fixed R, G, B that
+`test_pixelformat.py`. The condition is narrow and exact: true color, 32 bpp,
+depth 24, three 8-bit channels. The byte order is a fixed R, G, B that
 ignores the big-endian flag and the channel shifts, which is what makes it
 unlike CPIXEL. Touches no decoder.
 
-**Stage 2 — the whole-rectangle pump path. Done.** A `WholeRectDecoder` base beside
+**Stage 2: the whole-rectangle pump path. Done.** A `WholeRectDecoder` base beside
 `PixelDecoder`, `_pumpFor` dispatching to it, and its own `test_pump.py` cases
 including the one-byte-at-a-time segmentation case, since this path does not go
 through the existing one. A Tight rectangle carries one compression type for the
 whole rectangle, so the decoder returns `(bytes, PixelFormat)` and no
-`RectBuffer` is allocated — which is also what keeps a 3-byte TPIXEL rectangle
+`RectBuffer` is allocated, which is also what keeps a 3-byte TPIXEL rectangle
 from being written into a buffer sized for a 4-byte negotiated format. Touches
 no decoder; independent of stage 1 in content, stacked on it in git.
 
-**Stage 3 — the decoder, against real bytes. Done.** Registration
+**Stage 3: the decoder, against real bytes. Done.** Registration
 (`DECODERS`, `ENCODING_NAMES["tight"]`) lands first so `--encodings tight` can be
 offered at all, then `vnclog --capture-raw` against `tigervnc` produces the bytes
 the implementation is written against. In order: the control byte and its reset
@@ -148,15 +147,15 @@ bits over four independent streams, fill, basic/copy, basic/palette. Gradient
 raises `DecodeError`; JPEG is stage 5. Unit tests in
 `tests/unit/test_decoder_tight.py`, every case driven from captured bytes.
 
-Framing details that desynchronise the stream rather than merely producing a
+Framing details that desynchronize the stream rather than merely producing a
 wrong image, so each gets a test: the filter byte exists only when bit 6 is set;
 palette size is stored minus one; the 12-byte uncompressed threshold is computed
 by the decoder from `height * rowSize` and never signalled on the wire; a
-2-colour palette packs 1-bit rows padded to a byte boundary. The 2048-pixel width
+2-color palette packs 1-bit rows padded to a byte boundary. The 2048-pixel width
 check exempts Fill, because TigerVNC servers before 1.16.0 sent wider Fill
 rectangles and its own decoder exempts them.
 
-**Stage 4 — goldens. Done.** `tests/goldens/capture.py --encoding tight
+**Stage 4: goldens. Done.** `tests/goldens/capture.py --encoding tight
 --pixel-format bgrx8888`, committed as `tigervnc-tight-bgrx8888`, plus the
 non-default formats the matrix asks for: TPIXEL width varies with the negotiated
 format, and 32 bpp is exactly the case that hides it. `test_goldens.py` walks the
@@ -164,35 +163,35 @@ tree and needs no edit.
 
 **No single scene is the palette scene for Tight**, which the Testing section
 below assumed there would be. Palette coverage at bgrx8888 arrives spread across
-the catalogue — 24 basic/palette rectangles at palette sizes 2, 3, 4, 5, 8 and
-16 — and which rectangles come out palette is a function of the negotiated
+the catalogue: 24 basic/palette rectangles at palette sizes 2, 3, 4, 5, 8, and
+16. Which rectangles come out palette is a function of the negotiated
 format as much as of the content: at rgb565, quantizing to 5/6/5 collapses the
-dense and scattered scenes far enough that TigerVNC sends palettes of 37, 40 and
-204 colours where at bgrx8888 it sent the same rectangles as a raw copy. Which
+dense and scattered scenes far enough that TigerVNC sends palettes of 37, 40, and
+204 colors where at bgrx8888 it sent the same rectangles as a raw copy. Which
 filter a fixture reaches is therefore a property of the (scene, format) pair, not
 of the scene; the capture is read back afterwards to find out what it got, and
 what each one got is recorded in the commit that added it.
 
-**Stage 5 — JPEG. Done.** `--jpeg-quality N` offering one of -23..-32, the
+**Stage 5: JPEG. Done.** `--jpeg-quality N` offering one of -23..-32, the
 Pillow decode path in the decoder, and a `tigervnc-tight-jpeg-bgrx8888`
 fixture captured with the flag set, carrying a lossy-encoding tolerance and
 the quality level it was taken at. Also the grayscale case: TurboVNC under
 `-subsamp gray` emits 1-component JPEG, so the decoder converts whatever
 components arrive to RGB rather than assuming three. That one has no captured
-fixture — no fleet server emits it — so its unit case re-encodes a captured
+fixture, since no fleet server emits it, so its unit case re-encodes a captured
 rectangle's own pixels with one component and splices them into that
 rectangle's framing, and the PR says the branch is taken on the brief's
 authority alone.
 
 Two things the plan had wrong, found here. Offering a quality level *moves*
 work off the other branches rather than adding to it: TigerVNC sends JPEG
-where it would have sent a full-colour copy rectangle, so the lossy capture
+where it would have sent a full-color copy rectangle, so the lossy capture
 reaches no copy filter, no implicit filter and nothing under the 12-byte
 threshold, and it carries its own coverage contract rather than the lossless
 one. And `expect` could not sequence a lossy capture at all, which
 [expect-matching.md](expect-matching.md) went on to fix.
 
-**Stage 6 — live and measured. Done.** `"tight"` joins `EMITTED_BY_TIGERVNC` in
+**Stage 6: live and measured. Done.** `"tight"` joins `EMITTED_BY_TIGERVNC` in
 `tests/functional/test_encodings.py`; the per-encoding cases generate themselves
 from `ENCODING_NAMES` and render both scenes byte for byte. N2's bandwidth half
 lands as two cases in `test_bandwidth.py`, one per content class, and is met
@@ -213,9 +212,9 @@ the "Offering" line carries, so adding any name to `EMITTED_BY_TIGERVNC` passed.
 The witness is `vnclog --capture-raw`'s `encodings_seen`. And `benchmark.py`
 replayed every fixture as if it were captured at the server's native format,
 which is invisible until a fixture is narrower than four bytes: the rgb565
-fixture desynchronised, aborted, and reported 112 us as if it were a win.
+fixture desynchronized, aborted, and reported 112 us as if it were a win.
 
-**Stage 7 — docs, CHANGELOG, and the R1 check. Done.** `--encodings tight` and
+**Stage 7: docs, CHANGELOG, and the R1 check. Done.** `--encodings tight` and
 `--jpeg-quality` are documented under Encodings in `docs/usage.rst`, beside the
 other flags; the CHANGELOG entries the stages wrote independently are
 consolidated.
@@ -233,24 +232,24 @@ consolidated.
 Of the fifteen commits in the stack, exactly one touches `rfb.py` and none
 touches `const.py`.
 
-**`const.py` is a literal zero and `rfb.py`'s encoding tables are untouched** —
+**`const.py` is a literal zero and `rfb.py`'s encoding tables are untouched**:
 neither `SUPPORTED_ENCODINGS` nor `_UNMIGRATED_ENCODINGS` appears anywhere in
 the stack's `rfb.py` diff, and `Encoding.TIGHT` was already in `const.py`. That
 is R1's actual claim, and it holds: **adding the encoding needed no `rfb.py`
 edit at all.** Stage 3, which is the encoding, changed three lines in
-`decoders/__init__.py` — an import, a `DECODERS` entry, an `ENCODING_NAMES`
-entry — and nothing else outside `decoders/`.
+`decoders/__init__.py`: an import, a `DECODERS` entry, and an `ENCODING_NAMES`
+entry, and nothing else outside `decoders/`.
 
 **The 30 lines in `rfb.py` are real and are not the encoding.** Every one of
 them is stage 2's `_pumpWholeRectangle`: a third pump path, plus threading a
 generator's return value out through `_pumpGenerator`'s `on_done`. A pump path
 is `rfb.py`'s own subject matter, not an encoding's, and the architecture's
-registry claim — "nothing tells `rfb.py` the encoding exists" — survives it
+registry claim, "nothing tells `rfb.py` the encoding exists," survives it
 intact. But R1 as written says `rfb.py` is unchanged, and this stack changed it,
 so the honest reading is that Phase 6 discharges R1 for *registration* and
 leaves open whether R1 also intends to bar new pump shapes. An encoding whose
 framing fits neither existing path costs an `rfb.py` edit once, and the next
-whole-rectangle encoding will cost none.
+whole-rectangle encoding costs none.
 
 Since resolved the other way: the pump now has a single entry point, and a base
 class decides for itself what to feed the generator and what its `Outcome` is
@@ -285,13 +284,13 @@ it.
 except CoRRE**, which alone lands inside the noise against Raw. What the slow
 rows share is per-rectangle Python decode work, not decompression: only Tight
 and ZRLE decompress at all, and RRE at 1.58x and Hextile at 11.2x reach those
-figures without zlib — Hextile's cost is per-subrectangle Python. Hextile and
+figures without zlib; Hextile's cost is per-subrectangle Python. Hextile and
 ZRLE shipped in phases 4 and 5 with N2 stated and unmet at 11x and 55x, so this
 is a requirement almost nothing has ever met, not a regression Tight introduced.
 
 The profile says why. Over 20 profiled replays of `tigervnc-tight-bgrx8888`,
 0.068 s total: `_unpalette` 0.012 s of self time (the per-pixel Python loop that
-expands palette indices), `zlib.Decompress.decompress` 0.010 s, then the pump —
+expands palette indices), `zlib.Decompress.decompress` 0.010 s, then the pump:
 427 `_pumpGenerator` sends per replay of 87 rectangles, against Raw's zero. Raw
 is fast because it takes none of these: it enters `_pumpRectangle`, reads
 `width * height * bypp` bytes straight off the wire in the negotiated layout, and
@@ -299,7 +298,7 @@ pastes them. Its profile has no decoder frame in the top twenty-five at all.
 Doing any per-pixel work in Python therefore cannot be free, and a bar measured
 against the one encoding that does none asks for exactly that.
 
-### Proposed replacement for N2 — not applied
+### Proposed replacement for N2: not applied
 
 `decoder-architecture.md` is not edited here: amending a standing architectural
 requirement is the repository owner's call. This is the case, for them to accept
@@ -316,14 +315,14 @@ or reject.
 > and render-time question together, not render time alone.
 
 If the owner prefers to keep an absolute bar, the alternative is to state it as
-a budget rather than a comparison — "no encoding costs more than N ms per
-full-screen update at 1920x1080" — and to accept that ZRLE fails it today and
-needs the `cpixel` loop replaced before it can pass.
+a budget rather than a comparison: "no encoding costs more than N ms per
+full-screen update at 1920x1080." That requires accepting that ZRLE fails it
+today and needs the `cpixel` loop replaced before it can pass.
 
 ## Testing
 
 Tier 1 is `test_goldens.py` against the captured fixture, and per-branch unit
-tests in `tests/unit/test_decoder_tight.py` driven from captured bytes — never
+tests in `tests/unit/test_decoder_tight.py` driven from captured bytes, never
 from bytes assembled out of the specification, per `decoder-goldens.md`. Tier 2
 is `test_encodings.py` against the fleet. Tier 3 is the existing scene
 catalogue, which covers the content classes the filters split on: solid fills
@@ -331,7 +330,7 @@ catalogue, which covers the content classes the filters split on: solid fills
 (palette filter).
 
 The scene catalogue was built before Tight was in view. If a filter turns out
-unreachable with the scenes we have, the fix is a scene, not a hand-built
+unreachable with the available scenes, the fix is a scene, not a hand-built
 fixture.
 
 ## Deferred
@@ -340,15 +339,15 @@ fixture.
   Nothing measurable rides on it until someone has a bandwidth complaint.
 - **The gradient filter.** No encoder in the fleet emits it, and the brief
   records an unresolved disagreement between LibVNCServer and TigerVNC about how
-  it behaves at non-888 formats. Revisit when a server that emits it turns up —
-  and start by finding that server, exactly as `decoder-architecture.md` says of
+  it behaves at non-888 formats. Revisit when a server that emits it turns up,
+  starting by finding that server, exactly as `decoder-architecture.md` says of
   TRLE.
 - **Tight security type 16**, which TightVNC requires before falling back to VNC
   auth (server-compatibility-plan Phase 2.1). Decoding Tight and authenticating
   to TightVNC are separate; this one needs a TightVNC server in the fleet.
 - **Tight Encoding Without Zlib (-317)**, which is what makes the `0xA0`/`0xE0`
-  control bytes legal. We do not advertise it, so those bytes are a protocol
-  error.
+  control bytes legal. vncdotool does not advertise it, so those bytes are a
+  protocol error.
 - **TightPNG (-260)**. No fleet server emits it, so under the captured-fixture
   rule it cannot be tested.
 

--- a/specs/tight-wire.md
+++ b/specs/tight-wire.md
@@ -1,20 +1,20 @@
-# Tight encoding (RFB encoding type 7) — wire-format brief
+# Tight encoding (RFB encoding type 7): wire-format brief
 
-Primary source: rfbproto pinned at `152107db63cd34b3536ad8ddf54a0cfc9017a9f9` (2025-06-03, `master` head as of 2026-09-01); the copy read hashes to blob `d16232d457341201c5375d1b21bc9c0310320d41`, identical to `rfbproto.rst` at that commit. Citations are reference links resolved at the bottom; anchors are GitHub rST section slugs, with line numbers at the pinned SHA inline so a claim stays checkable if slugs change. **RFC 6143 does not define Tight at all** — encoding 7 is outside it. Secondary sources, pinned: TigerVNC 1.16.2 `b555312d70d7ff017f866649a7e7167af4eb8fca`, TurboVNC 3.3.1 `afb793371a79240171f6eadb7bbcee2aaa422b44`, LibVNCServer `42494999e6492aaab9c1db785ecd293ef10b3aed` (`src/libvncclient/tight.c` blob `3ee0d5e071f8beac66efe414ca940e95423b76f6`).
+Primary source: rfbproto pinned at `152107db63cd34b3536ad8ddf54a0cfc9017a9f9` (2025-06-03, `master` head as of 2026-09-01); the copy read hashes to blob `d16232d457341201c5375d1b21bc9c0310320d41`, identical to `rfbproto.rst` at that commit. Citations are reference links resolved at the bottom; anchors are GitHub rST section slugs, with line numbers at the pinned SHA inline so a claim stays checkable if slugs change. **RFC 6143 does not define Tight at all**: encoding 7 is outside it. Secondary sources, pinned: TigerVNC 1.16.2 `b555312d70d7ff017f866649a7e7167af4eb8fca`, TurboVNC 3.3.1 `afb793371a79240171f6eadb7bbcee2aaa422b44`, LibVNCServer `42494999e6492aaab9c1db785ecd293ef10b3aed` (`src/libvncclient/tight.c` blob `3ee0d5e071f8beac66efe414ca940e95423b76f6`).
 
 ## 1. TPIXEL, versus ZRLE's CPIXEL
 
-A `TPIXEL` is a `PIXEL` in the agreed pixel format **except** when all of: *true-colour-flag* non-zero, *bits-per-pixel* = 32, *depth* = 24, and red/green/blue intensities each exactly 8 bits wide. Then it is **3 bytes**: byte 0 red, byte 1 green, byte 2 blue. [spec §Tight][S-tight] (3488–3497). Byte order is fixed R,G,B — it does **not** depend on *big-endian-flag*, nor on the red/green/blue shifts; shifts and maxes only decide whether the condition holds.
+A `TPIXEL` is a `PIXEL` in the agreed pixel format **except** when all of: *true-colour-flag* non-zero, *bits-per-pixel* = 32, *depth* = 24, and red/green/blue intensities each exactly 8 bits wide. Then it is **3 bytes**: byte 0 red, byte 1 green, byte 2 blue. [spec §Tight][S-tight] (3488–3497). Byte order is fixed R,G,B; it does **not** depend on *big-endian-flag*, nor on the red/green/blue shifts, and shifts and maxes only decide whether the condition holds.
 
 CPIXEL differs three ways: it applies at *depth* **24 or less**, not only 24; it is defined as *which 3 of the packed PIXEL's 4 bytes survive* (least- or most-significant three, whichever holds the RGB bits), so it keeps native packed order and endianness rather than being R,G,B; and it has a tie-break convention (prefer the three least-significant bytes). [spec §ZRLE][S-zrle] (3697–3712)
 
-Divergence, harmless in practice: TigerVNC gates on `PixelFormat::is888()`, adding a requirement the spec omits — each shift a multiple of 8 [PixelFormat.cxx][PF]. LibVNCServer checks only `depth==24 && redMax==greenMax==blueMax==0xFF` at 32bpp [lvs L384][LVS384].
+Divergence, harmless in practice: TigerVNC gates on `PixelFormat::is888()`, adding a requirement the spec omits (each shift a multiple of 8) [PixelFormat.cxx][PF]. LibVNCServer checks only `depth==24 && redMax==greenMax==blueMax==0xFF` at 32bpp [lvs L384][LVS384].
 
 ## 2. The compression-control byte
 
 One `U8` opens every Tight rectangle [spec §Tight][S-tight] (3423–3429).
 
-Bits 0–3, independently: bit *n* set means **reset zlib stream *n*** (streams 0..3) before decoding this rectangle (3431–3443). The reset must be honoured **even when the type is Fill or JPEG**, which carry no zlib data — NOTE1 (3620–3625).
+Bits 0–3, independently: bit *n* set means **reset zlib stream *n*** (streams 0..3) before decoding this rectangle (3431–3443). The reset must be honoured **even when the type is Fill or JPEG**, which carry no zlib data (NOTE1, 3620–3625).
 
 Bit 7 = 0 → **BasicCompression**: bits 5–4 are the stream id to *use* (00→0 … 11→3), bit 6 is the *read-filter-id* flag (3445–3462). Bit 7 = 1 → bits 7–4 select (3464–3477):
 
@@ -23,32 +23,32 @@ Bit 7 = 0 → **BasicCompression**: bits 5–4 are the stream id to *use* (00→
 | 1000 | 0x80 | **FillCompression** |
 | 1001 | 0x90 | **JpegCompression** |
 | 1010 | 0xA0 | **BasicCompression Without Zlib** |
-| 1110 | 0xE0 | as above, plus *read-filter-id* |
+| 1110 | 0xE0 | as preceding, plus *read-filter-id* |
 | other | — | invalid |
 
-So the shorthand "0x08 fill / 0x09 JPEG" is `comp_ctl >> 4`, and the basic-compression range is `comp_ctl >> 4` in **0x0–0x7** (stream id in bits 5–4, filter flag 0x4). TigerVNC's constants match exactly — `tightExplicitFilter=0x04`, `tightFill=0x08`, `tightJpeg=0x09`, `tightMaxSubencoding=0x09` [TightConstants.h][TC] — and it writes `tightJpeg << 4`, the byte `0x90` [TightJPEGEncoder L93][TJE93]. Framing rule: **strip the low 4 reset bits first**, then compare the remainder; TigerVNC consumes bits 0–3 in a reset loop, then shifts right 4 [TightDecoder L269][TD269].
+So the shorthand "0x08 fill / 0x09 JPEG" is `comp_ctl >> 4`, and the basic-compression range is `comp_ctl >> 4` in **0x0–0x7** (stream id in bits 5–4, filter flag 0x4). TigerVNC's constants match exactly: `tightExplicitFilter=0x04`, `tightFill=0x08`, `tightJpeg=0x09`, `tightMaxSubencoding=0x09` [TightConstants.h][TC]. It writes `tightJpeg << 4`, the byte `0x90` [TightJPEGEncoder L93][TJE93]. Framing rule: **strip the low 4 reset bits first**, then compare the remainder; TigerVNC consumes bits 0–3 in a reset loop, then shifts right 4 [TightDecoder L269][TD269].
 
 **BasicCompression Without Zlib** (0xA0/0xE0) is legal only if the client advertised the Tight Encoding Without Zlib pseudo-encoding, **-317** [spec §no-zlib][S-nz] (4508–4514; also 3485–3486, 3626–3628).
 
 ## 3. FillCompression
 
-Payload is **one TPIXEL and nothing else** — no length, no count — applying to every pixel of the rectangle [spec §Tight][S-tight] (3501–3504). Byte count is 3 when §1's condition holds, else *bits-per-pixel*/8.
+Payload is **one TPIXEL and nothing else**, with no length and no count, applying to every pixel of the rectangle [spec §Tight][S-tight] (3501–3504). Byte count is 3 when §1's condition holds, else *bits-per-pixel*/8.
 
 ## 4. JpegCompression
 
 Payload: *length* in compact representation (1–3 bytes), then *length* bytes of *jpeg-data*, which is a **JFIF stream** [spec §Tight][S-tight] (3505–3533). There is no filter byte and no zlib; the 12-byte rule of §6 does not apply.
 
-The spec says nothing about colour space; the JFIF stream carries its own. In practice it is baseline 3-component YCbCr decoding to 8-bit RGB, which the client then converts into its own pixel format. **It may also be 1-component grayscale**: TurboVNC emits grayscale JPEG when the client selected the "gray" subsampling level [turbo tight.c L820][TT820]. A decoder assuming three components breaks against TurboVNC with `-subsamp gray`.
+The spec says nothing about color space; the JFIF stream carries its own. In practice it is baseline 3-component YCbCr decoding to 8-bit RGB, which the client then converts into its own pixel format. **It may also be 1-component grayscale**: TurboVNC emits grayscale JPEG when the client selected the "gray" subsampling level [turbo tight.c L820][TT820]. A decoder assuming three components breaks against TurboVNC with `-subsamp gray`.
 
 ## 5. BasicCompression and the three filters
 
 With bit 6 set, the **second** byte is *filter-id*: 0 **CopyFilter**, 1 **PaletteFilter**, 2 **GradientFilter**. With bit 6 clear there is no filter byte and CopyFilter is implied [spec §Tight][S-tight] (3535–3552).
 
-**CopyFilter** — raw TPIXELs, row-major, no padding. Row size `width*3` in the 3-byte-TPIXEL case, else `width * bpp/8` (3554–3558).
+**CopyFilter**: raw TPIXELs, row-major, no padding. Row size `width*3` in the 3-byte-TPIXEL case, else `width * bpp/8` (3554–3558).
 
-**PaletteFilter** — one `U8` = *palette size minus 1* (1 means 2 colours, 255 means 256), then that many TPIXELs, then indices. At exactly 2 colours each pixel is **1 bit**, MSB = leftmost pixel, and **each row is padded to a byte boundary**: row size `(width+7)/8`. Otherwise 8 bits per pixel, row size `width` (3559–3572). Confirmed independently by TigerVNC [TightDecoder L388][TD388] and by LibVNCServer's generic `rowSize = (rw*bitsPixel+7)/8` with `bitsPixel` 1 or 8 [lvs L254][LVS254].
+**PaletteFilter**: one `U8` = *palette size minus 1* (1 means 2 colors, 255 means 256), then that many TPIXELs, then indices. At exactly 2 colors each pixel is **1 bit**, MSB = leftmost pixel, and **each row is padded to a byte boundary**: row size `(width+7)/8`. Otherwise 8 bits per pixel, row size `width` (3559–3572). Confirmed independently by TigerVNC [TightDecoder L388][TD388] and by LibVNCServer's generic `rowSize = (rw*bitsPixel+7)/8` with `bitsPixel` 1 or 8 [lvs L254][LVS254].
 
-**GradientFilter** — per colour component, the encoder sends a difference from a prediction:
+**GradientFilter**: per color component, the encoder sends a difference from a prediction:
 
 ```
 P[i,j] := V[i-1,j] + V[i,j-1] - V[i-1,j-1];
@@ -59,7 +59,7 @@ D[i,j] := V[i,j] - P[i,j];
 `V` outside the rectangle is 0; MAX is that component's maximum intensity. Legal only when *bits-per-pixel* is **16 or 32** (3574–3594). The filter does not change data volume, so row size matches CopyFilter's. Two implicit points, and one open disagreement:
 
 - The prediction is clamped **before** the difference is added, and the addition itself wraps modulo (MAX+1). Both LibVNCServer [lvs L484][LVS484] and TigerVNC (uint8 arithmetic) [TightDecoder L545][TD545] do this.
-- **Unresolved.** For non-888 formats (e.g. 16bpp 5-6-5), LibVNCServer runs the gradient in *native component* space: extract with `>> shift`, clamp the estimate to that component's `*-max`, mask the sum with `& max`. TigerVNC instead converts to 8-bit-per-component RGB, runs with MAX=255, converts back — and its 16bpp path indexes a `uint8_t*` input by pixel index rather than byte offset, which looks like a stride bug. I could not settle this empirically because **neither TigerVNC nor TurboVNC ever emits the gradient filter** (no "gradient" match anywhere in TurboVNC's `tight.c`; TigerVNC's `TightEncoder.cxx` writes only copy/mono/indexed). LibVNCServer's native-component reading matches the spec's wording ("MAX is the maximum intensity value for a color component") but is untested against a live encoder — likely-correct, not confirmed.
+- **Unresolved.** For non-888 formats (for example 16bpp 5-6-5), LibVNCServer runs the gradient in *native component* space: extract with `>> shift`, clamp the estimate to that component's `*-max`, mask the sum with `& max`. TigerVNC instead converts to 8-bit-per-component RGB, runs with MAX=255, and converts back; its 16bpp path also indexes a `uint8_t*` input by pixel index rather than byte offset, which looks like a stride bug. This could not be settled empirically because **neither TigerVNC nor TurboVNC ever emits the gradient filter** (no "gradient" match anywhere in TurboVNC's `tight.c`; TigerVNC's `TightEncoder.cxx` writes only copy/mono/indexed). LibVNCServer's native-component reading matches the spec's wording ("MAX is the maximum intensity value for a color component") but is untested against a live encoder: likely correct, not confirmed.
 
 After filtering the data is zlib-compressed on the selected stream; see §6 (3596–3618).
 
@@ -75,21 +75,21 @@ After filtering the data is zlib-compressed on the selected stream; see §6 (359
 
 The third byte is a **full 8 bits**, not 7; maximum representable value 4194303. The spec's worked example: decimal 10000 → `0x90 0x4E`.
 
-Threshold: "if the data size after applying the filter but before the compression is less th[a]n 12, then the data is sent as is, uncompressed" (3596–3600). The decoder must compute that size itself — `height * rowSize` from §5 — and if **< 12**, read exactly that many raw bytes with **no compact length prefix and no zlib**; otherwise read a compact length then that many bytes of zlib data. Confirmed in all three implementations: TigerVNC `if (length < 12)`, commented "This value should not be changed, doing so will break compatibility" [TightEncoder L246][TE246]; TurboVNC `#define TIGHT_MIN_TO_COMPRESS 12` [turbo tight.c L41][TT41]; LibVNCServer the same [lvs L38][LVS38]. Interaction with **BasicCompression Without Zlib**: the 12-byte short-circuit is checked *first*, and above the threshold a compact length is still read — it just prefixes raw filtered bytes rather than zlib data [lvs L253][LVS253].
+Threshold: "if the data size after applying the filter but before the compression is less th[a]n 12, then the data is sent as is, uncompressed" (3596–3600). The decoder must compute that size itself (`height * rowSize` from §5): if **< 12**, read exactly that many raw bytes with **no compact length prefix and no zlib**; otherwise read a compact length then that many bytes of zlib data. Confirmed in all three implementations: TigerVNC `if (length < 12)`, commented "This value should not be changed, doing so will break compatibility" [TightEncoder L246][TE246]; TurboVNC `#define TIGHT_MIN_TO_COMPRESS 12` [turbo tight.c L41][TT41]; LibVNCServer the same [lvs L38][LVS38]. Interaction with **BasicCompression Without Zlib**: the 12-byte short-circuit is checked *first*, and above the threshold a compact length is still read; it just prefixes raw filtered bytes rather than zlib data [lvs L253][LVS253].
 
 ## 7. Rectangle-size and JPEG constraints
 
-**Width ≤ 2048 pixels** for any Tight rectangle; wider regions must be split into several rectangles encoded separately [spec §Tight][S-tight] (3417–3421). The spec states **no maximum pixel count**. TigerVNC additionally splits at `SubRectMaxArea = 65536` / `SubRectMaxWidth = 2048` [EncodeManager L52][EM52]; TurboVNC's per-compression-level table uses the same 65536/2048 pair [turbo tight.c L88][TT88]. A decoder should not *require* ≤65536 pixels, but sizing row buffers for 2048 is safe — both TigerVNC and LibVNCServer hard-code 2048 for gradient row buffers. Field wrinkle: TigerVNC's decoder notes that **TigerVNC servers before 1.16.0 sent oversized Fill rectangles**, so it applies the 2048 check to every type *except* Fill [TightDecoder L104][TD104]; a decoder that rejects wide Fill rects will fail.
+**Width ≤ 2048 pixels** for any Tight rectangle; wider regions must be split into several rectangles encoded separately [spec §Tight][S-tight] (3417–3421). The spec states **no maximum pixel count**. TigerVNC additionally splits at `SubRectMaxArea = 65536` / `SubRectMaxWidth = 2048` [EncodeManager L52][EM52]; TurboVNC's per-compression-level table uses the same 65536/2048 pair [turbo tight.c L88][TT88]. A decoder should not *require* ≤65536 pixels, but sizing row buffers for 2048 is safe: both TigerVNC and LibVNCServer hard-code 2048 for gradient row buffers. Field wrinkle: TigerVNC's decoder notes that **TigerVNC servers before 1.16.0 sent oversized Fill rectangles**, so it applies the 2048 check to every type *except* Fill [TightDecoder L104][TD104]; a decoder that rejects wide Fill rects fails.
 
-**JpegCompression may be used only when *bits-per-pixel* is 16 or 32 and the client has advertised a quality level** via the JPEG Quality Level pseudo-encoding (3479–3483). The spec is silent on whether true-colour is required; JPEG under a colour map is meaningless and no implementation emits it. TigerVNC's own format gate is looser than the spec: `pf().bpp < 16` is the only check [TightJPEGEncoder L43][TJE].
+**JpegCompression may be used only when *bits-per-pixel* is 16 or 32 and the client has advertised a quality level** via the JPEG Quality Level pseudo-encoding (3479–3483). The spec is silent on whether true-color is required; JPEG under a color map is meaningless and no implementation emits it. TigerVNC's own format gate is looser than the spec: `pf().bpp < 16` is the only check [TightJPEGEncoder L43][TJE].
 
 ## 8. Tight-related pseudo-encodings, and unasked-for JPEG
 
-JPEG Quality Level **-23..-32** (-23 high quality, -32 low) [spec §quality][S-jq] (3979–3992). Compression Level **-247..-256** (-247 high compression, -256 low), a hint only with no defined per-level meaning [spec §compression][S-cl] (4139–4158). Tight PNG **-260** — a genuine encoding, not a pseudo-encoding — forbids BasicCompression and replaces it with **PngCompression** at bits 7–4 = 1010 [spec §TightPNG][S-png] (3937–3975). Also relevant: JPEG Fine-Grained Quality Level -412..-512 and JPEG Subsampling Level -763..-768 (3088–3089, 4516–4531).
+JPEG Quality Level **-23..-32** (-23 high quality, -32 low) [spec §quality][S-jq] (3979–3992). Compression Level **-247..-256** (-247 high compression, -256 low), a hint only with no defined per-level meaning [spec §compression][S-cl] (4139–4158). Tight PNG **-260** (a genuine encoding, not a pseudo-encoding) forbids BasicCompression and replaces it with **PngCompression** at bits 7–4 = 1010 [spec §TightPNG][S-png] (3937–3975). Also relevant: JPEG Fine-Grained Quality Level -412..-512 and JPEG Subsampling Level -763..-768 (3088–3089, 4516–4531).
 
 **Does a server send JPEG when the client offered no quality level?** rfbproto settles it: "If the JPEG quality level is not specified, **JpegCompression is not used** in the Tight Encoding" (3984–3986). Both encoders agree, verified in source rather than inferred:
 
-- **TigerVNC 1.16.2**: `TightJPEGEncoder::isSupported()` returns false unless the client advertised Tight *and* `pf().bpp >= 16` *and* at least one of `qualityLevel`, `fineQualityLevel`, `subsampling` is not -1 — closing comment literally "Tight support, but not JPEG" [TightJPEGEncoder L43][TJE]. `EncodeManager` only selects a JPEG encoder that reports `isSupported()` [EncodeManager L405][EM405].
+- **TigerVNC 1.16.2**: `TightJPEGEncoder::isSupported()` returns false unless the client advertised Tight *and* `pf().bpp >= 16` *and* at least one of `qualityLevel`, `fineQualityLevel`, `subsampling` is not -1; the closing comment reads literally "Tight support, but not JPEG" [TightJPEGEncoder L43][TJE]. `EncodeManager` only selects a JPEG encoder that reports `isSupported()` [EncodeManager L405][EM405].
 - **TurboVNC 3.3.1**: `cl->tightQualityLevel` initialises to **-1** [rfbserver L443][RS443] and is set only from a -23..-32 or fine-grained pseudo-encoding [rfbserver L1178][RS1178]. Every `SendJpegRect` call site is guarded by `qualityLevel != -1` [turbo tight.c L820][TT820].
 
 So a client offering encoding 7 and none of -23..-32 / -412..-512 / -763..-768 receives no JPEG rectangles from either. Caveat: that is a property of these two servers at these versions. Nothing in the wire format prevents a non-conforming server from sending `0x9_`, so a decoder without JPEG support should fail loudly rather than silently.
@@ -97,13 +97,13 @@ So a client offering encoding 7 and none of -23..-32 / -412..-512 / -763..-768 r
 ## 9. What a from-scratch decoder gets wrong
 
 - **Ordering is mandatory.** The four zlib streams are per-connection and stateful across rectangles *and* across FramebufferUpdate messages. Tight rectangles must be decoded in the order received; they cannot be decoded out of order or in parallel without tracking which stream each touches. TigerVNC's parallel decoder computes an explicit conflict predicate over stream ids and reset bits before letting two rects run concurrently [TightDecoder L236][TD236].
-- **Stream lifetime is the whole connection**, not the rectangle or the update. Reset only on an explicit bit 0–3, and reset even for Fill and JPEG rects (NOTE1, 3620–3625).
-- **Servers differ in how they use the four streams.** TigerVNC pins stream 0 to full-colour, 1 to mono, 2 to indexed, and never sets a reset bit [TightEncoder L169][TE169]; TurboVNC rotates round-robin through a per-thread range of ids [turbo tight.c L955][TT955]. Maintain all four independently — assuming only stream 0 is live works against TigerVNC and fails against TurboVNC.
+- **Stream lifetime is the whole connection**, not the rectangle, or the update. Reset only on an explicit bit 0–3, and reset even for Fill and JPEG rects (NOTE1, 3620–3625).
+- **Servers differ in how they use the four streams.** TigerVNC pins stream 0 to full-color, 1 to mono, 2 to indexed, and never sets a reset bit [TightEncoder L169][TE169]; TurboVNC rotates round-robin through a per-thread range of ids [turbo tight.c L955][TT955]. Maintain all four independently: assuming only stream 0 is live works against TigerVNC and fails against TurboVNC.
 - **A zlib stream is not "one deflate blob per rectangle."** The server sync-flushes at each rectangle boundary and keeps the dictionary. Feed the decompressor the rectangle's bytes and ask for exactly `height * rowSize` output, retaining state for the next rectangle. Reading "until end of stream" hangs.
 - **The compressed-vs-uncompressed choice is not signalled on the wire.** It is derived from the decoder's own `height * rowSize < 12` computation (§6), which depends on palette size and TPIXEL width. Getting the TPIXEL condition wrong silently desynchronises the byte stream rather than merely producing a wrong-looking image.
 - **SetPixelFormat changes TPIXEL width mid-connection.** A client must not have an outstanding FramebufferUpdateRequest when it sends SetPixelFormat, precisely because the next update's format would be ambiguous [spec §SetPixelFormat][S-spf] (1691–1694); with ContinuousUpdates the Fence **SyncNext** flag exists for the same reason (2163–2167). The pixel format does *not* reset the zlib streams.
-- **The filter byte is conditional** — present only when bit 6 is set, never for Fill or JPEG. Consuming it unconditionally (or never) is the most common framing bug.
-- **Palette size is stored minus one.** A byte of 1 means two colours and therefore 1-bit rows. A byte of 0 (one colour) is not produced by the palette filter; a solid rectangle is sent as FillCompression instead.
+- **The filter byte is conditional**: present only when bit 6 is set, never for Fill, or JPEG. Consuming it unconditionally (or never) is the most common framing bug.
+- **Palette size is stored minus one.** A byte of 1 means two colors and therefore 1-bit rows. A byte of 0 (one color) is not produced by the palette filter; a solid rectangle is sent as FillCompression instead.
 
 <!-- citations -->
 [S-tight]: https://github.com/rfbproto/rfbproto/blob/152107db63cd34b3536ad8ddf54a0cfc9017a9f9/rfbproto.rst#tight-encoding


### PR DESCRIPTION
## Summary

Adds Vale as a manual prose linter for `docs/*.rst`, `README.rst`, and
`specs/*.md` (Google style rules, `Google.Headings` off since it misfires
on CLI command signatures and numbered specs headings). `make prose-lint`
runs it; styles vendor on demand via `vale sync`, gitignored like
`docs/rfbproto/`. `writing-code-comments`' Mode D now points at running a
repo's prose linter first, worded generically since that skill also lives
outside this repo.

All flagged docs/specs are fixed. The dominant finding was the `—`/`--`
em-dash convention, reworded into separate sentences or commas rather than
mechanically squished. 23 residual findings are false positives (a
protocol field name, a verbatim source quote, microseconds read as "us")
and are left as unsuppressed lint noise rather than `<!-- vale -->`
comments cluttering human-facing docs.

## Test plan

- `make prose-lint`: 2 errors, 21 warnings, all documented false positives.
- No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
