### PR TITLE
Fix updateCursor crashing/glitching on hide-pointer updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 2.0.0.dev0 (UNRELEASED)
+- Fix `updateCursor` decoding a hide-pointer update (width or height 0) as an empty image instead of hiding the cursor, which raised inside Pillow or pasted a bogus zero-size image onto the screen (@sibson, #449)
 - Fix `RFBFactory` raising `AttributeError` on ARD authentication when used directly, instead of through `VNCDoToolFactory` (@sibson)
 - Add `vncdo stable SECONDS [FUZZ]` and `rstable SECONDS X Y W H [FUZZ]`, waiting until the screen stops changing rather than until it matches a reference image (@sibson)
 - Fix `rexpect` polling until `--timeout` and `rcapture` writing black pixels when the region runs off the screen, and `expect` doing the same against a target image larger than the screen. All three now fail with a message naming the region and the screen size, exiting 30 (@sibson)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -67,6 +67,22 @@ class TestVNCDoToolClient(TestCase):
         (offered,) = cli.setEncodings.call_args[0]
         self.assertNotIn(client.rfb.Encoding.PSEUDO_FENCE, offered)
 
+    def test_updateCursor_hides_pointer_on_zero_size(self):
+        """RFC 6143 7.6.1: a Cursor pseudo-encoding update with width or
+        height 0 means hide the pointer, not an empty image to decode.
+        """
+        cli = self.client
+        cli.factory.nocursor = False
+        cli.cursor = Image.new("RGB", (4, 4))
+        cli.cmask = Image.new("1", (4, 4))
+        cli.screen = Image.new("RGB", (100, 100))
+
+        cli.updateCursor(0, 0, 0, 0, b"", b"")
+
+        self.assertIsNone(cli.cursor)
+        self.assertIsNone(cli.cmask)
+        cli.drawCursor()
+
     def test_requested_encodings_replace_the_default_list(self):
         cli = self.client
         cli.requested_encodings = [client.rfb.Encoding.RAW]

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -591,6 +591,8 @@ class VNCDoToolClient(rfb.RFBClient):
 
         if not width or not height:
             self.cursor = None
+            self.cmask = None
+            return
 
         self.cursor = Image.frombytes(
             "RGB", (width, height), image, "raw", self._image_mode


### PR DESCRIPTION
A Cursor pseudo-encoding update with width or height 0 means "hide the pointer" (RFC 6143 7.6.1) and carries no pixel data. `updateCursor` set `self.cursor = None` for that case but fell through into `Image.frombytes` on the empty bytes anyway, which either raised inside Pillow (tearing down the connection) or produced a bogus zero-size image for `drawCursor` to paste.

Adds the missing early return, clearing `cmask` alongside `cursor` for consistent state, and a regression test in `tests/unit/test_client.py`.

Fixes #449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
