### PR TITLE
Decompose non-rectangle message handlers out of rfb.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 2.0.0.dev0 (UNRELEASED)
+- `SetColourMapEntries`, `ServerCutText`, `Bell` and `ServerFence` move out of `rfb.py` into per-message handlers under `vncdotool/messages/`, mirroring the rectangle-decoder registry (#474). A `ServerCutText` or `SetColourMapEntries` declaring a length above 1 MiB now ends the session with a reported error instead of buffering an unbounded amount of data (@sibson, #474)
 - Fix `updateCursor` decoding a hide-pointer update (width or height 0) as an empty image instead of hiding the cursor, which raised inside Pillow or pasted a bogus zero-size image onto the screen (@sibson, #449)
 - Fix `RFBFactory` raising `AttributeError` on ARD authentication when used directly, instead of through `VNCDoToolFactory` (@sibson)
 - Add `vncdo stable SECONDS [FUZZ]` and `rstable SECONDS X Y W H [FUZZ]`, waiting until the screen stops changing rather than until it matches a reference image (@sibson)

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -1,0 +1,117 @@
+from struct import pack
+from unittest import TestCase, mock
+
+from vncdotool import messages
+from vncdotool.const import FenceFlags, MsgS2C
+from vncdotool.decoders import DecodeError
+
+
+def drive(handler, client, *blocks):
+    """Send a handler's generator each block in turn, like the pump would."""
+    generator = handler.handle(client)
+    block = None
+    for block in (None, *blocks):
+        try:
+            generator.send(block)
+        except StopIteration:
+            return
+    raise AssertionError("handler did not finish after the given blocks")
+
+
+class TestHandlerRegistry(TestCase):
+
+    def test_registry_keys_match_their_own_class(self):
+        for message, cls in messages.HANDLERS.items():
+            assert cls.MESSAGE == message
+
+    def test_for_connection_builds_one_instance_per_message(self):
+        instances = messages.for_connection()
+        assert set(instances) == set(messages.HANDLERS)
+        for message, handler in instances.items():
+            assert isinstance(handler, messages.HANDLERS[message])
+
+
+class TestBellHandler(TestCase):
+
+    def test_bell(self):
+        client = mock.Mock()
+        handler = messages.HANDLERS[MsgS2C.BELL]()
+        drive(handler, client)
+        client.bell.assert_called_once_with()
+
+
+class TestSetColourMapEntriesHandler(TestCase):
+
+    def test_set_color_map(self):
+        client = mock.Mock()
+        handler = messages.HANDLERS[MsgS2C.SET_COLOUR_MAP_ENTRIES]()
+        colors = [(1, 2, 3), (0xFFFF, 0, 0x1234)]
+        payload = pack("!xHH", 5, len(colors)) + b"".join(
+            pack("!HHH", *color) for color in colors
+        )
+        drive(handler, client, payload[:5], payload[5:])
+        client.requirePayload.assert_called_once_with(6 * len(colors))
+        client.set_color_map.assert_called_once_with(5, colors)
+
+    def test_oversized_colour_count_is_bounded(self):
+        client = mock.Mock()
+        client.requirePayload.side_effect = DecodeError("too big")
+        handler = messages.HANDLERS[MsgS2C.SET_COLOUR_MAP_ENTRIES]()
+        generator = handler.handle(client)
+        generator.send(None)
+        with self.assertRaises(DecodeError):
+            generator.send(pack("!xHH", 0, 0xFFFF))
+
+
+class TestServerCutTextHandler(TestCase):
+
+    def test_copy_text(self):
+        client = mock.Mock()
+        handler = messages.HANDLERS[MsgS2C.SERVER_CUT_TEXT]()
+        text = "hello"
+        data = text.encode("iso-8859-1")
+        drive(handler, client, pack("!xxxI", len(data)), data)
+        client.requirePayload.assert_called_once_with(len(data))
+        client.copy_text.assert_called_once_with(text)
+
+    def test_oversized_length_is_bounded_before_reading_the_payload(self):
+        client = mock.Mock()
+        client.requirePayload.side_effect = DecodeError("too big")
+        handler = messages.HANDLERS[MsgS2C.SERVER_CUT_TEXT]()
+        generator = handler.handle(client)
+        generator.send(None)
+        with self.assertRaises(DecodeError):
+            generator.send(pack("!xxxI", 1 << 30))
+        client.copy_text.assert_not_called()
+
+
+class TestServerFenceHandler(TestCase):
+
+    def test_request_gets_a_response_with_request_cleared(self):
+        client = mock.Mock()
+        handler = messages.HANDLERS[MsgS2C.SERVER_FENCE]()
+        flags = FenceFlags.REQUEST | FenceFlags.BLOCK_AFTER | FenceFlags.BLOCK_BEFORE
+        drive(handler, client, pack("!xxxIB", flags, 0))
+        client.clientFence.assert_called_once_with(
+            FenceFlags.BLOCK_AFTER | FenceFlags.BLOCK_BEFORE, b""
+        )
+
+    def test_clears_bits_the_client_does_not_understand(self):
+        client = mock.Mock()
+        handler = messages.HANDLERS[MsgS2C.SERVER_FENCE]()
+        flags = FenceFlags.REQUEST | 0x08  # an unknown bit
+        drive(handler, client, pack("!xxxIB", flags, 0))
+        client.clientFence.assert_called_once_with(FenceFlags(0), b"")
+
+    def test_response_is_not_echoed_back(self):
+        client = mock.Mock()
+        handler = messages.HANDLERS[MsgS2C.SERVER_FENCE]()
+        flags = FenceFlags.BLOCK_AFTER | FenceFlags.BLOCK_BEFORE  # no REQUEST
+        drive(handler, client, pack("!xxxIB", flags, 0))
+        client.clientFence.assert_not_called()
+
+    def test_payload_is_echoed_back_with_the_response(self):
+        client = mock.Mock()
+        handler = messages.HANDLERS[MsgS2C.SERVER_FENCE]()
+        drive(handler, client, pack("!xxxIB", FenceFlags.REQUEST, 4), b"ping")
+        client.clientFence.assert_called_once_with(FenceFlags(0), b"ping")

--- a/tests/unit/test_pump.py
+++ b/tests/unit/test_pump.py
@@ -106,7 +106,7 @@ class TestDecodeErrorHandling(TestCase):
             raise decoders.DecodeError("bogus subencoding")
             yield  # pragma: no cover - never reached
 
-        cli._pumpGenerator(None, failing(), (0, 0, 1, 1))
+        cli._pump(None, failing(), lambda outcome: None, "this rectangle")
 
         cli.vncProtocolError.assert_called_once()
         self.assertIn("bogus subencoding", cli.vncProtocolError.call_args.args[0])

--- a/tests/unit/test_rfb.py
+++ b/tests/unit/test_rfb.py
@@ -119,51 +119,8 @@ class TestRFB(TestCase):
 
     def test_server_fence_dispatches_from_handleConnection(self):
         self.client._handleConnection(b"\xf8")  # SERVER_FENCE
-        assert self.client._expected_handler == self.client._handleServerFence
+        assert self.client._expected_handler == self.client._pump
         assert self.client._expected_len == 8
-
-    def test_server_fence_request_gets_a_response_with_request_cleared(self):
-        self.client._handleServerFence(
-            b"\x00\x00\x00"  # padding
-            b"\x80\x00\x00\x03"  # flags: REQUEST | BLOCK_AFTER | BLOCK_BEFORE
-            b"\x00"  # payload length
-        )
-        self.client.transport.write.assert_called_once_with(
-            b"\xf8\x00\x00\x00"  # CLIENT_FENCE, padding
-            b"\x00\x00\x00\x03"  # flags: BLOCK_AFTER | BLOCK_BEFORE, REQUEST cleared
-            b"\x00"  # payload length
-        )
-
-    def test_server_fence_request_clears_bits_the_client_does_not_understand(self):
-        self.client._handleServerFence(
-            b"\x00\x00\x00"  # padding
-            b"\x80\x00\x00\x08"  # flags: REQUEST | an unknown bit
-            b"\x00"  # payload length
-        )
-        self.client.transport.write.assert_called_once_with(
-            b"\xf8\x00\x00\x00"
-            b"\x00\x00\x00\x00"  # the unknown bit is cleared in the response
-            b"\x00"
-        )
-
-    def test_server_fence_response_is_not_echoed_back(self):
-        self.client._handleServerFence(
-            b"\x00\x00\x00"  # padding
-            b"\x00\x00\x00\x03"  # flags: BLOCK_AFTER | BLOCK_BEFORE, no REQUEST
-            b"\x00"  # payload length
-        )
-        self.client.transport.write.assert_not_called()
-
-    def test_server_fence_payload_is_echoed_back_with_the_response(self):
-        self.client._handleServerFence(
-            b"\x00\x00\x00"
-            b"\x80\x00\x00\x00"  # REQUEST
-            b"\x04"  # payload length
-        )
-        self.client._handleServerFencePayload(b"ping", 0x80000000)
-        self.client.transport.write.assert_called_once_with(
-            b"\xf8\x00\x00\x00\x00\x00\x00\x00\x04ping"
-        )
 
     def test_clientFence(self):
         self.client.clientFence(rfb.FenceFlags.SYNC_NEXT, b"abc")
@@ -186,6 +143,21 @@ class TestRFB(TestCase):
             mock.call(b"\x01"),  # AuthTypes.NONE
             mock.call(b"\x00"),  # shared
         ])
+
+    def test_oversized_server_cut_text_length_is_a_diagnosed_disconnect(self):
+        self.client.vncProtocolError = mock.Mock()
+        self.client._handler = self.client._handleExpected
+        self.client.expect(self.client._handleConnection, 1)
+        oversized = self.client.MAX_MESSAGE_PAYLOAD + 1
+        self.client._packet += bytes([rfb.MsgS2C.SERVER_CUT_TEXT]) + pack(
+            "!xxxI", oversized
+        )
+        self.client._handler()
+        self.client.vncProtocolError.assert_called_once()
+        self.client.transport.loseConnection.assert_called_once()
+        assert self.client._aborted
+        # never grew a buffer waiting for the declared length
+        assert not self.client._packet
 
     def test_ardRequestCredentials_prompts_when_factory_has_no_username(self):
         self.client.factory = rfb.RFBFactory()

--- a/vncdotool/messages/__init__.py
+++ b/vncdotool/messages/__init__.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from ..const import MsgS2C
+from .base import MessageHandler
+from .clipboard import ServerCutTextHandler
+from .colourmap import SetColourMapEntriesHandler
+from .fence import ServerFenceHandler
+from .simple import BellHandler
+
+HANDLERS: Dict[MsgS2C, Type[MessageHandler]] = {
+    cls.MESSAGE: cls
+    for cls in (
+        SetColourMapEntriesHandler,
+        BellHandler,
+        ServerCutTextHandler,
+        ServerFenceHandler,
+    )
+}
+
+
+def for_connection() -> Dict[MsgS2C, MessageHandler]:
+    return {message: cls() for message, cls in HANDLERS.items()}
+
+
+__all__ = [
+    "HANDLERS",
+    "MessageHandler",
+    "for_connection",
+]

--- a/vncdotool/messages/base.py
+++ b/vncdotool/messages/base.py
@@ -1,0 +1,18 @@
+"""specs/decoder-architecture.md is the design this package mirrors."""
+from __future__ import annotations
+
+from typing import Any, ClassVar, Generator
+
+from ..const import MsgS2C
+
+
+class MessageHandler:
+    """One server-to-client message: RFC 6143 section 7.6."""
+
+    MESSAGE: ClassVar[MsgS2C]
+
+    def handle(self, client: Any) -> Generator[int, bytes, None]:
+        """Yield the byte counts this message needs, each satisfied in full.
+        The message-type byte has already been read.
+        """
+        raise NotImplementedError

--- a/vncdotool/messages/clipboard.py
+++ b/vncdotool/messages/clipboard.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from struct import unpack
+from typing import Any, Generator
+
+from ..const import MsgS2C
+from .base import MessageHandler
+
+
+class ServerCutTextHandler(MessageHandler):
+    MESSAGE = MsgS2C.SERVER_CUT_TEXT
+
+    def handle(self, client: Any) -> Generator[int, bytes, None]:
+        # RFC 6143 7.6.4: 3 bytes padding, U32 length, then length bytes.
+        (length,) = unpack("!xxxI", (yield 7))
+        client.requirePayload(length)
+        client.copy_text((yield length).decode("iso-8859-1"))

--- a/vncdotool/messages/colourmap.py
+++ b/vncdotool/messages/colourmap.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from struct import unpack, unpack_from
+from typing import Any, Generator, List, Tuple, cast
+
+from ..const import MsgS2C
+from .base import MessageHandler
+
+
+class SetColourMapEntriesHandler(MessageHandler):
+    MESSAGE = MsgS2C.SET_COLOUR_MAP_ENTRIES
+
+    def handle(self, client: Any) -> Generator[int, bytes, None]:
+        # RFC 6143 7.6.2: 1 byte padding, U16 first-colour, U16
+        # number-of-colours, then 6 bytes (R, G, B, each U16) per colour.
+        (first_color, number_of_colors) = unpack("!xHH", (yield 5))
+        payload_len = 6 * number_of_colors
+        client.requirePayload(payload_len)
+        block = yield payload_len
+        colors = [
+            unpack_from("!HHH", block, offset) for offset in range(0, len(block), 6)
+        ]
+        client.set_color_map(first_color, cast(List[Tuple[int, int, int]], colors))

--- a/vncdotool/messages/fence.py
+++ b/vncdotool/messages/fence.py
@@ -11,12 +11,10 @@ class ServerFenceHandler(MessageHandler):
     MESSAGE = MsgS2C.SERVER_FENCE
 
     def handle(self, client: Any) -> Generator[int, bytes, None]:
-        # rfbproto ServerFence: 3 bytes padding, U32 flags, U8 payload-length.
         flags, length = unpack("!xxxIB", (yield 8))
         payload = (yield length) if length else b""
         if flags & FenceFlags.REQUEST:
-            # rfbproto ServerFence: masking to the flags handled here, rather
-            # than just clearing Request, is what lets the server tell which
-            # flags this client supports as new ones are defined.
+            # Masking, not clearing REQUEST alone, is what lets the server
+            # learn which flags this client understands.
             known = FenceFlags.BLOCK_BEFORE | FenceFlags.BLOCK_AFTER | FenceFlags.SYNC_NEXT
             client.clientFence(FenceFlags(flags) & known, payload)

--- a/vncdotool/messages/fence.py
+++ b/vncdotool/messages/fence.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from struct import unpack
+from typing import Any, Generator
+
+from ..const import FenceFlags, MsgS2C
+from .base import MessageHandler
+
+
+class ServerFenceHandler(MessageHandler):
+    MESSAGE = MsgS2C.SERVER_FENCE
+
+    def handle(self, client: Any) -> Generator[int, bytes, None]:
+        # rfbproto ServerFence: 3 bytes padding, U32 flags, U8 payload-length.
+        flags, length = unpack("!xxxIB", (yield 8))
+        payload = (yield length) if length else b""
+        if flags & FenceFlags.REQUEST:
+            # rfbproto ServerFence: masking to the flags handled here, rather
+            # than just clearing Request, is what lets the server tell which
+            # flags this client supports as new ones are defined.
+            known = FenceFlags.BLOCK_BEFORE | FenceFlags.BLOCK_AFTER | FenceFlags.SYNC_NEXT
+            client.clientFence(FenceFlags(flags) & known, payload)

--- a/vncdotool/messages/simple.py
+++ b/vncdotool/messages/simple.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any, Generator
+
+from ..const import MsgS2C
+from .base import MessageHandler
+
+
+class BellHandler(MessageHandler):
+    MESSAGE = MsgS2C.BELL
+
+    def handle(self, client: Any) -> Generator[int, bytes, None]:
+        client.bell()
+        return
+        yield  # pragma: no cover -- unreachable; keeps this a generator function

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -14,19 +14,18 @@ https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst
 
 from __future__ import annotations
 
+import functools
 import getpass
 import sys
 import warnings
 import zlib
-from struct import error as StructError, pack, unpack, unpack_from
+from struct import error as StructError, pack, unpack
 from typing import (
     Any,
     Callable,
     Collection,
     Generator,
-    List,
     Tuple,
-    cast,
 )
 
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
@@ -40,7 +39,7 @@ from twisted.internet.protocol import Protocol
 from twisted.python import log, usage
 from twisted.python.failure import Failure
 
-from . import decoders
+from . import decoders, messages
 from .const import Encoding, AuthTypes, FenceFlags, MsgC2S, MsgS2C
 from .keys import Key
 from .pixelformat import PixelFormat
@@ -77,6 +76,11 @@ class RFBClient(Protocol):
     # Greater than any u16 dimension, so it refuses nothing until a subclass
     # narrows it.
     MAX_DESKTOP_SIZE = 0x10000
+
+    # Bounds a server-declared message payload length (ServerCutText,
+    # SetColourMapEntries) before it sizes a read; policy, not protocol, and
+    # narrowable by a subclass.
+    MAX_MESSAGE_PAYLOAD = 1 << 20
 
     _HEADER = b"RFB 000.000\n"
     _HEADER_TRANSLATE = bytes.maketrans(b"0123456789", b"0" * 10)
@@ -115,6 +119,7 @@ class RFBClient(Protocol):
         self.height = 0
         self._rect_backing = bytearray()
         self._decoders = decoders.for_connection()
+        self._messages = messages.for_connection()
 
     @property
     def bypp(self) -> int:
@@ -312,17 +317,21 @@ class RFBClient(Protocol):
         (msgid,) = unpack("!B", block)
         if msgid == MsgS2C.FRAMEBUFFER_UPDATE:
             self.expect(self._handleFramebufferUpdate, 3)
-        elif msgid == MsgS2C.SET_COLOUR_MAP_ENTRIES:
-            self.expect(self._handleColourMapEntries, 5)
-        elif msgid == MsgS2C.BELL:
-            self.bell()
-            self.expect(self._handleConnection, 1)
-        elif msgid == MsgS2C.SERVER_CUT_TEXT:
-            self.expect(self._handleServerCutText, 7)
-        elif msgid == MsgS2C.SERVER_FENCE:
-            self.expect(self._handleServerFence, 8)
-        else:
+            return
+        handler_cls = messages.HANDLERS.get(msgid)
+        if handler_cls is None:
             self.abortConnection(f"unknown message received {MsgS2C.lookup(msgid)!r}")
+            return
+        handler = self._messages[msgid]
+        self._pump(
+            None,
+            handler.handle(self),
+            self._finishMessage,
+            f"the {MsgS2C.lookup(msgid)!r} message",
+        )
+
+    def _finishMessage(self, _outcome: None) -> None:
+        self.expect(self._handleConnection, 1)
 
     def _handleFramebufferUpdate(self, block: bytes) -> None:
         (self.rectangles,) = unpack("!xH", block)
@@ -358,7 +367,12 @@ class RFBClient(Protocol):
         self, decoder: decoders.Decoder, x: int, y: int, width: int, height: int
     ) -> None:
         rect = (x, y, width, height)
-        self._pumpGenerator(None, decoder.decode(self, rect, self.pixel_format), rect)
+        self._pump(
+            None,
+            decoder.decode(self, rect, self.pixel_format),
+            functools.partial(self._finishRectangle, rect),
+            "this rectangle",
+        )
 
     def _finishRectangle(
         self, rect: tuple[int, int, int, int], outcome: decoders.Outcome
@@ -402,70 +416,36 @@ class RFBClient(Protocol):
             raise decoders.DecodeError(f"no memory for a {width}x{height} rectangle")
         return decoders.RectBuffer(width, height, self.bypp, self._rect_backing)
 
-    def _pumpGenerator(
+    def requirePayload(self, length: int) -> None:
+        """Raise unless a server-declared message payload fits the bound."""
+        if length > self.MAX_MESSAGE_PAYLOAD:
+            raise decoders.DecodeError(
+                f"payload of {length} bytes exceeds the {self.MAX_MESSAGE_PAYLOAD} "
+                "byte limit"
+            )
+
+    def _pump(
         self,
         block: bytes | None,
-        generator: Generator[int, Any, decoders.Outcome],
-        rect: tuple[int, int, int, int],
+        generator: Generator[int, Any, Any],
+        on_done: Callable[[Any], None],
+        describe: str,
     ) -> None:
         try:
             size = generator.send(block)
         except StopIteration as stop:
-            self._finishRectangle(rect, stop.value)
+            on_done(stop.value)
             return
         except (decoders.DecodeError, StructError, MemoryError, zlib.error) as exc:
             generator.close()
-            self.abortConnection(f"cannot decode this rectangle: {exc}")
+            self.abortConnection(f"cannot decode {describe}: {exc}")
             return
 
         if size < 0:
             generator.close()
             self.abortConnection(f"decoder asked for {size} bytes")
             return
-        self.expect(self._pumpGenerator, size, generator, rect)
-
-    # ---  other server messages
-
-    def _handleColourMapEntries(self, block: bytes) -> None:
-        (first_color, number_of_colors) = unpack("!xHH", block)
-        self.expect(
-            self._handleColourMapEntriesValue, 6 * number_of_colors, first_color
-        )
-
-    def _handleColourMapEntriesValue(self, block: bytes, first_color: int) -> None:
-        colors = [
-            unpack_from("!HHH", block, offset) for offset in range(0, len(block), 6)
-        ]
-        self.set_color_map(first_color, cast(List[Tuple[int, int, int]], colors))
-        self.expect(self._handleConnection, 1)
-
-    def _handleServerCutText(self, block: bytes) -> None:
-        (length,) = unpack("!xxxI", block)
-        self.expect(self._handleServerCutTextValue, length)
-
-    def _handleServerCutTextValue(self, block: bytes) -> None:
-        self.copy_text(block.decode("iso-8859-1"))
-        self.expect(self._handleConnection, 1)
-
-    def _handleServerFence(self, block: bytes) -> None:
-        # rfbproto ServerFence: 3 bytes padding, U32 flags, U8 payload-length.
-        flags, length = unpack("!xxxIB", block)
-        if length:
-            self.expect(self._handleServerFencePayload, length, flags)
-        else:
-            self._doServerFence(flags, b"")
-
-    def _handleServerFencePayload(self, block: bytes, flags: int) -> None:
-        self._doServerFence(flags, block)
-
-    def _doServerFence(self, flags: int, payload: bytes) -> None:
-        if flags & FenceFlags.REQUEST:
-            # rfbproto ServerFence: masking to the flags handled here, rather
-            # than just clearing Request, is what lets the server tell which
-            # flags this client supports as new ones are defined.
-            known = FenceFlags.BLOCK_BEFORE | FenceFlags.BLOCK_AFTER | FenceFlags.SYNC_NEXT
-            self.clientFence(FenceFlags(flags) & known, payload)
-        self.expect(self._handleConnection, 1)
+        self.expect(self._pump, size, generator, on_done, describe)
 
     # ------------------------------------------------------
     # incomming data redirector

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -77,7 +77,6 @@ class RFBClient(Protocol):
     # narrows it.
     MAX_DESKTOP_SIZE = 0x10000
 
-    # Policy, not protocol: narrowable by a subclass.
     MAX_MESSAGE_PAYLOAD = 1 << 20
 
     _HEADER = b"RFB 000.000\n"

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -77,9 +77,7 @@ class RFBClient(Protocol):
     # narrows it.
     MAX_DESKTOP_SIZE = 0x10000
 
-    # Bounds a server-declared message payload length (ServerCutText,
-    # SetColourMapEntries) before it sizes a read; policy, not protocol, and
-    # narrowable by a subclass.
+    # Policy, not protocol: narrowable by a subclass.
     MAX_MESSAGE_PAYLOAD = 1 << 20
 
     _HEADER = b"RFB 000.000\n"
@@ -318,11 +316,10 @@ class RFBClient(Protocol):
         if msgid == MsgS2C.FRAMEBUFFER_UPDATE:
             self.expect(self._handleFramebufferUpdate, 3)
             return
-        handler_cls = messages.HANDLERS.get(msgid)
-        if handler_cls is None:
+        handler = self._messages.get(msgid)
+        if handler is None:
             self.abortConnection(f"unknown message received {MsgS2C.lookup(msgid)!r}")
             return
-        handler = self._messages[msgid]
         self._pump(
             None,
             handler.handle(self),


### PR DESCRIPTION
Phase 1 of #474: moves SetColourMapEntries, ServerCutText, Bell and ServerFence out of `rfb.py` into `vncdotool/messages/`, one handler class per message, mirroring the `DECODERS` registry from `specs/decoder-architecture.md`. Each handler is a generator, unit-testable with no reactor or `RFBClient`. `FRAMEBUFFER_UPDATE`/the rectangle loop are untouched (deferred, per the design doc's phasing).

Real bug fix included: `SetColourMapEntries`' colour count and `ServerCutText`'s length were server-declared and unbounded, so a malformed server could make the client buffer arbitrarily much data. `requirePayload()` now bounds both at 1 MiB and raises the existing `DecodeError`.

Tests: 629 unit tests pass, flake8 clean. New `tests/unit/test_messages.py` plus an integration test for the oversized-payload disconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
