### PR TITLE
Fix ZRLE decoding for misreported pixel depths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 2.0.0.dev0 (UNRELEASED)
+- Fix ZRLE captures from servers that declare depth 32 for 24-bit color (@kudala-bharani, #483)
 - Fix `updateCursor` decoding a hide-pointer update (width or height 0) as an empty image instead of hiding the cursor, which raised inside Pillow or pasted a bogus zero-size image onto the screen (@sibson, #449)
 - Fix `RFBFactory` raising `AttributeError` on ARD authentication when used directly, instead of through `VNCDoToolFactory` (@sibson)
 - Add `vncdo stable SECONDS [FUZZ]` and `rstable SECONDS X Y W H [FUZZ]`, waiting until the screen stops changing rather than until it matches a reference image (@sibson)

--- a/specs/pixel-format.md
+++ b/specs/pixel-format.md
@@ -116,7 +116,6 @@ def channel_tolerance(pf: PixelFormat) -> tuple[int, int, int]:  # 8-bit error p
 ```
 
 `raw_mode` ignores `depth`: it does not affect where the channels sit.
-`cpixel_bytes` must obey it, since the encoder used the same declaration.
 
 `UnsupportedPixelFormat` rather than a guess, though under the policy below a
 caller only reaches it when a server ignores what was requested.
@@ -125,6 +124,10 @@ caller only reaches it when a server ignores what was requested.
 and every color bit sits in either the low or the high three bytes; which
 placement is a function of the shifts. rfbproto adds a tie-break the RFC omits:
 at depth ≤ 16 both placements fit, and the low three bytes are sent.
+
+[LibVNCServer's ZRLE encoder](https://github.com/LibVNC/libvncserver/blob/42494999e6492aaab9c1db785ecd293ef10b3aed/src/libvncserver/zrle.c#L154-L185)
+sends three bytes when the channels fit, even when its example server
+declares depth 32.
 
 Placement is in value space and `cpixel_offset` is in byte space, so big-endian
 reverses which end of the pixel they sit at. Slicing at the wrong end takes the

--- a/tests/unit/test_decoder_zrle.py
+++ b/tests/unit/test_decoder_zrle.py
@@ -198,6 +198,20 @@ class TestZRLE(unittest.TestCase):
 
         assert_pixels(self, self.cli.screen, [colour] * (width * height))
 
+    def test_zrle_rle_accepts_a_depth_32_declaration_with_24_colour_bits(self) -> None:
+        width = height = 64
+        pixel_format = rfb.PixelFormat(32, 32, False, True, 255, 255, 255, 0, 8, 16)
+        self.cli.dataReceived(b"RFB 003.003\n")
+        self.cli.dataReceived(pack("!I", rfb.AuthTypes.NONE))
+        self.cli.dataReceived(pack("!HH16sI", width, height, pixel_format.to_bytes(), 0))
+
+        colour = (10, 20, 30)
+        body = pack("!B", 0x80) + zrle_run(_cpixel(*colour), width * height)
+        self.cli.dataReceived(framebuffer_update([zrle_rect(0, 0, width, height, body)]))
+
+        self.cli.transport.loseConnection.assert_not_called()
+        assert_pixels(self, self.cli.screen, [colour] * (width * height))
+
     def test_zrle_palette_rle_mixes_single_and_run_pixels(self) -> None:
         width, height = 6, 1
         handshake(self.cli, width, height)

--- a/tests/unit/test_pixelformat.py
+++ b/tests/unit/test_pixelformat.py
@@ -210,8 +210,13 @@ class TestCPixel(TestCase):
         self.assertEqual(cpixel_bytes(BGR565), BGR565.bypp)
         self.assertEqual(cpixel_offset(BGR565), 0)
 
-    def test_depth_32_is_never_a_cpixel(self):
-        pixel_format = rfb.PixelFormat(32, 32, False, True, 255, 255, 255, 0, 8, 16)
+    def test_30_colour_bits_require_a_full_pixel(self):
+        pixel_format = rfb.PixelFormat(32, 30, False, True, 1023, 1023, 1023, 20, 10, 0)
+        self.assertEqual(cpixel_bytes(pixel_format), pixel_format.bypp)
+        self.assertEqual(cpixel_offset(pixel_format), 0)
+
+    def test_colour_mapped_32bpp_requires_a_full_pixel(self):
+        pixel_format = rfb.PixelFormat(32, 32, False, False, 255, 255, 255, 0, 8, 16)
         self.assertEqual(cpixel_bytes(pixel_format), pixel_format.bypp)
         self.assertEqual(cpixel_offset(pixel_format), 0)
 
@@ -301,3 +306,24 @@ class TestChannelTolerance(TestCase):
             worst = max(min(abs(value - near) for near in grid) for value in range(256))
             with self.subTest(pixel_format=pixel_format, channel=channel):
                 self.assertLessEqual(worst, channel_tolerance(pixel_format)[channel])
+
+
+class CPixelDepth32:
+    def test_24_colour_bits_fit_despite_declared_depth(self):
+        self.assertEqual(cpixel_bytes(self.pixel_format), 3)
+        self.assertEqual(cpixel_offset(self.pixel_format), self.expected_offset)
+
+
+def load_tests(loader, tests, pattern):
+    for name, bigendian, shifts, offset in (
+        ("low_little_endian", False, (0, 8, 16), 0),
+        ("low_big_endian", True, (0, 8, 16), 1),
+        ("high_little_endian", False, (8, 16, 24), 1),
+        ("high_big_endian", True, (8, 16, 24), 0),
+    ):
+        case = type(f"TestCPixelDepth32_{name}", (CPixelDepth32, TestCase), {
+            "pixel_format": rfb.PixelFormat(32, 32, bigendian, True, 255, 255, 255, *shifts),
+            "expected_offset": offset,
+        })
+        tests.addTests(loader.loadTestsFromTestCase(case))
+    return tests

--- a/vncdotool/pixelformat.py
+++ b/vncdotool/pixelformat.py
@@ -179,7 +179,6 @@ def cpixel_bytes(pixel_format: PixelFormat) -> int:
     if (
         pixel_format.truecolor
         and pixel_format.bpp == 32
-        and pixel_format.depth <= 24
         and _cpixel_placement(pixel_format) is not None
     ):
         return 3
@@ -203,8 +202,7 @@ def tpixel_bytes(pixel_format: PixelFormat) -> int:
     """3 for a TPIXEL-eligible format, otherwise ``bypp`` (a PIXEL).
 
     Narrower than CPIXEL: rfbproto §Tight requires depth exactly 24 and three
-    8-bit channels, where CPIXEL takes depth 24 or less. See
-    ``specs/tight-wire.md`` §1.
+    8-bit channels. See ``specs/tight-wire.md`` §1.
     """
     if (
         pixel_format.truecolor


### PR DESCRIPTION
Fixes #483: ZRLE captures accept a depth-32 declaration when the actual color channels fit three bytes.

This follows LibVNCServer's encoder; genuine deep-color formats still need four bytes. The five regression cases fail on the original code.

The advisory type checker reports the same 74 errors before and after the fix. Live-server tests and prose lint were not run locally: Docker is stopped and Vale is unavailable.
