### PR TITLE
Mark four specs built (they already are)

### DIFF
--- a/specs/pixel-format.md
+++ b/specs/pixel-format.md
@@ -1,8 +1,9 @@
 # Pixel Format: Design
 
-Status: draft, under review. The first slice of
+Status: built. The first slice of
 [decoder-architecture.md](decoder-architecture.md) Phase 1, and the `rgb565`
 entry point [decoder-goldens.md](decoder-goldens.md) names in its phasing.
+Golden and functional coverage at `rgb565` is still deferred (see below).
 
 ## Problem
 

--- a/specs/screen-stability.md
+++ b/specs/screen-stability.md
@@ -1,8 +1,9 @@
 # Screen Stability Design
 
-Status: draft, under review. Sibling of the `expect` matching design; this is
-the "Not in scope" item from it: blocking until the screen stops changing,
-with no reference image.
+Status: built. Sibling of the `expect` matching design; this is the "Not in
+scope" item from it: blocking until the screen stops changing, with no
+reference image. The `scene-lossy.vdo` golden migration noted below is not
+done.
 
 ## Problem
 

--- a/specs/testing-framework.md
+++ b/specs/testing-framework.md
@@ -1,8 +1,9 @@
 # Server Testing Framework Design
 
-Status: draft, under review. Companion to
+Status: built. Companion to
 [server-compatibility-plan.md](server-compatibility-plan.md); this document
-designs the Phase 0 framework that plan calls for.
+designs the Phase 0 framework that plan calls for. "Open questions / TODOs"
+below are follow-on work, not gaps in the framework itself.
 
 ## Problem
 

--- a/specs/tight-encoding.md
+++ b/specs/tight-encoding.md
@@ -1,9 +1,11 @@
 # Tight Encoding: Build Plan
 
-Status: draft, under review. Executes
+Status: built. Executes
 [decoder-architecture.md](decoder-architecture.md) Phase 6 and the Tight half of
 [server-compatibility-plan.md](server-compatibility-plan.md) Phase 2.1. Closes
-#264.
+#264. The Tight security type, the gradient filter, TightPNG, and Tight
+Encoding Without Zlib stay unimplemented, per "Decode only, against
+TigerVNC" below.
 
 ## What Phase 6 assumed, and what is actually missing
 


### PR DESCRIPTION
`screen-stability.md`, `pixel-format.md`, `tight-encoding.md` and `testing-framework.md` all said `draft, under review` while the features they design (`stable`/`rstable`, `--pixel-format`, Tight decoding, the docker-fleet test framework) are already in `CHANGELOG.md` under `2.0.0.dev0`. Flips each to `built` and names what's genuinely still open next to it (rgb565 golden coverage, the `scene-lossy.vdo` migration, Tight's unimplemented corners, testing-framework's follow-on TODOs), matching `expect-matching.md`'s existing pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
