### PR TITLE
Move the RFB security types onto pluggable handlers

### DIFF
--- a/specs/security-handler-architecture.md
+++ b/specs/security-handler-architecture.md
@@ -1,0 +1,155 @@
+# Pluggable Security Handlers
+
+`specs/decoder-architecture.md` is the design this mirrors. Read that first;
+this document only records where authentication differs from rectangle
+decoding, and what the migration has to preserve.
+
+## The handshake is a trampoline
+
+Every security type in `rfb.py` is a chain of `expect(callback, n)` hops, each
+method parking the next. Authentication is 20 of them:
+
+| Security type | Methods |
+|---|---|
+| None | `_handleSecurityTypes` inline, version-dependent |
+| VNC Authentication (2) | `_handleVNCAuth` |
+| VeNCrypt (19) | `_handleVeNCryptVersion`, `…VersionAck`, `…SubtypeCount`, `…Subtypes`, `…TLSAck`, `_startVeNCryptSubAuth`, `_sendVeNCryptPlain` |
+| ARD Diffie-Hellman (30) | `_handleDHAuth`, `_handleDHAuthKey`, `_handleDHAuthCert`, `_encryptArd` |
+| shared tail | `_handleVNCAuthResult`, `_handleAuthFailed`, `_handleAuthFailedMessage` |
+
+Two costs, and neither is line count:
+
+**Handler-local state is stored on the client.** `self._challenge`,
+`self.generator`, `self.keyLen`, `self.modulus`, `self.serverKey` exist only
+because a callback cannot keep a local variable alive across a hop. They are
+live on `RFBClient` for the whole session, long after the handshake that used
+them, and nothing stops a later method reading a stale one.
+
+**The shared tail is hardcoded at six call sites.** `expect(self._handleVNCAuthResult, 4)`
+appears once per path that ends in a SecurityResult. Whether a SecurityResult
+follows at all is a protocol rule — RFB 3.3 and 3.7 send none after security
+type None — and that rule is currently spelled out wherever someone remembered
+it.
+
+## `_pump` already does this, at any phase
+
+`RFBClient._pump` takes any generator, an `on_done`, and a description; it is
+built on `expect` and knows nothing about rectangles. `messages/base.py`
+already defines the contract it drives:
+
+```python
+def handle(self, client: Any) -> Generator[int, bytes, None]:
+    """Yield the byte counts this message needs, each satisfied in full."""
+```
+
+Nothing binds that to the post-handshake loop. A security handler can be the
+same generator, driven by the same pump, during the handshake. No new
+machinery — this migration adds a package and a base class, not a mechanism.
+
+## Reads are sequenced, writes are not
+
+The generator suspends only on *reads*. Writes are ordinary side effects a
+handler performs whenever it likes, including from code the handler does not
+control.
+
+This is what makes VNC authentication migratable without breaking its public
+API. `rfb.py` documents `vncRequestPassword` as an override point that calls
+`sendPassword` — the three in-tree implementations all call it synchronously,
+but the docstring invites a subclass to call it later, out of band. The
+handler must therefore **not** model the password as something it yields for.
+It stashes the challenge, calls `client.vncRequestPassword()`, and goes
+straight to waiting for the next read. Whenever `sendPassword` fires, it
+writes; the generator neither knows nor cares.
+
+**Do not change that contract in this migration.** `vncRequestPassword`,
+`sendPassword`, `ardRequestCredentials` and `vncAuthFailed` keep their present
+signatures and semantics. They are published, and `docs/library.rst` documents
+subclassing.
+
+## The contract
+
+`vncdotool/security/base.py`:
+
+```python
+class SecurityHandler:
+    """One RFB security type: RFC 6143 section 7.2."""
+
+    SECURITY_TYPE: ClassVar[AuthTypes]
+
+    def handle(self, client: Any) -> Generator[int, bytes, None]:
+        """Yield the byte counts this security type needs, each satisfied in
+        full. The security-type byte has already been written.
+        """
+        raise NotImplementedError
+```
+
+Registry mirrors `messages/__init__.py`: a `HANDLERS` dict keyed on
+`AuthTypes`, and `for_connection()` returning fresh instances.
+
+### SecurityResult is a generator handlers compose with
+
+The shared tail becomes one generator that handlers `yield from` where the
+protocol says a SecurityResult follows:
+
+```python
+def security_result(client) -> Generator[int, bytes, None]:
+    (result,) = unpack("!I", (yield 4))
+    ...
+```
+
+That is the payoff the callback chain cannot express. `None` on RFB < 3.8
+simply does not `yield from` it; VeNCrypt's `X509None` does. The rule lives
+next to the code that depends on it instead of at six call sites.
+
+Failure handling (`_handleAuthFailed`, `_handleAuthFailedMessage`) folds into
+the same generator — it is a length-prefixed read followed by
+`client.vncAuthFailed(...)`.
+
+## Scope of the first pass
+
+Migrate **None, VNC Authentication (2), and ARD Diffie-Hellman (30)**, plus
+the shared SecurityResult tail. This is pre-existing debt being paid before
+new code lands on top of it.
+
+**Leave VeNCrypt on the `expect` chain.** `_handleSecurityTypes` dispatches per
+security type, so the registry and the old chain coexist: types with a handler
+go through `_pump`, VeNCrypt keeps its `expect(self._handleVeNCryptVersion, 2)`
+branch. VeNCrypt migrates separately, in the PR that introduces it (#498), once
+this has landed.
+
+Out of scope, deliberately:
+
+- `_handleInitial`, `_handleNumberSecurityTypes`, `_handleSecurityTypes`,
+  `_doClientInitialization`, `_handleServerInit`. Version negotiation and
+  ClientInit are not security types.
+- `_usableAuths` and the `max(valid_types)` choice. Selection policy stays put.
+- The `input()`/`getpass()` calls in `ardRequestCredentials`, which block the
+  reactor. Real, pre-existing, and not this change.
+- The `AuthTypes.INVALID` / `_handleConnFailed` path from the RFB 3.3
+  `_handleAuth`, which is a connection failure rather than a security type.
+
+## What tells us it worked
+
+`self._challenge`, `self.generator`, `self.keyLen`, `self.modulus` and
+`self.serverKey` are gone from `RFBClient`, having become locals in the
+handlers that use them. If they are still attributes at the end, the migration
+recreated the trampoline with extra files.
+
+`_pump`'s except clause catches decoder-flavoured exceptions
+(`decoders.DecodeError`, `StructError`, `MemoryError`, `zlib.error`) and
+reports `cannot decode {describe}`. A security handler wants its own verb and
+its own error set; widen or parameterise rather than reporting a failed
+handshake as a decode error.
+
+## Testing
+
+Unit tests only; `tests/unit/test_rfb.py` is the topical home and already
+drives the handshake with a mocked transport. Behaviour must not move: the
+existing auth tests should pass unchanged, and a diff that edits them is a
+diff that changed behaviour. New tests cover the handlers directly — a
+generator can be driven with `send()` without a transport at all, which is the
+other reason to do this.
+
+`tests/functional/` needs nothing new. The fleet already exercises None
+(`tigervnc`) and VNC authentication (`tigervnc-auth`); ARD has no server to
+test against, which is exactly why its tests must not be disturbed.

--- a/specs/security-handler-architecture.md
+++ b/specs/security-handler-architecture.md
@@ -7,13 +7,12 @@ decoding, and what the migration has to preserve.
 ## The handshake is a trampoline
 
 Every security type in `rfb.py` is a chain of `expect(callback, n)` hops, each
-method parking the next. Authentication is 20 of them:
+method parking the next:
 
 | Security type | Methods |
 |---|---|
 | None | `_handleSecurityTypes` inline, version-dependent |
 | VNC Authentication (2) | `_handleVNCAuth` |
-| VeNCrypt (19) | `_handleVeNCryptVersion`, `…VersionAck`, `…SubtypeCount`, `…Subtypes`, `…TLSAck`, `_startVeNCryptSubAuth`, `_sendVeNCryptPlain` |
 | ARD Diffie-Hellman (30) | `_handleDHAuth`, `_handleDHAuthKey`, `_handleDHAuthCert`, `_encryptArd` |
 | shared tail | `_handleVNCAuthResult`, `_handleAuthFailed`, `_handleAuthFailedMessage` |
 
@@ -76,12 +75,23 @@ class SecurityHandler:
 
     SECURITY_TYPE: ClassVar[AuthTypes]
 
-    def handle(self, client: Any) -> Generator[int, bytes, None]:
+    def handle(self, client: Any) -> Generator[int, bytes, bool]:
         """Yield the byte counts this security type needs, each satisfied in
-        full. The security-type byte has already been written.
+        full, and return whether the connection proceeds to initialisation.
+        The security-type byte has already been written.
         """
         raise NotImplementedError
 ```
+
+The return value is what `messages/base.py` does not need. A message handler
+that finishes has nothing left to say; a security handler has to tell the pump
+whether authentication succeeded, because on failure the old code's signal was
+simply not calling `_doClientInitialization`. A `None` return cannot carry
+that. The alternatives are all worse: a flag on the client recreates the
+handler-state-on-the-client problem this package exists to remove, an
+exception routes through `abortConnection` and changes behaviour, and calling
+`_doClientInitialization` from inside a handler hands it a private client
+method. Decoders already return an `Outcome` through this same pump.
 
 Registry mirrors `messages/__init__.py`: a `HANDLERS` dict keyed on
 `AuthTypes`, and `for_connection()` returning fresh instances.
@@ -92,14 +102,14 @@ The shared tail becomes one generator that handlers `yield from` where the
 protocol says a SecurityResult follows:
 
 ```python
-def security_result(client) -> Generator[int, bytes, None]:
+def security_result(client) -> Generator[int, bytes, bool]:
     (result,) = unpack("!I", (yield 4))
     ...
 ```
 
 That is the payoff the callback chain cannot express. `None` on RFB < 3.8
-simply does not `yield from` it; VeNCrypt's `X509None` does. The rule lives
-next to the code that depends on it instead of at six call sites.
+simply does not `yield from` it. The rule lives next to the code that depends
+on it instead of at six call sites.
 
 Failure handling (`_handleAuthFailed`, `_handleAuthFailedMessage`) folds into
 the same generator — it is a length-prefixed read followed by
@@ -111,11 +121,11 @@ Migrate **None, VNC Authentication (2), and ARD Diffie-Hellman (30)**, plus
 the shared SecurityResult tail. This is pre-existing debt being paid before
 new code lands on top of it.
 
-**Leave VeNCrypt on the `expect` chain.** `_handleSecurityTypes` dispatches per
-security type, so the registry and the old chain coexist: types with a handler
-go through `_pump`, VeNCrypt keeps its `expect(self._handleVeNCryptVersion, 2)`
-branch. VeNCrypt migrates separately, in the PR that introduces it (#498), once
-this has landed.
+VeNCrypt (19) is not here because it is not on `main` yet; #498 adds it, on its
+own `expect` chain. `_handleSecurityTypes` dispatches per security type, so a
+registry handler and a leftover chain coexist without either knowing about the
+other, and VeNCrypt migrates onto this contract inside #498 rather than being
+rewritten twice.
 
 Out of scope, deliberately:
 
@@ -130,10 +140,16 @@ Out of scope, deliberately:
 
 ## What tells us it worked
 
-`self._challenge`, `self.generator`, `self.keyLen`, `self.modulus` and
-`self.serverKey` are gone from `RFBClient`, having become locals in the
-handlers that use them. If they are still attributes at the end, the migration
-recreated the trampoline with extra files.
+`self.generator`, `self.keyLen`, `self.modulus` and `self.serverKey` are gone
+from `RFBClient`, having become locals in the handlers that use them. If they
+are still attributes at the end, the migration recreated the trampoline with
+extra files.
+
+`self._challenge` is the exception and has to stay. `sendPassword` reads it,
+`sendPassword` is published, and its docstring invites a subclass to call it
+out of band — after the handler that would own the local has already returned.
+Nothing reachable from the client can see a handler's locals, so the challenge
+lives on the client or the published contract breaks.
 
 `_pump`'s except clause catches decoder-flavoured exceptions
 (`decoders.DecodeError`, `StructError`, `MemoryError`, `zlib.error`) and

--- a/tests/unit/test_rfb.py
+++ b/tests/unit/test_rfb.py
@@ -159,6 +159,52 @@ class TestRFB(TestCase):
         # never grew a buffer waiting for the declared length
         assert not self.client._packet
 
+    def test_auth_vnc38(self):
+        challenge = bytes(range(16))
+        self.client._packet += (
+            b"RFB 003.008\n"  # header
+            b"\x01"  # num-auth-types
+            b"\x02"  # AuthTypes.VNC_AUTHENTICATION
+            + challenge
+            + b"\x00\x00\x00\x00"  # OK
+        )
+        self.client.factory.password = "secret"
+        self.client.factory.shared = 0
+        self.client._handler()
+        self.client.transport.write.assert_has_calls([
+            mock.call(b"RFB 003.008\n"),
+            mock.call(b"\x02"),  # AuthTypes.VNC_AUTHENTICATION
+            mock.call(rfb.des_encrypt(rfb._vnc_des("secret"), challenge)),
+            mock.call(b"\x00"),  # shared
+        ])
+
+    def test_password_sent_after_the_handshake_still_answers_the_challenge(self):
+        challenge = bytes(range(16))
+        self.client._packet += (
+            b"RFB 003.008\n"  # header
+            b"\x01"  # num-auth-types
+            b"\x02"  # AuthTypes.VNC_AUTHENTICATION
+            + challenge
+        )
+        self.client.factory.password = None
+        self.client._handler()
+        self.client.sendPassword("secret")
+        self.client.transport.write.assert_called_with(
+            rfb.des_encrypt(rfb._vnc_des("secret"), challenge)
+        )
+
+    def test_security_type_without_a_handler_reports_protocol_error(self):
+        self.client.vncProtocolError = mock.Mock()
+        self.client.SUPPORTED_AUTHS = {rfb.AuthTypes.TIGHT}
+        self.client._packet += (
+            b"RFB 003.008\n"  # header
+            b"\x01"  # num-auth-types
+            b"\x10"  # AuthTypes.TIGHT
+        )
+        self.client._handler()
+        self.client.vncProtocolError.assert_called_once()
+        assert self.client._aborted
+
     def test_ardRequestCredentials_prompts_when_factory_has_no_username(self):
         self.client.factory = rfb.RFBFactory()
         with (

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -1,0 +1,211 @@
+import warnings
+from contextlib import contextmanager
+from struct import pack
+from unittest import TestCase, mock
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import dh
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.utils import CryptographyDeprecationWarning
+
+from vncdotool import security
+from vncdotool.const import AuthTypes
+
+SECURITY_OK = pack("!I", 0)
+SECURITY_FAILED = pack("!I", 1)
+SECURITY_TOO_MANY = pack("!I", 2)
+
+# RFC 3526 group 14, a published 2048-bit safe prime.
+MODP_2048 = int(
+    "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E08"
+    "8A67CC74020BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B"
+    "302B0A6DF25F14374FE1356D6D51C245E485B576625E7EC6F44C42E9"
+    "A637ED6B0BFF5CB6F406B7EDEE386BFB5A899FA5AE9F24117C4B1FE6"
+    "49286651ECE45B3DC2007CB8A163BF0598DA48361C55D39A69163FA8"
+    "FD24CF5F83655D23DCA3AD961C62F356208552BB9ED529077096966D"
+    "670C354E4ABC9804F1746C08CA18217C32905E462E36CE3BE39E772C"
+    "180E86039B2783A2EC07A28FB5C55DF06F4C52C9DE2BCBF695581718"
+    "3995497CEA956AE515D2261898FA051015728E5A8AACAA68FFFFFFFF"
+    "FFFFFFFF",
+    16,
+)
+
+
+@contextmanager
+def ffdh():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", CryptographyDeprecationWarning)
+        yield
+
+
+def drive(handler, client, *blocks):
+    """Drive a handler's generator the way RFBClient._pump does."""
+    generator = handler.handle(client)
+    for block in (None, *blocks):
+        try:
+            generator.send(block)
+        except StopIteration as stop:
+            return stop.value
+    raise AssertionError("handler did not finish after the given blocks")
+
+
+class TestHandlerRegistry(TestCase):
+
+    def test_registry_keys_match_their_own_class(self):
+        for sec_type, cls in security.HANDLERS.items():
+            assert cls.SECURITY_TYPE == sec_type
+
+    def test_for_connection_builds_one_instance_per_security_type(self):
+        instances = security.for_connection()
+        assert set(instances) == set(security.HANDLERS)
+        for sec_type, handler in instances.items():
+            assert isinstance(handler, security.HANDLERS[sec_type])
+
+    def test_base_handler_has_no_implementation(self):
+        with self.assertRaises(NotImplementedError):
+            security.SecurityHandler().handle(mock.Mock())
+
+
+class TestNoneHandler(TestCase):
+
+    def setUp(self):
+        self.handler = security.HANDLERS[AuthTypes.NONE]()
+        self.client = mock.Mock()
+
+    def test_no_security_result_before_38(self):
+        self.client._version = (3, 7)
+        assert drive(self.handler, self.client) is True
+
+    def test_security_result_from_38(self):
+        self.client._version = (3, 8)
+        assert drive(self.handler, self.client, SECURITY_OK) is True
+
+    def test_failure_from_38_does_not_proceed(self):
+        self.client._version = (3, 8)
+        outcome = drive(
+            self.handler, self.client, SECURITY_FAILED, pack("!I", 4), b"nope"
+        )
+        assert outcome is False
+        self.client.vncAuthFailed.assert_called_once_with(b"nope")
+
+
+class TestSecurityResult(TestCase):
+
+    def setUp(self):
+        self.client = mock.Mock()
+
+    def drive_result(self, *blocks):
+        generator = security.security_result(self.client)
+        for block in (None, *blocks):
+            try:
+                generator.send(block)
+            except StopIteration as stop:
+                return stop.value
+        raise AssertionError("security_result did not finish")
+
+    def test_ok_proceeds_and_keeps_the_connection(self):
+        self.client._version = (3, 8)
+        assert self.drive_result(SECURITY_OK) is True
+        self.client.transport.loseConnection.assert_not_called()
+
+    def test_failure_before_38_has_no_reason_string_on_the_wire(self):
+        self.client._version = (3, 3)
+        assert self.drive_result(SECURITY_FAILED) is False
+        self.client.vncAuthFailed.assert_called_once_with("authentication failed")
+        self.client.transport.loseConnection.assert_called_once()
+
+    def test_too_many_before_38(self):
+        self.client._version = (3, 3)
+        assert self.drive_result(SECURITY_TOO_MANY) is False
+        self.client.vncAuthFailed.assert_called_once_with("too many tries to log in")
+
+    def test_too_many_from_38_reads_the_servers_reason(self):
+        self.client._version = (3, 8)
+        reason = b"too many security failures"
+        outcome = self.drive_result(
+            SECURITY_TOO_MANY, pack("!I", len(reason)), reason
+        )
+        assert outcome is False
+        self.client.vncAuthFailed.assert_called_once_with(reason)
+        self.client.transport.loseConnection.assert_called_once()
+
+    def test_unknown_result_drops_the_connection_without_a_reason(self):
+        self.client._version = (3, 8)
+        assert self.drive_result(pack("!I", 7)) is False
+        self.client.vncAuthFailed.assert_not_called()
+        self.client.transport.loseConnection.assert_called_once()
+
+
+class TestVNCAuthenticationHandler(TestCase):
+
+    def setUp(self):
+        self.handler = security.HANDLERS[AuthTypes.VNC_AUTHENTICATION]()
+        self.client = mock.Mock()
+        self.client._version = (3, 8)
+
+    def test_challenge_is_left_on_the_client_for_sendPassword(self):
+        challenge = bytes(range(16))
+        assert drive(self.handler, self.client, challenge, SECURITY_OK) is True
+        assert self.client._challenge == challenge
+        self.client.vncRequestPassword.assert_called_once_with()
+
+    def test_the_handler_never_waits_for_the_password(self):
+        generator = self.handler.handle(self.client)
+        generator.send(None)
+        assert generator.send(bytes(16)) == 4
+
+
+class TestDiffieHellmanHandler(TestCase):
+
+    def setUp(self):
+        self.handler = security.HANDLERS[AuthTypes.DIFFIE_HELLMAN]()
+        self.client = mock.Mock()
+        self.client._version = (3, 8)
+        self.client.factory.username = "alice"
+        self.client.factory.password = "secret"
+
+    def test_credentials_decrypt_with_the_shared_secret(self):
+        generator, key_len = 2, 256
+        with ffdh():
+            params = dh.DHParameterNumbers(p=MODP_2048, g=generator)
+            server_private = params.parameters().generate_private_key()
+        server_public = server_private.public_key().public_numbers().y
+
+        outcome = drive(
+            self.handler,
+            self.client,
+            pack("!HH", generator, key_len),
+            MODP_2048.to_bytes(key_len, "big"),
+            server_public.to_bytes(key_len, "big"),
+            SECURITY_OK,
+        )
+        assert outcome is True
+        self.client.ardRequestCredentials.assert_called_once_with()
+
+        (sent,) = self.client.transport.write.call_args.args
+        assert len(sent) == 128 + key_len
+        ciphertext, client_public = sent[:128], sent[128:]
+
+        with ffdh():
+            shared = server_private.exchange(
+                dh.DHPublicNumbers(
+                    int.from_bytes(client_public, "big"), params
+                ).public_key()
+            )
+        digest = hashes.Hash(hashes.MD5())
+        digest.update(shared)
+        decryptor = Cipher(algorithms.AES(digest.finalize()), modes.ECB()).decryptor()
+        plaintext = decryptor.update(ciphertext) + decryptor.finalize()
+
+        assert plaintext[:64] == b"alice".ljust(64, b"\0")
+        assert plaintext[64:] == b"secret".ljust(64, b"\0")
+
+    def test_credentials_are_requested_before_anything_is_sent(self):
+        self.client.ardRequestCredentials.side_effect = AssertionError("asked late")
+        generator = self.handler.handle(self.client)
+        generator.send(None)
+        generator.send(pack("!HH", 2, 4))
+        generator.send(b"\x00" * 4)
+        with self.assertRaises(AssertionError):
+            generator.send(b"\x00" * 4)
+        self.client.transport.write.assert_not_called()

--- a/vncdotool/capture.py
+++ b/vncdotool/capture.py
@@ -14,8 +14,7 @@ from typing import Any, Generator, NamedTuple
 
 from .const import AuthTypes, Encoding
 
-# AES-ECB over a fixed 64-byte username + 64-byte password struct; see
-# RFBClient._encryptArd().
+# AES-ECB over a fixed 64-byte username + 64-byte password struct.
 ARD_CREDENTIALS_LEN = 128
 
 
@@ -203,7 +202,8 @@ class HandshakeScrubber:
             yield _Want(self.s2c, 16)  # challenge
             yield _Want(self.c2s, 16)  # response
         elif sectype == AuthTypes.DIFFIE_HELLMAN:
-            # ARD, laid out as RFBClient._handleDHAuth reads it. A `none`
+            # ARD, laid out as rfbproto's Diffie-Hellman Authentication has
+            # it: a generator and key size, then two key-size values. A `none`
             # handshake has nowhere for the DH values, so they go too.
             head = yield _Want(self.s2c, 4)
             _generator, key_len = unpack("!HH", head)

--- a/vncdotool/rfb.py
+++ b/vncdotool/rfb.py
@@ -29,10 +29,7 @@ from typing import (
 )
 
 from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-from cryptography.hazmat.primitives.asymmetric import dh
-from cryptography.hazmat.primitives import hashes
-from cryptography.utils import CryptographyDeprecationWarning
+from cryptography.hazmat.primitives.ciphers import Cipher, modes
 from twisted.application import internet, service
 from twisted.internet import protocol
 from twisted.internet.interfaces import IConnector, ITransport
@@ -40,12 +37,15 @@ from twisted.internet.protocol import Protocol
 from twisted.python import log, usage
 from twisted.python.failure import Failure
 
-from . import decoders, messages
+from . import decoders, messages, security
 from .const import Encoding, AuthTypes, FenceFlags, MsgC2S, MsgS2C
 from .keys import Key
 from .pixelformat import PixelFormat
 
 Ver = Tuple[int, int]
+
+_DECODE_ERRORS = (decoders.DecodeError, StructError, MemoryError, zlib.error)
+_SECURITY_ERRORS = (security.SecurityError, StructError)
 
 # ~ from twisted.internet import reactor
 
@@ -63,11 +63,7 @@ class RFBClient(Protocol):
         (5, 0),  # RealVNC 5.3
     }
     MAX_CLIENT_VERSION = (3, 8)
-    SUPPORTED_AUTHS = {
-        AuthTypes.NONE,
-        AuthTypes.VNC_AUTHENTICATION,
-        AuthTypes.DIFFIE_HELLMAN,
-    }
+    SUPPORTED_AUTHS = set(security.HANDLERS)
     _UNMIGRATED_ENCODINGS = {
         Encoding.ZRLE,
         Encoding.PSEUDO_LAST_RECT,
@@ -86,6 +82,8 @@ class RFBClient(Protocol):
     _CHANGING_HOOKS = ("fillRectangle", "updateRectangle")
 
     transport: ITransport
+
+    _challenge: bytes
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -118,6 +116,7 @@ class RFBClient(Protocol):
         self._rect_backing = bytearray()
         self._decoders = decoders.for_connection()
         self._messages = messages.for_connection()
+        self._security = security.for_connection()
 
     @property
     def bypp(self) -> int:
@@ -169,15 +168,7 @@ class RFBClient(Protocol):
         if valid_types:
             sec_type = max(valid_types)
             self.transport.write(pack("!B", sec_type))
-            if sec_type == AuthTypes.NONE:
-                if self._version < (3, 8):
-                    self._doClientInitialization()
-                else:
-                    self.expect(self._handleVNCAuthResult, 4)
-            elif sec_type == AuthTypes.VNC_AUTHENTICATION:
-                self.expect(self._handleVNCAuth, 16)
-            elif sec_type == AuthTypes.DIFFIE_HELLMAN:
-                self.expect(self._handleDHAuth, 4)
+            self._startSecurity(sec_type)
         else:
             self.abortConnection(f"unknown security types: {types!r}")
 
@@ -186,12 +177,32 @@ class RFBClient(Protocol):
         # ~ print(f"{auth=}")
         if auth == AuthTypes.INVALID:
             self.expect(self._handleConnFailed, 4)
-        elif auth == AuthTypes.NONE:
-            self._doClientInitialization()
-        elif auth == AuthTypes.VNC_AUTHENTICATION:
-            self.expect(self._handleVNCAuth, 16)
+        elif auth in self._security:
+            # Before 3.7 the server dictates the security type, so the client
+            # writes nothing to choose it.
+            self._startSecurity(auth)
         else:
             self.abortConnection(f"unknown auth response {AuthTypes.lookup(auth)!r}")
+
+    def _startSecurity(self, sec_type: int) -> None:
+        handler = self._security.get(sec_type)
+        if handler is None:
+            self.abortConnection(
+                f"unsupported security type {AuthTypes.lookup(sec_type)!r}"
+            )
+            return
+        self._pump(
+            None,
+            handler.handle(self),
+            self._finishSecurity,
+            f"the {AuthTypes.lookup(sec_type)!r} security type",
+            _SECURITY_ERRORS,
+            "negotiate",
+        )
+
+    def _finishSecurity(self, proceed: bool) -> None:
+        if proceed:
+            self._doClientInitialization()
 
     def _handleConnFailed(self, block: bytes) -> None:
         (waitfor,) = unpack("!I", block)
@@ -199,58 +210,6 @@ class RFBClient(Protocol):
 
     def _handleConnMessage(self, block: bytes) -> None:
         self.abortConnection(f"Connection refused: {block!r}")
-
-    def _handleVNCAuth(self, block: bytes) -> None:
-        self._challenge = block
-        self.vncRequestPassword()
-        self.expect(self._handleVNCAuthResult, 4)
-
-    def _handleDHAuth(self, block: bytes) -> None:
-        self.generator, self.keyLen = unpack("!HH", block)
-        self.expect(self._handleDHAuthKey, self.keyLen)
-
-    def _handleDHAuthKey(self, block: bytes) -> None:
-        self.modulus = block
-        self.expect(self._handleDHAuthCert, self.keyLen)
-
-    def _handleDHAuthCert(self, block: bytes) -> None:
-        self.serverKey = block
-
-        self.ardRequestCredentials()
-
-        self._encryptArd()
-        self.expect(self._handleVNCAuthResult, 4)
-
-    def _encryptArd(self) -> None:
-        userStruct = f"{self.factory.username:\0<64}{self.factory.password:\0<64}"
-
-        p = int.from_bytes(self.modulus, "big")
-        sk = int.from_bytes(self.serverKey, "big")
-        with warnings.catch_warnings():
-            # ARD auth is specified over classic finite-field DH; the server
-            # picks p/g and there is no other algorithm to negotiate into.
-            # Tracking upstream removal: https://github.com/sibson/vncdotool/issues/388
-            warnings.simplefilter("ignore", CryptographyDeprecationWarning)
-            param_nums = dh.DHParameterNumbers(p=p, g=self.generator)
-            server_key = dh.DHPublicNumbers(sk, param_nums).public_key()
-
-        params = param_nums.parameters()
-        private_key = params.generate_private_key()
-        shared_key = private_key.exchange(server_key)
-
-        h = hashes.Hash(hashes.MD5())
-        h.update(shared_key)
-        key_digest = h.finalize()
-
-        cipher = Cipher(algorithms.AES(key_digest), modes.ECB())
-        encryptor = cipher.encryptor()
-        ciphertext = encryptor.update(userStruct.encode("utf-8"))
-        ciphertext += encryptor.finalize()
-
-        public_key = private_key.public_key()
-        y = public_key.public_numbers().y.to_bytes(self.keyLen, "big")
-
-        self.transport.write(ciphertext + y)
 
     def ardRequestCredentials(self) -> None:
         if self.factory.username is None:
@@ -261,36 +220,6 @@ class RFBClient(Protocol):
     def sendPassword(self, password: str) -> None:
         """send password"""
         self.transport.write(des_encrypt(_vnc_des(password), self._challenge))
-
-    def _handleVNCAuthResult(self, block: bytes) -> None:
-        (result,) = unpack("!I", block)
-        # ~ print(f"{auth=}")
-        if result == 0:  # OK
-            self._doClientInitialization()
-            return
-        elif result == 1:  # failed
-            if self._version < (3, 8):
-                self.vncAuthFailed("authentication failed")
-                self.transport.loseConnection()
-            else:
-                self.expect(self._handleAuthFailed, 4)
-        elif result == 2:  # too many
-            if self._version < (3, 8):
-                self.vncAuthFailed("too many tries to log in")
-                self.transport.loseConnection()
-            else:
-                self.expect(self._handleAuthFailed, 4)
-        else:
-            log.msg(f"unknown auth response ({result})")
-            self.transport.loseConnection()
-
-    def _handleAuthFailed(self, block: bytes) -> None:
-        (waitfor,) = unpack("!I", block)
-        self.expect(self._handleAuthFailedMessage, waitfor)
-
-    def _handleAuthFailedMessage(self, block: bytes) -> None:
-        self.vncAuthFailed(block)
-        self.transport.loseConnection()
 
     def _doClientInitialization(self) -> None:
         self.transport.write(pack("!B", self.factory.shared))
@@ -427,22 +356,24 @@ class RFBClient(Protocol):
         generator: Generator[int, Any, Any],
         on_done: Callable[[Any], None],
         describe: str,
+        errors: tuple[type[BaseException], ...] = _DECODE_ERRORS,
+        verb: str = "decode",
     ) -> None:
         try:
             size = generator.send(block)
         except StopIteration as stop:
             on_done(stop.value)
             return
-        except (decoders.DecodeError, StructError, MemoryError, zlib.error) as exc:
+        except errors as exc:
             generator.close()
-            self.abortConnection(f"cannot decode {describe}: {exc}")
+            self.abortConnection(f"cannot {verb} {describe}: {exc}")
             return
 
         if size < 0:
             generator.close()
             self.abortConnection(f"decoder asked for {size} bytes")
             return
-        self.expect(self._pump, size, generator, on_done, describe)
+        self.expect(self._pump, size, generator, on_done, describe, errors, verb)
 
     # ------------------------------------------------------
     # incomming data redirector

--- a/vncdotool/security/__init__.py
+++ b/vncdotool/security/__init__.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from ..const import AuthTypes
+from .ard import DiffieHellmanHandler
+from .base import SecurityHandler, security_result
+from .errors import SecurityError
+from .none import NoneHandler
+from .vncauth import VNCAuthenticationHandler
+
+HANDLERS: Dict[AuthTypes, Type[SecurityHandler]] = {
+    cls.SECURITY_TYPE: cls
+    for cls in (
+        NoneHandler,
+        VNCAuthenticationHandler,
+        DiffieHellmanHandler,
+    )
+}
+
+
+def for_connection() -> Dict[AuthTypes, SecurityHandler]:
+    return {sec_type: cls() for sec_type, cls in HANDLERS.items()}
+
+
+__all__ = [
+    "HANDLERS",
+    "SecurityError",
+    "SecurityHandler",
+    "for_connection",
+    "security_result",
+]

--- a/vncdotool/security/ard.py
+++ b/vncdotool/security/ard.py
@@ -17,9 +17,6 @@ class DiffieHellmanHandler(SecurityHandler):
     SECURITY_TYPE = AuthTypes.DIFFIE_HELLMAN
 
     def handle(self, client: Any) -> Generator[int, bytes, bool]:
-        # rfbproto, Diffie-Hellman Authentication: a U16 generator and a U16
-        # key size, then the prime modulus and the server's public value, each
-        # key-size bytes.
         generator, key_len = unpack("!HH", (yield 4))
         modulus = yield key_len
         server_key = yield key_len
@@ -40,9 +37,6 @@ def _encrypt(
     p = int.from_bytes(modulus, "big")
     sk = int.from_bytes(server_key, "big")
     with warnings.catch_warnings():
-        # ARD auth is specified over classic finite-field DH; the server
-        # picks p/g and there is no other algorithm to negotiate into.
-        # Tracking upstream removal: https://github.com/sibson/vncdotool/issues/388
         warnings.simplefilter("ignore", CryptographyDeprecationWarning)
         param_nums = dh.DHParameterNumbers(p=p, g=generator)
         server_public = dh.DHPublicNumbers(sk, param_nums).public_key()

--- a/vncdotool/security/ard.py
+++ b/vncdotool/security/ard.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import warnings
+from struct import unpack
+from typing import Any, Generator
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import dh
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.utils import CryptographyDeprecationWarning
+
+from ..const import AuthTypes
+from .base import SecurityHandler, security_result
+
+
+class DiffieHellmanHandler(SecurityHandler):
+    SECURITY_TYPE = AuthTypes.DIFFIE_HELLMAN
+
+    def handle(self, client: Any) -> Generator[int, bytes, bool]:
+        # rfbproto, Diffie-Hellman Authentication: a U16 generator and a U16
+        # key size, then the prime modulus and the server's public value, each
+        # key-size bytes.
+        generator, key_len = unpack("!HH", (yield 4))
+        modulus = yield key_len
+        server_key = yield key_len
+
+        client.ardRequestCredentials()
+
+        client.transport.write(
+            _encrypt(client, generator, key_len, modulus, server_key)
+        )
+        return (yield from security_result(client))
+
+
+def _encrypt(
+    client: Any, generator: int, key_len: int, modulus: bytes, server_key: bytes
+) -> bytes:
+    userStruct = f"{client.factory.username:\0<64}{client.factory.password:\0<64}"
+
+    p = int.from_bytes(modulus, "big")
+    sk = int.from_bytes(server_key, "big")
+    with warnings.catch_warnings():
+        # ARD auth is specified over classic finite-field DH; the server
+        # picks p/g and there is no other algorithm to negotiate into.
+        # Tracking upstream removal: https://github.com/sibson/vncdotool/issues/388
+        warnings.simplefilter("ignore", CryptographyDeprecationWarning)
+        param_nums = dh.DHParameterNumbers(p=p, g=generator)
+        server_public = dh.DHPublicNumbers(sk, param_nums).public_key()
+
+    params = param_nums.parameters()
+    private_key = params.generate_private_key()
+    shared_key = private_key.exchange(server_public)
+
+    h = hashes.Hash(hashes.MD5())
+    h.update(shared_key)
+    key_digest = h.finalize()
+
+    cipher = Cipher(algorithms.AES(key_digest), modes.ECB())
+    encryptor = cipher.encryptor()
+    ciphertext = encryptor.update(userStruct.encode("utf-8"))
+    ciphertext += encryptor.finalize()
+
+    public_key = private_key.public_key()
+    y = public_key.public_numbers().y.to_bytes(key_len, "big")
+
+    return ciphertext + y

--- a/vncdotool/security/base.py
+++ b/vncdotool/security/base.py
@@ -1,0 +1,46 @@
+"""specs/security-handler-architecture.md is the design."""
+from __future__ import annotations
+
+from struct import unpack
+from typing import Any, ClassVar, Generator
+
+from twisted.python import log
+
+from ..const import AuthTypes
+
+
+class SecurityHandler:
+    """One RFB security type: RFC 6143 section 7.2."""
+
+    SECURITY_TYPE: ClassVar[AuthTypes]
+
+    def handle(self, client: Any) -> Generator[int, bytes, bool]:
+        """Yield the byte counts this security type needs, each satisfied in
+        full, and return whether the connection proceeds to initialisation.
+        The security type is already settled: written by the client on 3.7+,
+        dictated by the server on 3.3.
+        """
+        raise NotImplementedError
+
+
+def security_result(client: Any) -> Generator[int, bytes, bool]:
+    """RFC 6143 section 7.1.3, and the reason string 3.8 adds on failure."""
+    (result,) = unpack("!I", (yield 4))
+    if result == 0:  # OK
+        return True
+    elif result == 1:  # failed
+        reason = "authentication failed"
+    elif result == 2:  # too many
+        reason = "too many tries to log in"
+    else:
+        log.msg(f"unknown auth response ({result})")
+        client.transport.loseConnection()
+        return False
+
+    if client._version < (3, 8):
+        client.vncAuthFailed(reason)
+    else:
+        (waitfor,) = unpack("!I", (yield 4))
+        client.vncAuthFailed((yield waitfor))
+    client.transport.loseConnection()
+    return False

--- a/vncdotool/security/errors.py
+++ b/vncdotool/security/errors.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+class SecurityError(Exception):
+    """A security type could not be carried out as the protocol describes."""

--- a/vncdotool/security/none.py
+++ b/vncdotool/security/none.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Any, Generator
+
+from ..const import AuthTypes
+from .base import SecurityHandler, security_result
+
+
+class NoneHandler(SecurityHandler):
+    SECURITY_TYPE = AuthTypes.NONE
+
+    def handle(self, client: Any) -> Generator[int, bytes, bool]:
+        # rfbproto, security type None: 3.3 and 3.7 pass straight to
+        # initialisation; only from 3.8 does a SecurityResult follow.
+        if client._version < (3, 8):
+            return True
+        return (yield from security_result(client))

--- a/vncdotool/security/vncauth.py
+++ b/vncdotool/security/vncauth.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any, Generator
+
+from ..const import AuthTypes
+from .base import SecurityHandler, security_result
+
+
+class VNCAuthenticationHandler(SecurityHandler):
+    SECURITY_TYPE = AuthTypes.VNC_AUTHENTICATION
+
+    def handle(self, client: Any) -> Generator[int, bytes, bool]:
+        # RFC 6143 section 7.2.2: a 16-byte challenge, and the response goes
+        # back whenever sendPassword runs, which a subclass may leave until
+        # long after vncRequestPassword returns.
+        client._challenge = yield 16
+        client.vncRequestPassword()
+        return (yield from security_result(client))


### PR DESCRIPTION
`vncdotool/security/` mirrors `messages/`: one generator handler per RFB
security type, driven by the existing `_pump`. None, VNC Authentication and ARD
Diffie-Hellman move over; `rfb.py` loses 111 lines and the handler state it was
keeping on the client. Design in `specs/security-handler-architecture.md`.

Two things the diff won't tell you. `handle()` returns `bool` where
`MessageHandler` returns `None` — the old failure signal was *not* calling
`_doClientInitialization`, which `None` cannot carry. `_challenge` stays on the
client because `sendPassword` is published and may be called out of band, after
the handler's locals are gone.

RFB 3.3 now dispatches through the registry, so it accepts ARD where it did
not. Unreachable in practice: ARD servers announce 3.889 and negotiate to 3.8.

725 unit tests (+18, no existing test edited), flake8 0, mypy 72 against main's
74. The functional suite gave identical results on both branches. No CHANGELOG
entry — internal refactor, nothing user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
