### PR TITLE
Tag the fleet by the tree docker actually builds

### DIFF
--- a/specs/server-compatibility-plan.md
+++ b/specs/server-compatibility-plan.md
@@ -397,7 +397,7 @@ Tier 1 follow-ups:
   the workflow post/update a PR comment with `raw.githubusercontent.com`
   image links, so they render inline where review happens.
 - **Image build tax: done.** The `servers` job in `ci.yml` pulls the fleet
-  from GHCR, tagged with the `tests/servers` tree hash, instead of
+  from GHCR, tagged by `tests/servers/fleet-tag.sh`, instead of
   rebuilding it. A miss falls back to building, so a PR that edits the
   fleet (and any fork PR) behaves as it did before the registry existed,
   and a `main` push that built publishes what it built once the suite is

--- a/specs/testing-framework.md
+++ b/specs/testing-framework.md
@@ -62,11 +62,16 @@ committed files (the scene PNGs, `scene_player.py`, the entrypoints) into
 its images. So a checkout that never ran `make servers-up` tests against
 whichever checkout did, reading that checkout's baked files back off the
 wire as if they were its own. `tests/servers/fleet-tag.sh` hashes the
-Dockerfile's COPY inputs; `servers.mk` tags the images with it, and
-`fleet_mismatch()` in `tests/functional/utils.py` reads the tag back off
-the running container, so the mismatch fails by name in `servers-up` and in
-the tests that depend on baked content. The hash is of `HEAD`, so a fleet
-built from uncommitted edits to those files tags as the commit it sits on.
+Dockerfile's COPY inputs, plus the Dockerfile and `docker-compose.yml`
+themselves; `servers.mk` tags the images with it, and `fleet_mismatch()` in
+`tests/functional/utils.py` reads the tag back off the running container, so
+the mismatch fails by name in `servers-up` and in the tests that depend on
+baked content.
+
+The hash is of the working tree, because that is what `docker compose build`
+bakes. Identical content hashes identically whether committed or not, which
+CI relies on: `FLEET_TAG` is also the GHCR pull key that decides whether a
+fleet is fetched or rebuilt.
 
 **Execution model**: every fleet scenario runs the real command-line tool via
 `subprocess.run(["vncdo", ...], timeout=N)`.

--- a/tests/functional/test_scene_player.py
+++ b/tests/functional/test_scene_player.py
@@ -13,10 +13,13 @@ from .utils import TIGERVNC, assert_fleet_current, port_open, HOST, run_vncdo
 
 
 class TestScenePlayer(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        assert_fleet_current(TIGERVNC)
+
     def setUp(self) -> None:
         if not port_open(HOST, TIGERVNC.port):
             self.fail(f"{TIGERVNC.name} is not listening on {TIGERVNC.port}; {TIGERVNC.how_to_start}")
-        assert_fleet_current(self, TIGERVNC)
 
     def _capture(self, *args: str) -> Image.Image:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -325,10 +325,10 @@ def fleet_mismatch(server: VNCServer) -> Optional[str]:
     )
 
 
-def assert_fleet_current(test: TestCase, server: VNCServer) -> None:
+def assert_fleet_current(server: VNCServer) -> None:
     mismatch = fleet_mismatch(server)
     if mismatch is not None:
-        test.fail(mismatch)
+        raise AssertionError(mismatch)
 
 
 def screenshot_dir() -> Path:

--- a/tests/servers/fleet-tag.sh
+++ b/tests/servers/fleet-tag.sh
@@ -3,9 +3,10 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+paths=(servers/Dockerfile servers/docker-compose.yml)
+
 # A `COPY --from=` source is a path inside that build stage, not in this
 # tree; a leading `--chown=`/`--chmod=` is a flag, not a source.
-paths=(servers)
 while IFS= read -r path; do
     paths+=("$path")
 done < <(
@@ -15,5 +16,14 @@ done < <(
          }' servers/Dockerfile | sed 's:/*$::' | sort -u
 )
 
-revs=$(git rev-parse "${paths[@]/#/HEAD:./}")
+# A fresh directory, not a mktemp file: git rejects an existing empty file as
+# a truncated index.
+index_dir=$(mktemp -d)
+trap 'rm -rf "$index_dir"' EXIT
+export GIT_INDEX_FILE="$index_dir/index"
+
+git add --all -- "${paths[@]}"
+tree=$(git write-tree)
+
+revs=$(git rev-parse "${paths[@]/#/$tree:./}")
 printf '%s\n' "$revs" | git hash-object --stdin

--- a/tests/unit/test_fleet_tag.py
+++ b/tests/unit/test_fleet_tag.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+FLEET_TAG_SCRIPT = REPO / "tests" / "servers" / "fleet-tag.sh"
+
+# The `--from=` line names a path inside that stage, which does not exist in
+# the fixture tree: every run here fails if the script tries to hash it.
+DOCKERFILE = """\
+FROM debian:bookworm-slim AS base
+COPY servers/entrypoint.sh /entrypoint.sh
+COPY goldens/scenes/ /tests/goldens/scenes/
+COPY --from=base /usr/bin/true /usr/local/bin/true
+"""
+
+COMPOSE = """\
+services:
+  tigervnc:
+    build:
+      context: ..
+      dockerfile: servers/Dockerfile
+      target: base
+"""
+
+FIXTURE_FILES = {
+    "tests/servers/Dockerfile": DOCKERFILE,
+    "tests/servers/docker-compose.yml": COMPOSE,
+    "tests/servers/entrypoint.sh": "#!/bin/sh\nexec sleep infinity\n",
+    "tests/servers/PORTS.md": "| service | port |\n| ------- | ---- |\n",
+    "tests/goldens/scenes/scene.txt": "a scene\n",
+}
+
+# A GIT_DIR or GIT_INDEX_FILE inherited from the runner would point the
+# script at another repository entirely.
+CLEAN_ENV = {name: value for name, value in os.environ.items() if not name.startswith("GIT_")}
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, env=CLEAN_ENV, capture_output=True, text=True, check=True
+    )
+    return result.stdout
+
+
+def run_script(repo: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(repo / "tests" / "servers" / "fleet-tag.sh")],
+        cwd=repo, env=CLEAN_ENV, capture_output=True, text=True,
+    )
+
+
+class FleetTagTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.repo = Path(tmp.name)
+
+        for name, content in FIXTURE_FILES.items():
+            path = self.repo / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content)
+        shutil.copy2(FLEET_TAG_SCRIPT, self.repo / "tests" / "servers" / "fleet-tag.sh")
+
+        git(self.repo, "-c", "init.defaultBranch=main", "init", "-q")
+        git(self.repo, "config", "user.email", "fleet@example.invalid")
+        git(self.repo, "config", "user.name", "Fleet Fixture")
+        self.commit()
+
+    def commit(self, message: str = "fixture") -> None:
+        git(self.repo, "add", "--all")
+        git(self.repo, "commit", "-q", "-m", message)
+
+    def tag(self) -> str:
+        result = run_script(self.repo)
+        self.assertEqual(result.returncode, 0, f"fleet-tag.sh failed:\n{result.stderr}")
+        return result.stdout.strip()
+
+    def write(self, name: str, content: str) -> None:
+        (self.repo / name).write_text(content)
+
+    def test_a_clean_tree_tags_the_same_way_twice(self) -> None:
+        self.assertEqual(self.tag(), self.tag())
+
+    def test_an_uncommitted_edit_to_a_copy_source_changes_the_tag(self) -> None:
+        before = self.tag()
+
+        self.write("tests/servers/entrypoint.sh", "#!/bin/sh\nexec sleep 1\n")
+
+        self.assertNotEqual(before, self.tag())
+
+    def test_reverting_an_uncommitted_edit_restores_the_tag(self) -> None:
+        before = self.tag()
+        original = (self.repo / "tests" / "servers" / "entrypoint.sh").read_text()
+
+        self.write("tests/servers/entrypoint.sh", "#!/bin/sh\nexec sleep 1\n")
+        self.write("tests/servers/entrypoint.sh", original)
+
+        self.assertEqual(before, self.tag())
+
+    def test_committing_an_edit_does_not_change_its_tag(self) -> None:
+        self.write("tests/servers/entrypoint.sh", "#!/bin/sh\nexec sleep 1\n")
+        built_from = self.tag()
+
+        self.commit("edit the entrypoint")
+
+        self.assertEqual(built_from, self.tag())
+
+    def test_an_untracked_copy_source_changes_the_tag(self) -> None:
+        before = self.tag()
+
+        self.write("tests/goldens/scenes/added.txt", "another scene\n")
+
+        self.assertNotEqual(before, self.tag())
+
+    def test_a_gitignored_file_under_a_copy_source_does_not_change_the_tag(self) -> None:
+        self.write(".gitignore", "tests/goldens/scenes/*.png\n")
+        self.commit("ignore generated scenes")
+        before = self.tag()
+
+        self.write("tests/goldens/scenes/generated.png", "not really a png\n")
+
+        self.assertEqual(before, self.tag())
+
+    def test_committing_documentation_does_not_change_the_tag(self) -> None:
+        before = self.tag()
+
+        self.write("tests/servers/PORTS.md", "| service | port |\n| ------- | ---- |\n| a | 1 |\n")
+        self.commit("document a port")
+
+        self.assertEqual(before, self.tag())
+
+    def test_editing_the_dockerfile_changes_the_tag(self) -> None:
+        before = self.tag()
+
+        self.write("tests/servers/Dockerfile", DOCKERFILE + "ENV PROBE=1\n")
+
+        self.assertNotEqual(before, self.tag())
+
+    def test_editing_the_compose_file_changes_the_tag(self) -> None:
+        before = self.tag()
+
+        self.write("tests/servers/docker-compose.yml", COMPOSE.replace("target: base", "target: other"))
+
+        self.assertNotEqual(before, self.tag())
+
+    def test_the_repositorys_own_index_is_left_alone(self) -> None:
+        self.write("tests/servers/entrypoint.sh", "#!/bin/sh\nexec sleep 1\n")
+        git(self.repo, "add", "tests/servers/entrypoint.sh")
+        staged = git(self.repo, "diff", "--cached", "--name-only")
+
+        self.tag()
+
+        self.assertEqual(staged, git(self.repo, "diff", "--cached", "--name-only"))
+
+    def test_a_tree_without_a_git_store_fails(self) -> None:
+        shutil.rmtree(self.repo / ".git")
+
+        self.assertNotEqual(run_script(self.repo).returncode, 0)
+
+
+class RepositoryDockerfileTests(unittest.TestCase):
+    def test_the_checked_in_dockerfile_yields_a_tag(self) -> None:
+        """Every COPY form the real Dockerfile uses is one the awk can read."""
+        result = run_script(REPO)
+
+        self.assertEqual(result.returncode, 0, f"fleet-tag.sh failed:\n{result.stderr}")
+        self.assertRegex(result.stdout.strip(), r"^[0-9a-f]{40}$")


### PR DESCRIPTION
`FLEET_TAG` hashed `HEAD` while `docker compose up --build` bakes the working tree, so committing an edit already built into the fleet made every checkout report that fleet stale — and an uncommitted edit left the tag alone, so the check called a fleet current whatever the image had become. The tag now hashes a temporary index, naming the working tree without touching the repository's index or the worktree-shared stash stack. Identical content still hashes identically committed or not, which CI needs: `FLEET_TAG` is also the GHCR pull key.

The path set narrows to the Dockerfile, the compose file and the parsed `COPY` sources, so editing `PORTS.md` no longer invalidates the fleet.

Verified against the real fleet: built dirty, committed, no mismatch; then reverted without rebuilding and the check reported stale.

`libvncserver-example` capture-size flake seen once, clean on rerun — pre-existing, not this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
