### PR TITLE
Establish libvncserver-example's size instead of assuming it

### DIFF
--- a/tests/functional/test_desktop_resize.py
+++ b/tests/functional/test_desktop_resize.py
@@ -7,7 +7,7 @@ from .utils import (
     LIBVNCSERVER_EXAMPLE,
     distinct_colours,
     has_expected_content,
-    normalize_framebuffer,
+    normalize_size,
     port_open,
     run_vncdo,
     screenshot_dir,
@@ -25,9 +25,7 @@ class TestDesktopResize(TestCase):
                 f"{LIBVNCSERVER_EXAMPLE.name} not reachable on {HOST}:{LIBVNCSERVER_EXAMPLE.port} -- "
                 f"{LIBVNCSERVER_EXAMPLE.how_to_start}"
             )
-        # The size this test leaves behind is the size every later client of
-        # the fleet gets, including another checkout's run.
-        self.addCleanup(normalize_framebuffer, LIBVNCSERVER_EXAMPLE)
+        self.addCleanup(normalize_size, LIBVNCSERVER_EXAMPLE)
 
     def test_mid_session_resize_is_decoded(self) -> None:
         """Each capture's size reflects the server's actual PSEUDO_DESKTOP_SIZE

--- a/tests/functional/test_desktop_resize.py
+++ b/tests/functional/test_desktop_resize.py
@@ -2,7 +2,16 @@ from unittest import TestCase
 
 from PIL import Image
 
-from .utils import HOST, LIBVNCSERVER_EXAMPLE, distinct_colours, has_expected_content, port_open, run_vncdo, screenshot_dir
+from .utils import (
+    HOST,
+    LIBVNCSERVER_EXAMPLE,
+    distinct_colours,
+    has_expected_content,
+    normalize_framebuffer,
+    port_open,
+    run_vncdo,
+    screenshot_dir,
+)
 
 FLOOR_SIZE = (640, 480)
 RESIZED_SIZE = (800, 600)
@@ -16,6 +25,9 @@ class TestDesktopResize(TestCase):
                 f"{LIBVNCSERVER_EXAMPLE.name} not reachable on {HOST}:{LIBVNCSERVER_EXAMPLE.port} -- "
                 f"{LIBVNCSERVER_EXAMPLE.how_to_start}"
             )
+        # The size this test leaves behind is the size every later client of
+        # the fleet gets, including another checkout's run.
+        self.addCleanup(normalize_framebuffer, LIBVNCSERVER_EXAMPLE)
 
     def test_mid_session_resize_is_decoded(self) -> None:
         """Each capture's size reflects the server's actual PSEUDO_DESKTOP_SIZE

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -92,6 +92,10 @@ class VNCServer(NamedTuple):
     how_to_start: str = "start the servers first with `make servers-up`"
     # Honoured only off CI -- see absent_server_skips().
     skip_when_down: bool = False
+    # Keys that drive a server whose framebuffer size any client can change
+    # back to `size`, pressed before the readiness capture and after a test
+    # that resizes it.
+    normalize_keys: Tuple[str, ...] = ()
 
 
 # One constant per service in tests/servers/docker-compose.yml, named so a
@@ -122,8 +126,15 @@ WAYVNC = VNCServer(
 WAYVNC_CA_CERT = (
     Path(__file__).resolve().parents[1] / "servers" / "wayvnc-certs" / "cert.pem"
 )
-# 800x600 is the demo's hard-coded size; it takes no -geometry option.
-LIBVNCSERVER_EXAMPLE = VNCServer("libvncserver-example", 5935, size=(800, 600))
+# 800x600 is the size the demo starts at; it takes no -geometry option. Any
+# client can change it though: XK_Up and XK_Down step the whole server's
+# framebuffer through 640x480, 800x600 and 1024x768, clamped at both ends,
+# and it stays there for every later client. Two Ups then a Down therefore
+# land on 800x600 whatever the last client left behind.
+LIBVNCSERVER_EXAMPLE = VNCServer(
+    "libvncserver-example", 5935, size=(800, 600),
+    normalize_keys=("up", "up", "down"),
+)
 
 DOCKER_SERVERS = [TIGERVNC, TIGERVNC_AUTH, X11VNC, LIBVNCSERVER_EXAMPLE]
 
@@ -382,6 +393,22 @@ def has_expected_content(server: VNCServer, colours: Optional[int]) -> bool:
     return colours != 1
 
 
+def normalize_framebuffer(server: VNCServer) -> None:
+    """Put a server whose size a client can change back to ``server.size``.
+
+    A no-op for every server that serves one fixed size.
+    """
+    if not server.normalize_keys:
+        return
+    argv = [arg for key in server.normalize_keys for arg in ("key", key)]
+    result = run_vncdo(server, *argv)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"{server.name}: `vncdo {' '.join(argv)}` exited {result.returncode}, "
+            f"stderr:\n{result.stderr}"
+        )
+
+
 def wait_until_ready(
     server: VNCServer,
     deadline_seconds: float = READY_DEADLINE,
@@ -402,17 +429,23 @@ def wait_until_ready(
             time.sleep(RETRY_DELAY)
             continue
         try:
+            normalize_framebuffer(server)
             with tempfile.TemporaryDirectory() as tmp:
                 probe = Path(tmp) / f"{server.name}-ready.png"
                 capture_screenshot(server, probe, timeout=attempt_timeout)
                 with Image.open(probe) as image:
                     colours = distinct_colours(image)
+                    size = image.size
         except Exception as exc:  # noqa: BLE001 - any failure means try again
             print(f"{server.name}: not ready yet (attempt {attempt}: {exc})")
             time.sleep(RETRY_DELAY)
             continue
         if not has_expected_content(server, colours):
             print(f"{server.name}: not ready yet (attempt {attempt}: capture is flat)")
+            time.sleep(RETRY_DELAY)
+            continue
+        if server.size is not None and size != server.size:
+            print(f"{server.name}: not ready yet (attempt {attempt}: serving {size}, expected {server.size})")
             time.sleep(RETRY_DELAY)
             continue
         print(f"{server.name}: ready after {attempt} attempt(s)")

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -92,10 +92,7 @@ class VNCServer(NamedTuple):
     how_to_start: str = "start the servers first with `make servers-up`"
     # Honoured only off CI -- see absent_server_skips().
     skip_when_down: bool = False
-    # Keys that drive a server whose framebuffer size any client can change
-    # back to `size`, pressed before the readiness capture and after a test
-    # that resizes it.
-    normalize_keys: Tuple[str, ...] = ()
+    normalize_size_keys: Tuple[str, ...] = ()
 
 
 # One constant per service in tests/servers/docker-compose.yml, named so a
@@ -126,14 +123,11 @@ WAYVNC = VNCServer(
 WAYVNC_CA_CERT = (
     Path(__file__).resolve().parents[1] / "servers" / "wayvnc-certs" / "cert.pem"
 )
-# 800x600 is the size the demo starts at; it takes no -geometry option. Any
-# client can change it though: XK_Up and XK_Down step the whole server's
-# framebuffer through 640x480, 800x600 and 1024x768, clamped at both ends,
-# and it stays there for every later client. Two Ups then a Down therefore
-# land on 800x600 whatever the last client left behind.
+# 800x600 is the size the demo starts at; it takes no -geometry option, and
+# any client's arrow keys resize it for every later client.
 LIBVNCSERVER_EXAMPLE = VNCServer(
     "libvncserver-example", 5935, size=(800, 600),
-    normalize_keys=("up", "up", "down"),
+    normalize_size_keys=("up", "up", "down"),
 )
 
 DOCKER_SERVERS = [TIGERVNC, TIGERVNC_AUTH, X11VNC, LIBVNCSERVER_EXAMPLE]
@@ -393,14 +387,11 @@ def has_expected_content(server: VNCServer, colours: Optional[int]) -> bool:
     return colours != 1
 
 
-def normalize_framebuffer(server: VNCServer) -> None:
-    """Put a server whose size a client can change back to ``server.size``.
-
-    A no-op for every server that serves one fixed size.
-    """
-    if not server.normalize_keys:
+def normalize_size(server: VNCServer) -> None:
+    """Put a server whose size a client can change back to ``server.size``."""
+    if not server.normalize_size_keys:
         return
-    argv = [arg for key in server.normalize_keys for arg in ("key", key)]
+    argv = [arg for key in server.normalize_size_keys for arg in ("key", key)]
     result = run_vncdo(server, *argv)
     if result.returncode != 0:
         raise RuntimeError(
@@ -429,7 +420,7 @@ def wait_until_ready(
             time.sleep(RETRY_DELAY)
             continue
         try:
-            normalize_framebuffer(server)
+            normalize_size(server)
             with tempfile.TemporaryDirectory() as tmp:
                 probe = Path(tmp) / f"{server.name}-ready.png"
                 capture_screenshot(server, probe, timeout=attempt_timeout)


### PR DESCRIPTION
`TestServer_libvncserver_example.test_capture` was flaky, once capturing 640x480 where 800x600 was declared. The demo's framebuffer size is process-global state any client can change: XK_Up/XK_Down call `rfbNewFramebuffer` on the whole `rfbScreen`, and the new size outlives the client that asked for it, so a fresh connection gets whatever the last one left. Confirmed against a throwaway container — two Downs, disconnect, reconnect, still 640x480.

The readiness gate now drives the size it is about to assert (up, up, down clamps to 800x600 from any state) and then checks the capture against the declared size, so a fleet that cannot serve what the tests expect fails at `servers-up`. `test_desktop_resize` restores the same way via `addCleanup`.

Two suites running against the fleet at once can still race; nothing short of a per-run server fixes that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
