### PR TITLE
Stop every grid case on a fleet another checkout started

### DIFF
--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -343,16 +343,30 @@ def running_fleet_tag(server: VNCServer) -> Optional[str]:
     return tag or None
 
 
+_FLEET_MISMATCHES: Dict[str, Optional[str]] = {}
+
+
 def fleet_mismatch(server: VNCServer) -> Optional[str]:
-    """Why `server` is not this checkout's fleet, or None if it is or may be."""
+    """Why `server` is not this checkout's fleet, or None if it is or may be.
+
+    Answered once per server and remembered: a grid of a hundred cases asks
+    the same question a hundred times, and each answer costs two
+    subprocesses.
+    """
+    if server.name in _FLEET_MISMATCHES:
+        return _FLEET_MISMATCHES[server.name]
+
     expected, running = fleet_tag(), running_fleet_tag(server)
     if expected is None or running is None or expected == running:
-        return None
-    return (
-        f"{server.name} is running image tag {running!r}, but this checkout's server sources "
-        f"hash to {expected!r}: the fleet was started from a different checkout and serves "
-        f"that checkout's files. Run `make servers-down && make servers-up`."
-    )
+        mismatch = None
+    else:
+        mismatch = (
+            f"{server.name} is running image tag {running!r}, but this checkout's server sources "
+            f"hash to {expected!r}: the fleet was started from a different checkout and serves "
+            f"that checkout's files. Run `make servers-down && make servers-up`."
+        )
+    _FLEET_MISMATCHES[server.name] = mismatch
+    return mismatch
 
 
 def assert_fleet_current(server: VNCServer) -> None:
@@ -411,6 +425,10 @@ class FleetTestCase(TestCase):
     """Base for a grid that runs one body against several fleet servers."""
 
     server: VNCServer
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        assert_fleet_current(cls.server)
 
     def setUp(self) -> None:
         if not server_is_up(self.server):


### PR DESCRIPTION
The compose project name is global while the cert and scene mounts are relative to the compose file, so the first worktree to run `make servers-up` owns the fleet and every other worktree's `make test-func` silently drives that worktree's containers, certificates and scene PNGs. `fleet_mismatch()` already diagnoses this precisely, but only `test_scene_player` asked it, and `make test-func` is a bare `unittest discover` that never runs `wait_for_servers.py`.

Asking from `FleetTestCase.setUpClass` puts the real message on all 119 grid classes; the answer is cached per server so the grid doesn't spend two subprocesses per class re-deriving one tree hash.

Found while investigating 43 failures on a clean `origin/main` that turned out to be 39 stale-fleet plus 4 unrelated. Rebuilding the fleet took those 39 to zero; faking the checkout tag then confirmed all 119 classes error with the cause rather than running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
