### PR TITLE
Tell the distiller which JPEG quality level the capture asked for

### DIFF
--- a/specs/decoder-goldens.md
+++ b/specs/decoder-goldens.md
@@ -121,14 +121,13 @@ guess at how long that takes and, when wrong, a fixture labelled by the
 previous image's patch. A scene that never arrives now fails the capture
 naming the image it waited for.
 
-It compares per pixel, the perceived difference of
-[expect-matching.md](expect-matching.md), and every pixel has to be within the
-fuzz. That is enough to sequence on; the authoritative comparison against the
-same file is the golden test's.
+It sequences on the same per-pixel match as any `expect`
+([expect-matching.md](expect-matching.md)); the authoritative comparison
+against the same file is the golden test's.
 
-The fuzz is not written down in `scene.vdo`. `client.py` derives it from the
-negotiated format, so a capture tolerates that format's quantization and
-nothing beyond it: 0 at 32bpp, which is exact equality, and 8 at rgb565.
+`scene.vdo` names no fuzz, so the capture runs at the default the negotiated
+pixel format derives and tolerates that format's quantization, nothing beyond
+it.
 
 ## Capture
 
@@ -153,13 +152,10 @@ Auth stripping is irrelevant here: golden capture targets no-auth servers.
 a `NullTransport`, recording each FramebufferUpdate's raw bytes and the
 encoding actually used. It adds no wire parser and starts no reactor.
 
-The replay client is told the pixel format *and* the JPEG quality level the
-capture asked for. Both are client-to-server, so `s2c.bin` says neither, and a
-client that offered no quality level refuses the very Tight JPEG rectangles the
-capture requested. A stream that stops decoding raises rather than returning
-the steps it managed: the refusal ends the connection quietly, and without that
-check a lossy capture writes a fixture short by everything after the server's
-first JPEG rectangle and reports it as a success.
+The replay client is configured from what the capturing client asked for, its
+pixel format and its JPEG quality level, because `s2c.bin` carries neither. A
+stream that stops decoding fails the capture rather than writing the steps it
+managed, so a fixture cut short by a decoder's refusal never reaches the tree.
 
 Steps are cut where the keysym patch changes, not on FramebufferUpdate
 framing: a driver polling for a scene draws empty updates in reply, and a

--- a/specs/decoder-goldens.md
+++ b/specs/decoder-goldens.md
@@ -154,6 +154,14 @@ Auth stripping is irrelevant here: golden capture targets no-auth servers.
 a `NullTransport`, recording each FramebufferUpdate's raw bytes and the
 encoding actually used. It adds no wire parser and starts no reactor.
 
+The replay client is told the pixel format *and* the JPEG quality level the
+capture asked for. Both are client-to-server, so `s2c.bin` says neither, and a
+client that offered no quality level refuses the very Tight JPEG rectangles the
+capture requested. A stream that stops decoding raises rather than returning
+the steps it managed: the refusal ends the connection quietly, and without that
+check a lossy capture writes a fixture short by everything after the server's
+first JPEG rectangle and reports it as a success.
+
 Steps are cut where the keysym patch changes, not on FramebufferUpdate
 framing: a driver polling for a scene draws empty updates in reply, and a
 server may spread one scene over several. Every byte between two patches still

--- a/specs/decoder-goldens.md
+++ b/specs/decoder-goldens.md
@@ -121,15 +121,14 @@ guess at how long that takes and, when wrong, a fixture labelled by the
 previous image's patch. A scene that never arrives now fails the capture
 naming the image it waited for.
 
-It compares histograms rather than pixels, which is enough to sequence on; the
-pixel-exact comparison is the golden test's job, against the same file.
+It compares per pixel, the perceived difference of
+[expect-matching.md](expect-matching.md), and every pixel has to be within the
+fuzz. That is enough to sequence on; the authoritative comparison against the
+same file is the golden test's.
 
-At a reduced depth that histogram can never equal the scene PNG's, so `expect`
-also matches when every pixel is within the negotiated format's per-channel
-tolerance. `client.py` reads the tolerance off `self.pixel_format`, so nothing
-is written down in `scene.vdo` and every `expect` in the wild gains the same
-fix: at 8 bits per channel the tolerance is zero and the new condition is
-exact equality, which the old one already implied.
+The fuzz is not written down in `scene.vdo`. `client.py` derives it from the
+negotiated format, so a capture tolerates that format's quantization and
+nothing beyond it: 0 at 32bpp, which is exact equality, and 8 at rgb565.
 
 ## Capture
 

--- a/tests/goldens/capture.py
+++ b/tests/goldens/capture.py
@@ -134,7 +134,7 @@ def main() -> int:
             s2c = zipped.read("s2c.bin")
             meta = zipped.read("meta.json").decode()
 
-        init, steps = distill.split(s2c, args.pixel_format)
+        init, steps = distill.split(s2c, args.pixel_format, args.jpeg_quality)
         if not steps:
             raise SystemExit("capture holds no framebuffer updates; the stream desynced")
         for step in steps:

--- a/tests/goldens/distill.py
+++ b/tests/goldens/distill.py
@@ -49,8 +49,6 @@ class _Recorder(client.VNCDoToolClient):
         self.init_end = self.consumed
 
     def vncProtocolError(self, reason: str) -> None:
-        # The error reaches a mocked factory and goes nowhere, so it is kept
-        # here for `split` to raise on.
         self.abort_reason = reason
         super().vncProtocolError(reason)
 
@@ -97,11 +95,10 @@ class _Recorder(client.VNCDoToolClient):
 
 def _make_client(pixel_format: str, jpeg_quality: Optional[int] = None) -> _Recorder:
     """SetPixelFormat and SetEncodings are client-to-server (RFC 6143 sections
-    7.5.1 and 7.5.2), so the s2c stream being replayed never says the server
-    switched layouts, nor which encodings were asked for. The recorder has to
-    be told both: otherwise it unpacks the bytes as ServerInit announced them
-    and permutes every channel, and it refuses the JPEG rectangles the capture
-    itself requested.
+    7.5.1 and 7.5.2), so a replay of s2c alone is told neither the layout the
+    server switched to nor the encodings that were asked for. Without the
+    format the recorder permutes every channel. Without the quality level it
+    refuses the capture's own JPEG rectangles.
     """
     recorder = _Recorder()
     recorder.requested_pixel_format = pixelformat.PIXEL_FORMATS[pixel_format]

--- a/tests/goldens/distill.py
+++ b/tests/goldens/distill.py
@@ -42,10 +42,17 @@ class _Recorder(client.VNCDoToolClient):
         self.update_ends: List[int] = []
         self.init_end: Optional[int] = None
         self.consumed = 0
+        self.abort_reason: Optional[str] = None
 
     def vncConnectionMade(self) -> None:
         super().vncConnectionMade()
         self.init_end = self.consumed
+
+    def vncProtocolError(self, reason: str) -> None:
+        # The error reaches a mocked factory and goes nowhere, so it is kept
+        # here for `split` to raise on.
+        self.abort_reason = reason
+        super().vncProtocolError(reason)
 
     def commitUpdate(self, rectangles: Optional[list] = None) -> None:
         super().commitUpdate(rectangles)
@@ -58,6 +65,12 @@ class _Recorder(client.VNCDoToolClient):
             self.dataReceived(s2c[offset:offset + 1])
             if len(self.update_ends) > len(screens):
                 screens.append(self.screen.copy() if self.screen else None)
+
+        if self.abort_reason is not None:
+            raise ValueError(
+                f"the recorded stream stopped decoding after {len(self.update_ends)} "
+                f"updates: {self.abort_reason}"
+            )
 
         if self.init_end is None:
             raise ValueError("stream carries no ServerInit; it is not a whole recorded session")
@@ -82,14 +95,17 @@ class _Recorder(client.VNCDoToolClient):
         return s2c[: self.init_end], steps
 
 
-def _make_client(pixel_format: str) -> _Recorder:
-    """SetPixelFormat is client-to-server (RFC 6143 section 7.5.1), so the s2c
-    stream being replayed never says the server switched layouts. The recorder
-    has to be told, or it unpacks the bytes as ServerInit announced them and
-    permutes every channel.
+def _make_client(pixel_format: str, jpeg_quality: Optional[int] = None) -> _Recorder:
+    """SetPixelFormat and SetEncodings are client-to-server (RFC 6143 sections
+    7.5.1 and 7.5.2), so the s2c stream being replayed never says the server
+    switched layouts, nor which encodings were asked for. The recorder has to
+    be told both: otherwise it unpacks the bytes as ServerInit announced them
+    and permutes every channel, and it refuses the JPEG rectangles the capture
+    itself requested.
     """
     recorder = _Recorder()
     recorder.requested_pixel_format = pixelformat.PIXEL_FORMATS[pixel_format]
+    recorder.requested_jpeg_quality = jpeg_quality
     recorder.transport = mock.Mock()
     recorder.factory = mock.Mock()
     recorder.factory.shared = 0
@@ -102,8 +118,10 @@ def _make_client(pixel_format: str) -> _Recorder:
     return recorder
 
 
-def split(s2c: bytes, pixel_format: str) -> Tuple[bytes, List[Step]]:
-    return _make_client(pixel_format).split(s2c)
+def split(
+    s2c: bytes, pixel_format: str, jpeg_quality: Optional[int] = None
+) -> Tuple[bytes, List[Step]]:
+    return _make_client(pixel_format, jpeg_quality).split(s2c)
 
 
 _NUMBER_ARRAY = re.compile(r"\[\s+((?:-?\d+,\s+)*-?\d+)\s+\]")

--- a/tests/unit/test_distill.py
+++ b/tests/unit/test_distill.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import gzip
+import io
 import json
 import tempfile
 import unittest
@@ -13,6 +14,7 @@ from PIL import Image
 from tests.goldens import distill, scenes
 from vncdotool import pixelformat, rfb
 from vncdotool.const import AuthTypes, Encoding, MsgS2C
+from vncdotool.decoders.tight import JPEG
 
 PIXEL_FORMAT = rfb.PixelFormat()
 # Large enough for a whole glyph patch, which stamp_patch refuses to clip.
@@ -30,6 +32,32 @@ def raw_update(image: Image.Image) -> bytes:
     header = pack("!BxH", MsgS2C.FRAMEBUFFER_UPDATE, 1)
     rectangle = pack("!HHHHi", 0, 0, SIZE[0], SIZE[1], Encoding.RAW)
     return header + rectangle + image.convert("RGB").tobytes("raw", "RGBX")
+
+
+def compact(length: int) -> bytes:
+    """*length* in the wire's compact representation (specs/tight-wire.md
+    section 6).
+    """
+    out = bytearray()
+    while True:
+        byte, length = length & 0x7F, length >> 7
+        out.append(byte | (0x80 if length else 0))
+        if not length:
+            return bytes(out)
+
+
+def tight_jpeg_update(image: Image.Image) -> bytes:
+    payload = io.BytesIO()
+    image.convert("RGB").save(payload, "JPEG", quality=100)
+    jfif = payload.getvalue()
+    header = pack("!BxH", MsgS2C.FRAMEBUFFER_UPDATE, 1)
+    rectangle = pack("!HHHHi", 0, 0, SIZE[0], SIZE[1], Encoding.TIGHT)
+    return header + rectangle + bytes([JPEG << 4]) + compact(len(jfif)) + jfif
+
+
+def unknown_encoding_update() -> bytes:
+    header = pack("!BxH", MsgS2C.FRAMEBUFFER_UPDATE, 1)
+    return header + pack("!HHHHi", 0, 0, SIZE[0], SIZE[1], 0x4242)
 
 
 def screen(key: str) -> Image.Image:
@@ -77,6 +105,21 @@ class TestSplit(unittest.TestCase):
         stream = handshake_bytes(pixelformat.PIXEL_FORMATS["bgrx8888"]) + raw_update(screen("s"))
         _, steps = distill.split(stream, "rgbx8888")
         self.assertEqual([step.key for step in steps], ["s"])
+
+    def test_the_requested_quality_level_admits_a_jpeg_rectangle(self) -> None:
+        stream = handshake_bytes() + tight_jpeg_update(screen("d"))
+        _, steps = distill.split(stream, "rgbx8888", jpeg_quality=9)
+        self.assertEqual([step.key for step in steps], ["d"])
+
+    def test_a_jpeg_rectangle_without_a_quality_level_raises(self) -> None:
+        stream = handshake_bytes() + tight_jpeg_update(screen("d"))
+        with self.assertRaisesRegex(ValueError, "JPEG Quality Level"):
+            distill.split(stream, "rgbx8888")
+
+    def test_a_stream_that_stops_decoding_raises_rather_than_truncating(self) -> None:
+        stream = handshake_bytes() + raw_update(screen("0")) + unknown_encoding_update()
+        with self.assertRaisesRegex(ValueError, "stopped decoding after 1 updates"):
+            distill.split(stream, "rgbx8888")
 
 
 class TestWriteFixture(unittest.TestCase):


### PR DESCRIPTION
`make goldens` writes truncated lossy fixtures and reports success. The distiller replays `s2c.bin` alone, so it never offers the JPEG quality level the capture asked for, and `TightDecoder` refuses the first JPEG rectangle; the abort reaches a mocked factory and vanishes. Driving the fleet at quality 9 and 5 gives two-step fixtures where the committed ones hold eight. The guard that refuses postdates the last capture of those fixtures, which is the only reason they are whole today.

`split` now raises on anything that stopped the parser, so this cannot pass silently again.

Not run by CI: `make goldens` against the fleet before and after, which reproduces the eight committed steps of both lossy fixtures, and `make test-func`, green but for four macOS Screen Sharing cases failing on this host's auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
