### PR TITLE
Reclassify KasmVNC as Broken, and add --dialect to drive it anyway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 2.0.0.dev0 (UNRELEASED)
+- KasmVNC is now listed as Broken: `move`, `click` and `drag` end the session against it (@sibson)
 - `vncdo -v -v` names the encoding and geometry of every rectangle it receives (@sibson, #504)
 - Protocol failures name the security type, message or encoding they are about, spelled as rfbproto and a server's own configuration spell it, instead of printing a Python enum repr such as `<AuthTypes.VENCRYPT: 19>`. A server with no security type in common says what it offered and what vncdotool supports, a VeNCrypt refusal gives one subtype per line with its reason, and a server's own refusal reason reads as text rather than as `b'Too many security failures'` (#310)
 - Add VeNCrypt (security type 19), so a TLS-fronted server connects instead of failing as an unknown security type (#310, #138). Certificates are verified by default: `--tls-ca-cert FILE` supplies a private CA, `--tls-insecure-skip-verify` accepts a server that cannot be verified, and the cleartext `Plain` subtype is refused outright. SASL and Ident are unimplemented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.0.0.dev0 (UNRELEASED)
-- KasmVNC is now listed as Broken: `move`, `click` and `drag` end the session against it (@sibson)
+- Add `vncdo --dialect NAME` (`kasmvnc`, `vmware`) for servers that deviate from RFB; `--dialect kasmvnc` keeps the session alive through a pointer event (@sibson)
+- KasmVNC is now listed as Broken: without `--dialect kasmvnc`, `move`, `click` and `drag` end the session against it (@sibson)
 - `vncdo -v -v` names the encoding and geometry of every rectangle it receives (@sibson, #504)
 - Protocol failures name the security type, message or encoding they are about, spelled as rfbproto and a server's own configuration spell it, instead of printing a Python enum repr such as `<AuthTypes.VENCRYPT: 19>`. A server with no security type in common says what it offered and what vncdotool supports, a VeNCrypt refusal gives one subtype per line with its reason, and a server's own refusal reason reads as text rather than as `b'Too many security failures'` (#310)
 - Add VeNCrypt (security type 19), so a TLS-fronted server connects instead of failing as an unknown security type (#310, #138). Certificates are verified by default: `--tls-ca-cert FILE` supplies a private CA, `--tls-insecure-skip-verify` accepts a server that cannot be verified, and the cleartext `Plain` subtype is refused outright. SASL and Ident are unimplemented

--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ against it once. Not tracked by CI, so it ages. Nothing listed yet.
 work; any pointer event stops the server answering, and it drops the
 connection twenty seconds later. KasmVNC states that it has left the RFB
 specification and does not support VNC client applications, so expect no
-fix.
+fix. `vncdo --dialect kasmvnc` sends the eleven-byte pointer event its
+server reads instead of RFB's six, which keeps the session alive and moves
+the pointer; a button press reaches the X server, but has not been seen to
+reach an application.
 
 **TBD** — no data gathered: RealVNC, TightVNC, TurboVNC, PiKVM, and everything
 else. It should work; we make no claim. A report either way is welcome, and is

--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ This says what we have evidence for, not what works.
 pull request: [TigerVNC](https://tigervnc.org),
 [x11vnc](https://github.com/LibVNC/x11vnc),
 [wayvnc](https://github.com/any1/wayvnc),
-[LibVNCServer](https://libvnc.github.io),
-[KasmVNC](https://kasmweb.com/kasmvnc), [QEMU](https://qemu.org)'s built-in
+[LibVNCServer](https://libvnc.github.io), [QEMU](https://qemu.org)'s built-in
 server, [Selenoid](https://aerokube.com/selenoid/).
 
 **Supported on their own OS** — the same journey, but only on the pull
@@ -78,7 +77,12 @@ its captures come back near-solid whatever the client does.
 **Compatible** — a user reported it working, or we ran the compatibility suite
 against it once. Not tracked by CI, so it ages. Nothing listed yet.
 
-**Broken** — we tried it and it does not work. Nothing listed yet.
+**Broken** — we tried it and it does not work:
+[KasmVNC](https://kasmweb.com/kasmvnc). Connecting, key input and capture
+work; any pointer event stops the server answering, and it drops the
+connection twenty seconds later. KasmVNC states that it has left the RFB
+specification and does not support VNC client applications, so expect no
+fix.
 
 **TBD** — no data gathered: RealVNC, TightVNC, TurboVNC, PiKVM, and everything
 else. It should work; we make no claim. A report either way is welcome, and is

--- a/tests/functional/test_scene_player.py
+++ b/tests/functional/test_scene_player.py
@@ -98,7 +98,7 @@ class ClickSelectsAScene:
 
 
 for _server in SCENE_SERVERS:
-    if not _server.accepts_pointer_events:
+    if _server.skip_pointer_tests:
         continue
     _name = "TestClick_" + _server.name.replace("-", "_")
     globals()[_name] = type(

--- a/tests/functional/test_scene_player.py
+++ b/tests/functional/test_scene_player.py
@@ -98,6 +98,8 @@ class ClickSelectsAScene:
 
 
 for _server in SCENE_SERVERS:
+    if not _server.accepts_pointer_events:
+        continue
     _name = "TestClick_" + _server.name.replace("-", "_")
     globals()[_name] = type(
         _name, (ClickSelectsAScene, FleetTestCase), {"server": _server, "__module__": __name__}

--- a/tests/functional/test_server_compat_docker.py
+++ b/tests/functional/test_server_compat_docker.py
@@ -67,3 +67,16 @@ class TestKasmVNCInput(FleetTestCase):
             f"exited {result.returncode} rather than timing out, stderr:\n"
             f"{result.stderr}",
         )
+
+    def test_the_kasmvnc_dialect_keeps_the_session_answering(self) -> None:
+        result, png = self.capture_after("--dialect", "kasmvnc", "move", "10", "10")
+        self.assertEqual(
+            result.returncode, 0,
+            f"KasmVNC: --dialect kasmvnc exited {result.returncode}, stderr:\n"
+            f"{result.stderr}",
+        )
+        self.assertTrue(
+            png.exists(),
+            "KasmVNC served no framebuffer update after an eleven-byte "
+            "PointerEvent, so --dialect kasmvnc no longer matches its reader",
+        )

--- a/tests/functional/test_server_compat_docker.py
+++ b/tests/functional/test_server_compat_docker.py
@@ -24,18 +24,24 @@ register_server_tests(SUPPORTED_SERVERS, globals(), base=FleetTestCase)
 
 
 class TestKasmVNCInput(FleetTestCase):
+    """Locks the KasmVNC behaviour that keeps it out of SUPPORTED_SERVERS.
+
+    A failure here means the server changed: re-evaluate whether it moves
+    back to README.md's Supported class.
+    """
+
     server = KASMVNC
     # Long enough that a served update arrives, short enough that the wedge
     # surfaces well before KasmVNC's own 20-second idle timeout drops the
     # socket.
-    deadline = "5"
+    timeout = "5"
 
     def capture_after(self, *args: str) -> Tuple[subprocess.CompletedProcess, Path]:
         tmp = tempfile.TemporaryDirectory()
         self.addCleanup(tmp.cleanup)
         png = Path(tmp.name) / "after-input.png"
         result = run_vncdo(
-            self.server, "--timeout", self.deadline,
+            self.server, "--timeout", self.timeout,
             *args, "pause", "0.3", "capture", str(png),
         )
         return result, png
@@ -58,7 +64,7 @@ class TestKasmVNCInput(FleetTestCase):
         self.assertFalse(
             png.exists(),
             "KasmVNC served a framebuffer update after a PointerEvent, so it "
-            "now reads the RFB 6143 message: its accepts_pointer_events=False "
+            "now reads the RFB 6143 message: its skip_pointer_tests=True "
             "and its README.md Broken entry are both wrong",
         )
         self.assertEqual(

--- a/tests/functional/test_server_compat_docker.py
+++ b/tests/functional/test_server_compat_docker.py
@@ -9,8 +9,61 @@ default, override with ``VNCDOTOOL_SCREENSHOT_DIR``) so that a failing or
 suspicious capture can be looked at directly after the run.
 """
 
-from .utils import SUPPORTED_SERVERS, FleetTestCase, register_server_tests
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Tuple
+
+from vncdotool.command import ExitStatus
+
+from .utils import KASMVNC, SUPPORTED_SERVERS, FleetTestCase, register_server_tests, run_vncdo
 
 # Every scenario shells out to the vncdo CLI (see utils.run_vncdo), so
 # no reactor ever starts in this process and no api.shutdown() is needed.
 register_server_tests(SUPPORTED_SERVERS, globals(), base=FleetTestCase)
+
+
+class TestKasmVNCInput(FleetTestCase):
+    server = KASMVNC
+    # Long enough that a served update arrives, short enough that the wedge
+    # surfaces well before KasmVNC's own 20-second idle timeout drops the
+    # socket.
+    deadline = "5"
+
+    def capture_after(self, *args: str) -> Tuple[subprocess.CompletedProcess, Path]:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        png = Path(tmp.name) / "after-input.png"
+        result = run_vncdo(
+            self.server, "--timeout", self.deadline,
+            *args, "pause", "0.3", "capture", str(png),
+        )
+        return result, png
+
+    def test_a_key_event_leaves_the_session_answering(self) -> None:
+        result, png = self.capture_after("key", "x")
+        self.assertEqual(
+            result.returncode, 0,
+            f"KasmVNC: vncdo exited {result.returncode} after a KeyEvent, "
+            f"stderr:\n{result.stderr}",
+        )
+        self.assertTrue(
+            png.exists(),
+            "KasmVNC served no framebuffer update after a KeyEvent; only its "
+            "PointerEvent is known to differ from RFB 6143",
+        )
+
+    def test_a_pointer_event_stops_the_session_answering(self) -> None:
+        result, png = self.capture_after("move", "10", "10")
+        self.assertFalse(
+            png.exists(),
+            "KasmVNC served a framebuffer update after a PointerEvent, so it "
+            "now reads the RFB 6143 message: its accepts_pointer_events=False "
+            "and its README.md Broken entry are both wrong",
+        )
+        self.assertEqual(
+            result.returncode, ExitStatus.TIMEOUT,
+            f"KasmVNC: capture after a PointerEvent produced no PNG, but vncdo "
+            f"exited {result.returncode} rather than timing out, stderr:\n"
+            f"{result.stderr}",
+        )

--- a/tests/functional/test_websocket.py
+++ b/tests/functional/test_websocket.py
@@ -108,7 +108,7 @@ def _bases(server: VNCServer) -> tuple:
     bases = []
     if server not in SUPPORTED_SERVERS:
         bases.append(BasicWebSocketTests)
-        if server.accepts_pointer_events:
+        if not server.skip_pointer_tests:
             bases.append(PointerWebSocketTests)
     if server.address.startswith("wss://"):
         bases.append(TLSWebSocketTests)

--- a/tests/functional/test_websocket.py
+++ b/tests/functional/test_websocket.py
@@ -70,9 +70,6 @@ class BasicWebSocketTests(WebSocketTests):
     def test_a_key_event_is_accepted(self) -> None:
         self.assert_survives("key", "x")
 
-    def test_a_pointer_event_is_accepted(self) -> None:
-        self.assert_survives("move", "10", "10")
-
     def test_captures_a_real_screen(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             shot = Path(tmp) / "ws.png"
@@ -84,6 +81,12 @@ class BasicWebSocketTests(WebSocketTests):
             distinct_colours(captured), 1,
             f"{self.server.name}: captured a blank screen",
         )
+
+
+class PointerWebSocketTests(WebSocketTests):
+
+    def test_a_pointer_event_is_accepted(self) -> None:
+        self.assert_survives("move", "10", "10")
 
 
 class QueryStringTests(WebSocketTests):
@@ -105,6 +108,8 @@ def _bases(server: VNCServer) -> tuple:
     bases = []
     if server not in SUPPORTED_SERVERS:
         bases.append(BasicWebSocketTests)
+        if server.accepts_pointer_events:
+            bases.append(PointerWebSocketTests)
     if server.address.startswith("wss://"):
         bases.append(TLSWebSocketTests)
     if "?" in server.address:

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -96,9 +96,9 @@ class VNCServer(NamedTuple):
     # False means a flat, usually all-black, framebuffer is expected rather
     # than a failure -- see the macOS note in tests/servers/screen-sharing.
     renders_desktop: bool = True
-    # False where a pointer event ends the session instead of being acted on,
+    # True where a pointer event ends the session instead of being acted on,
     # so a grid that drives one has to leave this server out.
-    accepts_pointer_events: bool = True
+    skip_pointer_tests: bool = False
     # The default suits a container on loopback; an OS-hosted server sharing
     # a busy machine's real desktop can be far slower.
     timeout: float = CONNECT_TIMEOUT
@@ -235,7 +235,7 @@ SELENOID = VNCServer(
 KASMVNC = VNCServer(
     "kasmvnc", 5947, size=(256, 192),
     address="ws://127.0.0.1:5947/?password=vncdotool",
-    accepts_pointer_events=False,
+    skip_pointer_tests=True,
 )
 
 WEBSOCKET_SERVERS = [QEMU, QEMU_TLS, SELENOID, KASMVNC]

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -96,6 +96,9 @@ class VNCServer(NamedTuple):
     # False means a flat, usually all-black, framebuffer is expected rather
     # than a failure -- see the macOS note in tests/servers/screen-sharing.
     renders_desktop: bool = True
+    # False where a pointer event ends the session instead of being acted on,
+    # so a grid that drives one has to leave this server out.
+    accepts_pointer_events: bool = True
     # The default suits a container on loopback; an OS-hosted server sharing
     # a busy machine's real desktop can be far slower.
     timeout: float = CONNECT_TIMEOUT
@@ -232,6 +235,7 @@ SELENOID = VNCServer(
 KASMVNC = VNCServer(
     "kasmvnc", 5947, size=(256, 192),
     address="ws://127.0.0.1:5947/?password=vncdotool",
+    accepts_pointer_events=False,
 )
 
 WEBSOCKET_SERVERS = [QEMU, QEMU_TLS, SELENOID, KASMVNC]
@@ -246,7 +250,6 @@ SUPPORTED_SERVERS = [
     X11VNC,
     WAYVNC,
     LIBVNCSERVER_EXAMPLE,
-    KASMVNC,
     QEMU,
     SELENOID,
 ]
@@ -757,10 +760,8 @@ class _VNCServerTestMixin:
         return result
 
     def assert_survives(self, *args: str) -> None:
-        """The exit status alone proves nothing: vncdo has sent the event and
-        returned before the server reacts. KasmVNC closes the WebSocket on a
-        PointerEvent, and a bare `move` against it still exits 0 about a
-        second later.
+        """vncdo sends the event and returns before the server reacts, so a
+        zero exit status does not show the session survived it.
         """
         with tempfile.TemporaryDirectory() as tmp:
             png = Path(tmp) / "after-input.png"

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -599,6 +599,46 @@ class TestImageMode(TestCase):
         self.client.transport.loseConnection.assert_called_once()
 
 
+class TestKasmVNCDialect(TestCase):
+
+    def setUp(self) -> None:
+        self.client = type("C", (client.KasmVNCDialect, client.VNCDoToolClient), {})()
+        self.client.transport = mock.Mock()
+
+    def test_pointer_event_carries_a_u16_mask_and_scroll_deltas(self) -> None:
+        self.client.pointerEvent(20, 30, buttonmask=1)
+
+        self.client.transport.write.assert_called_once_with(
+            struct.pack("!BHHHhh", client.rfb.MsgC2S.POINTER_EVENT, 1, 20, 30, 0, 0)
+        )
+
+    def test_the_message_is_eleven_bytes(self) -> None:
+        self.client.pointerEvent(20, 30)
+
+        (payload,), _ = self.client.transport.write.call_args
+        self.assertEqual(len(payload), 11)
+
+
+class TestApplyDialect(TestCase):
+
+    def test_standard_leaves_the_client_class_alone(self) -> None:
+        factory = client.VNCDoToolFactory()
+        client.apply_dialect(factory, "standard")
+
+        self.assertIs(factory.protocol, client.VNCDoToolClient)
+
+    def test_a_dialect_mixes_into_whatever_client_the_factory_uses(self) -> None:
+        class CLIClient(client.VNCDoToolClient):
+            pass
+
+        factory = client.VNCDoToolFactory()
+        factory.protocol = CLIClient
+        client.apply_dialect(factory, "kasmvnc")
+
+        self.assertTrue(issubclass(factory.protocol, client.KasmVNCDialect))
+        self.assertTrue(issubclass(factory.protocol, CLIClient))
+
+
 class TestVMWareClient(TestCase):
 
     def setUp(self) -> None:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -602,8 +602,11 @@ class TestImageMode(TestCase):
 class TestKasmVNCDialect(TestCase):
 
     def setUp(self) -> None:
-        self.client = type("C", (client.KasmVNCDialect, client.VNCDoToolClient), {})()
+        self.client = client.KasmVNCClient()
         self.client.transport = mock.Mock()
+
+    def test_the_factory_serves_the_dialect(self) -> None:
+        self.assertIs(client.KasmVNCFactory.protocol, client.KasmVNCClient)
 
     def test_pointer_event_carries_a_u16_mask_and_scroll_deltas(self) -> None:
         self.client.pointerEvent(20, 30, buttonmask=1)

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -663,6 +663,10 @@ class VMWareDialect:
             super().dataReceived(data)
 
 
+class KasmVNCClient(KasmVNCDialect, VNCDoToolClient):
+    pass
+
+
 class VMWareClient(VMWareDialect, VNCDoToolClient):
     pass
 
@@ -733,6 +737,10 @@ class VNCDoToolFactory(rfb.RFBFactory):
 
     def clientConnectionMade(self, protocol: VNCDoToolClient) -> None:
         self.deferred.callback(protocol)
+
+
+class KasmVNCFactory(VNCDoToolFactory):
+    protocol = KasmVNCClient
 
 
 class VMWareFactory(VNCDoToolFactory):

--- a/vncdotool/client.py
+++ b/vncdotool/client.py
@@ -625,7 +625,16 @@ class VNCDoToolClient(rfb.RFBClient):
         self.width, self.height = width, height
 
 
-class VMWareClient(VNCDoToolClient):
+class KasmVNCDialect:
+    def pointerEvent(self, x: int, y: int, buttonmask: int = 0) -> None:
+        # KasmVNC reads a U16 button mask and a trailing pair of scroll deltas:
+        # eleven bytes where RFB 6143 defines six.
+        self.transport.write(
+            pack("!BHHHhh", rfb.MsgC2S.POINTER_EVENT, buttonmask, x, y, 0, 0)
+        )
+
+
+class VMWareDialect:
     SINGLE_PIXEL_UPDATE = pack(
         "!BxHHHHHixxxx",
         rfb.MsgS2C.FRAMEBUFFER_UPDATE,  # message-type
@@ -652,6 +661,31 @@ class VMWareClient(VNCDoToolClient):
             self._handler()
         else:
             super().dataReceived(data)
+
+
+class VMWareClient(VMWareDialect, VNCDoToolClient):
+    pass
+
+
+DIALECTS: dict[str, type | None] = {
+    "standard": None,
+    "kasmvnc": KasmVNCDialect,
+    "vmware": VMWareDialect,
+}
+
+
+def apply_dialect(factory: VNCDoToolFactory, name: str) -> None:
+    """The CLI and the library each bring their own client subclass, so a
+    dialect mixes into `factory.protocol` rather than replacing it.
+    """
+    dialect = DIALECTS[name]
+    if dialect is None:
+        return
+    factory.protocol = type(
+        dialect.__name__ + factory.protocol.__name__,
+        (dialect, factory.protocol),
+        {},
+    )
 
 
 class VNCDoToolFactory(rfb.RFBFactory):

--- a/vncdotool/command.py
+++ b/vncdotool/command.py
@@ -30,12 +30,14 @@ from twisted.python.log import PythonLoggingObserver
 from . import decoders, pixelformat, websocket
 from .capture import check_capture_target
 from .client import (
+    DIALECTS,
     JPEG_QUALITY_ENCODINGS,
     AuthenticationError,
     ProtocolError,
     TClient,
     VNCDoToolClient,
     VNCDoToolFactory,
+    apply_dialect,
     factory_connect,
 )
 from .loggingproxy import VNCLoggingServerFactory
@@ -630,6 +632,12 @@ def vncdo(argv: list[str] | None = None) -> None:
         help="delay MILLISECONDS between actions [%(default)sms]",
     )
     parser.add_argument(
+        "--dialect",
+        choices=sorted(DIALECTS),
+        default="standard",
+        help="speak the RFB variant used by this server [%(default)s]",
+    )
+    parser.add_argument(
         "--force-caps",
         action="store_true",
         help="for non-compliant servers, send shift-LETTER, ensures capitalization works",
@@ -740,6 +748,8 @@ def vncdo(argv: list[str] | None = None) -> None:
     factory = build_tool(options, args)
     factory.username = options.username
     factory.password = options.password
+
+    apply_dialect(factory, options.dialect)
 
     if options.localcursor:
         factory.pseudocursor = True


### PR DESCRIPTION
KasmVNC reads eleven bytes for the PointerEvent that RFB 6143 defines as six, so a conforming client's six wedge its reader and the connection dies twenty seconds later. README moves KasmVNC from Supported to Broken; upstream declines to support VNC clients (kasmtech/KasmVNC#119).

`--dialect NAME` mixes a per-server class into whichever client the entry point already uses, so the CLI keeps `VNCDoCLIClient` and the library keeps its `factory_class`. `--dialect kasmvnc` sends the eleven-byte form: the session survives and the pointer moves, checked with `XQueryPointer` inside the container. A press reaches X but has not been seen to reach an application. Misapplying a dialect desyncs a conforming server.

Stacked on #515, which is red on kasmvnc until this lands. The `--dialect` functional case has not run through the harness — the fleet is serving another checkout's images — so it was checked by driving `vncdo` at the fleet directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
