### PR TITLE
Boot the fleet's QEMU on OVMF so its screen holds still

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ pull request: [TigerVNC](https://tigervnc.org),
 [KasmVNC](https://kasmweb.com/kasmvnc), [QEMU](https://qemu.org)'s built-in
 server, [Selenoid](https://aerokube.com/selenoid/).
 
+QEMU is the exception: it boots firmware with no guest, so there is no
+desktop to draw a known scene, and its encodings are checked against its own
+Raw output rather than against a committed image.
+
 **Supported on their own OS** — the same journey, but only on the pull
 requests that touch code able to affect it, since these servers need a
 Windows or macOS runner: UltraVNC on Windows, and Apple Screen Sharing on

--- a/README.md
+++ b/README.md
@@ -68,10 +68,6 @@ pull request: [TigerVNC](https://tigervnc.org),
 [KasmVNC](https://kasmweb.com/kasmvnc), [QEMU](https://qemu.org)'s built-in
 server, [Selenoid](https://aerokube.com/selenoid/).
 
-QEMU is the exception: it boots firmware with no guest, so there is no
-desktop to draw a known scene, and its encodings are checked against its own
-Raw output rather than against a committed image.
-
 **Supported on their own OS** — the same journey, but only on the pull
 requests that touch code able to affect it, since these servers need a
 Windows or macOS runner: UltraVNC on Windows, and Apple Screen Sharing on

--- a/specs/testing-framework.md
+++ b/specs/testing-framework.md
@@ -65,11 +65,14 @@ reach it — the grid is the only thing that sends it input. Every other fleet
 server is covered in more detail by those grids and stays out of this one.
 
 QEMU has no X server either. It reaches the encoding grid on screens `type`
-asks OVMF's UEFI shell to draw, with a Raw capture of the same screen as the
-oracle — the firmware boots no guest, so there is no scene player and no
-committed PNG to hold a capture against. Checking the other decoders against
-the simplest one is weaker than what a scene server gets. The pixel-format
-grid and the decoder goldens still do not reach QEMU.
+asks OVMF's UEFI shell to draw, which is worth the trouble because QEMU's
+Hextile, ZRLE and Tight are written from the specification rather than
+shared with the rest of the fleet: the bytes on the wire are a variation the
+decoders would otherwise never see. The oracle is a Raw capture of the same
+screen, the firmware having no scene player and no committed PNG to hold a
+capture against, so what the comparison catches is a decoder that disagrees
+with our own Raw. The pixel-format grid and the decoder goldens still do not
+reach QEMU.
 
 Tier 2 keeps a subclass per server for the same reason as
 libvncserver-example: for an OS-hosted server the smoke grid is the only

--- a/specs/testing-framework.md
+++ b/specs/testing-framework.md
@@ -64,6 +64,13 @@ cannot run the scene player and the encoding and pixel-format grids cannot
 reach it — the grid is the only thing that sends it input. Every other fleet
 server is covered in more detail by those grids and stays out of this one.
 
+QEMU has no X server either. It reaches the encoding grid on screens `type`
+asks OVMF's UEFI shell to draw, with a Raw capture of the same screen as the
+oracle — the firmware boots no guest, so there is no scene player and no
+committed PNG to hold a capture against. Checking the other decoders against
+the simplest one is weaker than what a scene server gets. The pixel-format
+grid and the decoder goldens still do not reach QEMU.
+
 Tier 2 keeps a subclass per server for the same reason as
 libvncserver-example: for an OS-hosted server the smoke grid is the only
 coverage there is.
@@ -308,6 +315,19 @@ and can proceed while 3–5 follow.
   key classes (named keys, function keys, modifier combos, keypad) at every
   fleet server and reading the X-side sink. Needs a per-class matrix rather
   than the one-key-per-server smoke case that exists today.
+- **QEMU scenes via a UEFI application**: a payload rather than a guest OS.
+  OVMF's shell auto-runs `startup.nsh` off its boot media, so a small
+  gnu-efi application (Debian packages the library) can draw a scene
+  through the GOP `Blt()` protocol and read keys through
+  `SIMPLE_TEXT_INPUT_PROTOCOL`, on a FAT image `mtools` builds without root
+  or a loop mount. Converting the committed scene PNGs to raw BGRX at build
+  time keeps a PNG decoder out of the C. Measured 2026-09-09:
+  `-device VGA,edid=on,xres=256,yres=192` makes QEMU serve exactly the scene
+  geometry, and the payload adds under a megabyte against the ~250MB a guest
+  with Xorg costs. QEMU would then be an ordinary scene server, reaching
+  both grids and the goldens through the existing pipeline rather than a
+  second fixture shape. The goldens need the container's RFB port published
+  as well, since `vnclog` cannot dial the WebSocket the fleet exposes.
 - **Fleet expansion** (TightVNC, more): follows the plan's tier process;
   this framework adds a server as one descriptor, plus its membership of
   whichever server lists it belongs in.

--- a/tests/functional/capture_screenshots.py
+++ b/tests/functional/capture_screenshots.py
@@ -36,6 +36,7 @@ from utils import (  # noqa: E402
     VNCServer,
     capture_screenshot,
     port_open,
+    probe_context,
     screenshot_dir,
     select_servers,
 )
@@ -57,7 +58,8 @@ def capture(server: VNCServer, directory: Path) -> Capture:
 
     path = directory / f"{server.name}.png"
     try:
-        capture_screenshot(server, path)
+        with probe_context(server) as env:
+            capture_screenshot(server, path, env=env)
     except Exception as exc:  # noqa: BLE001 - diagnostics must not fail the build
         return Capture(server, None, f"failed, {exc}")
 

--- a/tests/functional/test_encodings.py
+++ b/tests/functional/test_encodings.py
@@ -32,7 +32,7 @@ SCENES = ("0", "s")
 # Flat enough that every server encodes it the way it was asked to.
 HONOURED_SCENE = "0"
 
-RECTANGLE_ENCODING = re.compile(r"Received <Encoding\.([A-Z_]+):")
+RECTANGLE_ENCODING = re.compile(r"Received ([A-Z_]+) \(-?\d+\) rectangle")
 
 # Measured against the fleet by offering one encoding at a time and reading
 # back the encoding of the rectangles that arrived. Every server here

--- a/tests/functional/test_encodings.py
+++ b/tests/functional/test_encodings.py
@@ -64,13 +64,12 @@ def capture(
         return Image.open(path).convert("RGB").copy(), result.stderr
 
 
-# `cls N` repaints OVMF's whole shell framebuffer in colour N.
 QEMU_SCREENS = {
-    "flat": ("cls 4",),
+    "flat": ("cls 4",),  # `cls N` repaints OVMF's whole shell framebuffer in colour N
     "text": ("cls 1", "echo vncdotool encoding probe"),
 }
 
-# Measured against QEMU's firmware screens the way EMITTED was.
+# Offered one at a time; QEMU sent these and answered with Raw for the rest.
 QEMU_EMITTED = {"raw", "hextile", "zrle", "tight"}
 
 # The shell answers a command over several framebuffer updates, so a capture

--- a/tests/functional/test_encodings.py
+++ b/tests/functional/test_encodings.py
@@ -48,13 +48,13 @@ EMITTED: Dict[str, Set[str]] = {
 
 
 def capture(
-    test: TestCase, server: VNCServer, encodings: str, key: str
+    test: TestCase, server: VNCServer, encodings: str, *before: str
 ) -> Tuple[Image.Image, str]:
+    """The screen `before` leaves behind, and the log naming its rectangles."""
     with tempfile.TemporaryDirectory() as tmp:
         path = Path(tmp) / "screen.png"
         result = run_vncdo(
-            server, "-v", "-v", "--encodings", encodings,
-            "key", key, *awaiting(key), "capture", str(path),
+            server, "-v", "-v", "--encodings", encodings, *before, "capture", str(path),
         )
         if result.returncode != 0:
             test.fail(
@@ -77,27 +77,13 @@ QEMU_EMITTED = {"raw", "hextile", "zrle", "tight"}
 QEMU_SETTLE_SECONDS = "1"
 
 
-def capture_qemu(test: TestCase, encoding: str, *before: str) -> Tuple[Image.Image, str]:
-    with tempfile.TemporaryDirectory() as tmp:
-        path = Path(tmp) / "screen.png"
-        result = run_vncdo(
-            QEMU, "-v", "-v", "--encodings", encoding, *before, "capture", str(path)
-        )
-        if result.returncode != 0:
-            test.fail(
-                f"qemu: vncdo --encodings {encoding} failed "
-                f"({result.returncode}): {result.stderr}"
-            )
-        return Image.open(path).convert("RGB").copy(), result.stderr
-
-
 def draw_on_qemu(test: TestCase, screen: str) -> Image.Image:
     """Put one of QEMU_SCREENS up, and return the Raw capture of it."""
     argv: List[str] = []
     for command in QEMU_SCREENS[screen]:
         argv += ["type", command, "key", "enter"]
     argv += ["stable", QEMU_SETTLE_SECONDS]
-    oracle, _ = capture_qemu(test, "raw", *argv)
+    oracle, _ = capture(test, QEMU, "raw", *argv)
     return oracle
 
 
@@ -112,7 +98,9 @@ class RendersTheScene:
     scene: str
 
     def test_renders_the_scene_through_the_encoding_it_asked_for(self) -> None:
-        screen, log = capture(self, self.server, self.encoding, self.scene)
+        screen, log = capture(
+            self, self.server, self.encoding, "key", self.scene, *awaiting(self.scene)
+        )
         oracle = Image.open(SCENES_DIR / f"{self.scene}.png").convert("RGB")
         self.assertEqual(screen.size, oracle.size)
         self.assertEqual(
@@ -145,7 +133,7 @@ class RendersTheSameScreenAsRaw:
 
     def test_renders_the_screen_as_raw_renders_it(self) -> None:
         oracle = draw_on_qemu(self, self.screen)
-        screen, log = capture_qemu(self, self.encoding)
+        screen, log = capture(self, QEMU, self.encoding)
         self.assertEqual(
             screen.tobytes(), oracle.tobytes(),
             f"qemu: {self.encoding} and raw disagree about the {self.screen} screen",
@@ -173,9 +161,8 @@ def qemu_cases() -> Iterator[TestCase]:
             yield case("test_renders_the_screen_as_raw_renders_it")
 
 
-def load_tests(loader: unittest.TestLoader, tests: unittest.TestSuite, pattern: object) -> unittest.TestSuite:
-    suite = unittest.TestSuite()
-    suite.addTests(qemu_cases())
+def scene_cases() -> Iterator[TestCase]:
+    """One case per encoding against each scene, on every server running the player."""
     for server in SCENE_SERVERS:
         label = server.name.replace("-", "_")
         for encoding in sorted(decoders.ENCODING_NAMES):
@@ -185,5 +172,11 @@ def load_tests(loader: unittest.TestLoader, tests: unittest.TestSuite, pattern: 
                     name, (RendersTheScene, FleetTestCase),
                     {"server": server, "encoding": encoding, "scene": scene},
                 )
-                suite.addTest(case("test_renders_the_scene_through_the_encoding_it_asked_for"))
+                yield case("test_renders_the_scene_through_the_encoding_it_asked_for")
+
+
+def load_tests(loader: unittest.TestLoader, tests: unittest.TestSuite, pattern: object) -> unittest.TestSuite:
+    suite = unittest.TestSuite()
+    suite.addTests(qemu_cases())
+    suite.addTests(scene_cases())
     return suite

--- a/tests/functional/test_encodings.py
+++ b/tests/functional/test_encodings.py
@@ -69,8 +69,7 @@ QEMU_SCREENS = {
     "text": ("cls 1", "echo vncdotool encoding probe"),
 }
 
-# Offered one at a time; QEMU sent these and answered with Raw for the rest.
-QEMU_EMITTED = {"raw", "hextile", "zrle", "tight"}
+QEMU_ENCODINGS = {"raw", "hextile", "zrle", "tight"}
 
 # The shell answers a command over several framebuffer updates, so a capture
 # taken as soon as the last key is sent can catch it half-drawn.
@@ -124,14 +123,14 @@ class RendersTheScene:
         )
 
 
-class RendersTheSameScreenAsRaw:
+class RenderMatchesRaw:
     """One encoding against QEMU's own Raw, on a screen the shell was told to draw."""
 
     server = QEMU
     encoding: str
     screen: str
 
-    def test_renders_the_screen_as_raw_renders_it(self) -> None:
+    def test_render_matches_raw(self) -> None:
         oracle = draw_on_qemu(self, self.screen)
         screen, log = capture(self, QEMU, self.encoding)
         self.assertEqual(
@@ -139,7 +138,7 @@ class RendersTheSameScreenAsRaw:
             f"qemu: {self.encoding} and raw disagree about the {self.screen} screen",
         )
 
-        if self.encoding not in QEMU_EMITTED:
+        if self.encoding not in QEMU_ENCODINGS:
             return
         wanted = decoders.ENCODING_NAMES[self.encoding]
         arrived = set(RECTANGLE_ENCODING.findall(log))
@@ -153,12 +152,12 @@ def qemu_cases() -> Iterator[TestCase]:
     """One case per encoding against each firmware screen."""
     for encoding in sorted(decoders.ENCODING_NAMES):
         for screen in sorted(QEMU_SCREENS):
-            name = f"TestRendersAsRaw_qemu_{encoding}_screen_{screen}"
+            name = f"TestMatchesRaw_qemu_{encoding}_screen_{screen}"
             case = type(
-                name, (RendersTheSameScreenAsRaw, FleetTestCase),
+                name, (RenderMatchesRaw, FleetTestCase),
                 {"encoding": encoding, "screen": screen},
             )
-            yield case("test_renders_the_screen_as_raw_renders_it")
+            yield case("test_render_matches_raw")
 
 
 def scene_cases() -> Iterator[TestCase]:

--- a/tests/functional/test_encodings.py
+++ b/tests/functional/test_encodings.py
@@ -8,10 +8,11 @@ encoding matches ours. See specs/decoder-goldens.md.
 from __future__ import annotations
 
 import re
+import time
 import tempfile
 import unittest
 from pathlib import Path
-from typing import Dict, Set, Tuple
+from typing import Dict, List, Set, Tuple
 from unittest import TestCase
 
 from PIL import Image
@@ -19,6 +20,7 @@ from PIL import Image
 from vncdotool import decoders
 
 from .utils import (
+    QEMU,
     SCENE_SERVERS,
     SCENES_DIR,
     FleetTestCase,
@@ -63,6 +65,57 @@ def capture(
         return Image.open(path).convert("RGB").copy(), result.stderr
 
 
+# `cls N` repaints OVMF's whole shell framebuffer in colour N.
+QEMU_SCREENS = {
+    "flat": ("cls 4",),
+    "text": ("cls 1", "echo vncdotool encoding probe"),
+}
+
+# Measured against QEMU's firmware screens the way EMITTED was.
+QEMU_EMITTED = {"raw", "hextile", "zrle", "tight"}
+
+SETTLE_DELAY = 0.5
+SETTLE_ATTEMPTS = 12
+
+
+def capture_current(test: TestCase, encoding: str) -> Tuple[Image.Image, str]:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "screen.png"
+        result = run_vncdo(QEMU, "-v", "-v", "--encodings", encoding, "capture", str(path))
+        if result.returncode != 0:
+            test.fail(
+                f"qemu: vncdo --encodings {encoding} failed "
+                f"({result.returncode}): {result.stderr}"
+            )
+        return Image.open(path).convert("RGB").copy(), result.stderr
+
+
+def type_commands(test: TestCase, commands: Tuple[str, ...]) -> None:
+    argv: List[str] = []
+    for command in commands:
+        argv += ["type", command, "key", "enter"]
+    result = run_vncdo(QEMU, *argv)
+    if result.returncode != 0:
+        test.fail(f"qemu: vncdo {' '.join(argv)} failed ({result.returncode}): {result.stderr}")
+
+
+def settled(test: TestCase) -> Image.Image:
+    """A Raw capture, once two in a row agree.
+
+    The shell redraws over several updates, and the firmware is still
+    booting when the fleet first comes up, so a single capture can catch a
+    half-drawn screen that the next encoding would never reproduce.
+    """
+    previous = None
+    for _ in range(SETTLE_ATTEMPTS):
+        current, _ = capture_current(test, "raw")
+        if previous is not None and current.tobytes() == previous.tobytes():
+            return current
+        previous = current
+        time.sleep(SETTLE_DELAY)
+    test.fail(f"qemu: screen never settled over {SETTLE_ATTEMPTS} captures")
+
+
 class RendersTheScene:
     """One encoding against one image the server was shown.
 
@@ -98,8 +151,42 @@ class RendersTheScene:
         )
 
 
+class RendersTheSameScreenAsRaw:
+    """One encoding against QEMU's own Raw, on a screen the shell was told to draw."""
+
+    server = QEMU
+    encoding: str
+    screen: str
+
+    def test_renders_the_screen_as_raw_renders_it(self) -> None:
+        type_commands(self, QEMU_SCREENS[self.screen])
+        oracle = settled(self)
+        screen, log = capture_current(self, self.encoding)
+        self.assertEqual(
+            screen.tobytes(), oracle.tobytes(),
+            f"qemu: {self.encoding} and raw disagree about the {self.screen} screen",
+        )
+
+        if self.encoding not in QEMU_EMITTED:
+            return
+        wanted = decoders.ENCODING_NAMES[self.encoding]
+        arrived = set(RECTANGLE_ENCODING.findall(log))
+        self.assertIn(
+            wanted.name, arrived,
+            f"no {wanted!r} rectangle arrived; qemu answered with {sorted(arrived)}",
+        )
+
+
 def load_tests(loader: unittest.TestLoader, tests: unittest.TestSuite, pattern: object) -> unittest.TestSuite:
     suite = unittest.TestSuite()
+    for encoding in sorted(decoders.ENCODING_NAMES):
+        for screen in sorted(QEMU_SCREENS):
+            name = f"TestRendersAsRaw_qemu_{encoding}_screen_{screen}"
+            case = type(
+                name, (RendersTheSameScreenAsRaw, FleetTestCase),
+                {"encoding": encoding, "screen": screen},
+            )
+            suite.addTest(case("test_renders_the_screen_as_raw_renders_it"))
     for server in SCENE_SERVERS:
         label = server.name.replace("-", "_")
         for encoding in sorted(decoders.ENCODING_NAMES):

--- a/tests/functional/test_encodings.py
+++ b/tests/functional/test_encodings.py
@@ -8,11 +8,10 @@ encoding matches ours. See specs/decoder-goldens.md.
 from __future__ import annotations
 
 import re
-import time
 import tempfile
 import unittest
 from pathlib import Path
-from typing import Dict, List, Set, Tuple
+from typing import Dict, Iterator, List, Set, Tuple
 from unittest import TestCase
 
 from PIL import Image
@@ -74,14 +73,17 @@ QEMU_SCREENS = {
 # Measured against QEMU's firmware screens the way EMITTED was.
 QEMU_EMITTED = {"raw", "hextile", "zrle", "tight"}
 
-SETTLE_DELAY = 0.5
-SETTLE_ATTEMPTS = 12
+# The shell answers a command over several framebuffer updates, so a capture
+# taken as soon as the last key is sent can catch it half-drawn.
+QEMU_SETTLE_SECONDS = "1"
 
 
-def capture_current(test: TestCase, encoding: str) -> Tuple[Image.Image, str]:
+def capture_qemu(test: TestCase, encoding: str, *before: str) -> Tuple[Image.Image, str]:
     with tempfile.TemporaryDirectory() as tmp:
         path = Path(tmp) / "screen.png"
-        result = run_vncdo(QEMU, "-v", "-v", "--encodings", encoding, "capture", str(path))
+        result = run_vncdo(
+            QEMU, "-v", "-v", "--encodings", encoding, *before, "capture", str(path)
+        )
         if result.returncode != 0:
             test.fail(
                 f"qemu: vncdo --encodings {encoding} failed "
@@ -90,30 +92,14 @@ def capture_current(test: TestCase, encoding: str) -> Tuple[Image.Image, str]:
         return Image.open(path).convert("RGB").copy(), result.stderr
 
 
-def type_commands(test: TestCase, commands: Tuple[str, ...]) -> None:
+def draw_on_qemu(test: TestCase, screen: str) -> Image.Image:
+    """Put one of QEMU_SCREENS up, and return the Raw capture of it."""
     argv: List[str] = []
-    for command in commands:
+    for command in QEMU_SCREENS[screen]:
         argv += ["type", command, "key", "enter"]
-    result = run_vncdo(QEMU, *argv)
-    if result.returncode != 0:
-        test.fail(f"qemu: vncdo {' '.join(argv)} failed ({result.returncode}): {result.stderr}")
-
-
-def settled(test: TestCase) -> Image.Image:
-    """A Raw capture, once two in a row agree.
-
-    The shell redraws over several updates, and the firmware is still
-    booting when the fleet first comes up, so a single capture can catch a
-    half-drawn screen that the next encoding would never reproduce.
-    """
-    previous = None
-    for _ in range(SETTLE_ATTEMPTS):
-        current, _ = capture_current(test, "raw")
-        if previous is not None and current.tobytes() == previous.tobytes():
-            return current
-        previous = current
-        time.sleep(SETTLE_DELAY)
-    test.fail(f"qemu: screen never settled over {SETTLE_ATTEMPTS} captures")
+    argv += ["stable", QEMU_SETTLE_SECONDS]
+    oracle, _ = capture_qemu(test, "raw", *argv)
+    return oracle
 
 
 class RendersTheScene:
@@ -159,9 +145,8 @@ class RendersTheSameScreenAsRaw:
     screen: str
 
     def test_renders_the_screen_as_raw_renders_it(self) -> None:
-        type_commands(self, QEMU_SCREENS[self.screen])
-        oracle = settled(self)
-        screen, log = capture_current(self, self.encoding)
+        oracle = draw_on_qemu(self, self.screen)
+        screen, log = capture_qemu(self, self.encoding)
         self.assertEqual(
             screen.tobytes(), oracle.tobytes(),
             f"qemu: {self.encoding} and raw disagree about the {self.screen} screen",
@@ -177,8 +162,8 @@ class RendersTheSameScreenAsRaw:
         )
 
 
-def load_tests(loader: unittest.TestLoader, tests: unittest.TestSuite, pattern: object) -> unittest.TestSuite:
-    suite = unittest.TestSuite()
+def qemu_cases() -> Iterator[TestCase]:
+    """One case per encoding against each firmware screen."""
     for encoding in sorted(decoders.ENCODING_NAMES):
         for screen in sorted(QEMU_SCREENS):
             name = f"TestRendersAsRaw_qemu_{encoding}_screen_{screen}"
@@ -186,7 +171,12 @@ def load_tests(loader: unittest.TestLoader, tests: unittest.TestSuite, pattern: 
                 name, (RendersTheSameScreenAsRaw, FleetTestCase),
                 {"encoding": encoding, "screen": screen},
             )
-            suite.addTest(case("test_renders_the_screen_as_raw_renders_it"))
+            yield case("test_renders_the_screen_as_raw_renders_it")
+
+
+def load_tests(loader: unittest.TestLoader, tests: unittest.TestSuite, pattern: object) -> unittest.TestSuite:
+    suite = unittest.TestSuite()
+    suite.addTests(qemu_cases())
     for server in SCENE_SERVERS:
         label = server.name.replace("-", "_")
         for encoding in sorted(decoders.ENCODING_NAMES):

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -290,7 +290,7 @@ def os_servers(platform: str = sys.platform) -> List[VNCServer]:
 
 
 def select_servers(group: str) -> List[VNCServer]:
-    groups = {"docker": TCP_SERVERS, "os": os_servers()}
+    groups = {"docker": TCP_SERVERS + WEBSOCKET_SERVERS, "os": os_servers()}
     if group == "all":
         return [server for servers in groups.values() for server in servers]
     if group not in groups:
@@ -462,9 +462,30 @@ def connect(server: VNCServer, timeout: Optional[float] = None) -> api.ThreadedV
     return client
 
 
-def capture_screenshot(server: VNCServer, path: Path, timeout: Optional[float] = None) -> Path:
+@contextlib.contextmanager
+def probe_context(server: VNCServer) -> Iterator[Optional[Dict[str, str]]]:
+    """What a bare `vncdo capture` of this server needs around it.
+
+    Selenoid's /vnc/ route resolves only while a WebDriver session is open,
+    and QEMU signs its wss:// certificate with a CA its container writes at
+    start-up rather than one OpenSSL already trusts.
+    """
+    env = {"SSL_CERT_FILE": str(QEMU_TLS_CA)} if server is QEMU_TLS else None
+    if server is SELENOID:
+        with selenoid_session():
+            yield env
+    else:
+        yield env
+
+
+def capture_screenshot(
+    server: VNCServer,
+    path: Path,
+    timeout: Optional[float] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> Path:
     """Capture through the CLI, which is what carries a server's extra_args."""
-    result = run_vncdo(server, "capture", str(path), timeout=timeout)
+    result = run_vncdo(server, "capture", str(path), timeout=timeout, env=env)
     if result.returncode != 0:
         raise AssertionError(
             f"{server.name}: vncdo capture exited {result.returncode}, "
@@ -518,9 +539,9 @@ def wait_until_ready(
             continue
         try:
             normalize_size(server)
-            with tempfile.TemporaryDirectory() as tmp:
+            with probe_context(server) as env, tempfile.TemporaryDirectory() as tmp:
                 probe = Path(tmp) / f"{server.name}-ready.png"
-                capture_screenshot(server, probe, timeout=attempt_timeout)
+                capture_screenshot(server, probe, timeout=attempt_timeout, env=env)
                 with Image.open(probe) as image:
                     colours = distinct_colours(image)
                     size = image.size

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -27,7 +27,19 @@ import time
 import urllib.request
 import zipfile
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Mapping, NamedTuple, Optional, Set, Tuple
+from typing import (
+    Any,
+    Callable,
+    ContextManager,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Set,
+    Tuple,
+)
 from unittest import TestCase
 
 from PIL import Image
@@ -94,6 +106,12 @@ class VNCServer(NamedTuple):
     # Honoured only off CI -- see absent_server_skips().
     skip_when_down: bool = False
     normalize_size_keys: Tuple[str, ...] = ()
+    # A CA to trust, for a server whose address takes no --tls-ca-cert.
+    # OpenSSL reads one from SSL_CERT_FILE instead.
+    tls_ca: Optional[Path] = None
+    # Held open around anything that talks to this server, where its address
+    # resolves only inside a session.
+    session: Optional[Callable[[], ContextManager[None]]] = None
 
 
 # Both written by their container into a bind mount at every start; neither
@@ -161,38 +179,21 @@ def vnclog_can_reach(server: VNCServer) -> bool:
     return not any(option in server.extra_args for option in TLS_OPTIONS)
 
 
-# 1280x800 is the mode OVMF's UEFI shell settles in.
-QEMU = VNCServer("qemu", 5944, size=(1280, 800), address="ws://127.0.0.1:5944/")
-QEMU_TLS = VNCServer("qemu-tls", 5945, size=(1280, 800), address="wss://localhost:5945/")
 # QEMU presents a leaf signed by a CA rather than a self-signed certificate,
 # so the trust anchor cannot be read off the connection. Its service writes
 # the CA here at start-up.
 QEMU_TLS_CA = Path(__file__).resolve().parent.parent / "servers" / "qemu-tls" / "ca-cert.pem"
 
-# Selenoid keys the session off the URL path, so this address only resolves
-# while a WebDriver session with this id is open.
-SELENOID_SESSION_ID = "c2ec57a377e94f515b35b2a57caad26e"
-SELENOID = VNCServer(
-    "selenoid", 5946, size=(256, 192),
-    address=f"ws://127.0.0.1:5946/vnc/{SELENOID_SESSION_ID}?password=vncdotool",
+# 1280x800 is the mode OVMF's UEFI shell settles in.
+QEMU = VNCServer("qemu", 5944, size=(1280, 800), address="ws://127.0.0.1:5944/")
+QEMU_TLS = VNCServer(
+    "qemu-tls", 5945, size=(1280, 800), address="wss://localhost:5945/",
+    tls_ca=QEMU_TLS_CA,
 )
-
-KASMVNC = VNCServer(
-    "kasmvnc", 5947, size=(256, 192),
-    address="ws://127.0.0.1:5947/?password=vncdotool",
-)
-
-WEBSOCKET_SERVERS = [QEMU, QEMU_TLS, SELENOID, KASMVNC]
-
-# Both run the scene player behind their bridge, so the encoding and pixel
-# format grids reach them over ws:// and the handshake is exercised by every
-# case rather than by a test of its own.
-SCENE_SERVERS += [SELENOID, KASMVNC]
 
 
 @contextlib.contextmanager
 def selenoid_session() -> Iterator[None]:
-    """Hold a Selenoid WebDriver session open, which its /vnc/ route needs."""
     endpoint = f"http://{HOST}:{SELENOID.port}/wd/hub/session"
     body = json.dumps(
         {
@@ -217,6 +218,28 @@ def selenoid_session() -> Iterator[None]:
             urllib.request.Request(f"{endpoint}/{session_id}", method="DELETE"),
             timeout=SELENOID.timeout,
         ).close()
+
+
+# Selenoid keys the session off the URL path, so this address only resolves
+# while a WebDriver session with this id is open.
+SELENOID_SESSION_ID = "c2ec57a377e94f515b35b2a57caad26e"
+SELENOID = VNCServer(
+    "selenoid", 5946, size=(256, 192),
+    address=f"ws://127.0.0.1:5946/vnc/{SELENOID_SESSION_ID}?password=vncdotool",
+    session=selenoid_session,
+)
+
+KASMVNC = VNCServer(
+    "kasmvnc", 5947, size=(256, 192),
+    address="ws://127.0.0.1:5947/?password=vncdotool",
+)
+
+WEBSOCKET_SERVERS = [QEMU, QEMU_TLS, SELENOID, KASMVNC]
+
+# Both run the scene player behind their bridge, so the encoding and pixel
+# format grids reach them over ws:// and the handshake is exercised by every
+# case rather than by a test of its own.
+SCENE_SERVERS += [SELENOID, KASMVNC]
 
 
 # An event sink rather than a rendering server, so it stays out of the smoke
@@ -437,8 +460,8 @@ class FleetTestCase(TestCase):
                 f"{self.server.name} is not listening on {self.server.port}; "
                 f"{self.server.how_to_start}"
             )
-        if self.server is SELENOID:
-            session = selenoid_session()
+        if self.server.session is not None:
+            session = self.server.session()
             session.__enter__()
             self.addCleanup(session.__exit__, None, None, None)
 
@@ -464,18 +487,13 @@ def connect(server: VNCServer, timeout: Optional[float] = None) -> api.ThreadedV
 
 @contextlib.contextmanager
 def probe_context(server: VNCServer) -> Iterator[Optional[Dict[str, str]]]:
-    """What a bare `vncdo capture` of this server needs around it.
-
-    Selenoid's /vnc/ route resolves only while a WebDriver session is open,
-    and QEMU signs its wss:// certificate with a CA its container writes at
-    start-up rather than one OpenSSL already trusts.
-    """
-    env = {"SSL_CERT_FILE": str(QEMU_TLS_CA)} if server is QEMU_TLS else None
-    if server is SELENOID:
-        with selenoid_session():
-            yield env
-    else:
+    """What a bare `vncdo capture` of this server needs around it."""
+    env = {"SSL_CERT_FILE": str(server.tls_ca)} if server.tls_ca else None
+    if server.session is None:
         yield env
+    else:
+        with server.session():
+            yield env
 
 
 def capture_screenshot(

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -161,8 +161,9 @@ def vnclog_can_reach(server: VNCServer) -> bool:
     return not any(option in server.extra_args for option in TLS_OPTIONS)
 
 
-QEMU = VNCServer("qemu", 5944, size=(720, 400), address="ws://127.0.0.1:5944/")
-QEMU_TLS = VNCServer("qemu-tls", 5945, size=(720, 400), address="wss://localhost:5945/")
+# 1280x800 is the mode OVMF's UEFI shell settles in.
+QEMU = VNCServer("qemu", 5944, size=(1280, 800), address="ws://127.0.0.1:5944/")
+QEMU_TLS = VNCServer("qemu-tls", 5945, size=(1280, 800), address="wss://localhost:5945/")
 # QEMU presents a leaf signed by a CA rather than a self-signed certificate,
 # so the trust anchor cannot be read off the connection. Its service writes
 # the CA here at start-up.

--- a/tests/servers/Dockerfile
+++ b/tests/servers/Dockerfile
@@ -144,6 +144,7 @@ FROM base AS qemu
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         qemu-system-x86 \
+        ovmf \
         openssl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tests/servers/qemu-entrypoint.sh
+++ b/tests/servers/qemu-entrypoint.sh
@@ -32,10 +32,8 @@ else
     set --
 fi
 
-# No disk, so the firmware's own screen is the framebuffer. SeaBIOS blinks a
-# VGA text cursor, so two captures of an idle machine differ; the UEFI shell
-# holds still. Without -net none OVMF retries PXE forever and the screen
-# scrolls.
+# SeaBIOS blinks a VGA text cursor, so two captures of an idle machine
+# differ. Without -net none OVMF retries PXE forever and the screen scrolls.
 exec qemu-system-x86_64 \
     -m 128 \
     -display none \

--- a/tests/servers/qemu-entrypoint.sh
+++ b/tests/servers/qemu-entrypoint.sh
@@ -32,10 +32,14 @@ else
     set --
 fi
 
-# No disk: SeaBIOS draws its own boot screen, which is a real framebuffer
-# with stable content and needs no guest image.
+# No disk, so the firmware's own screen is the framebuffer. SeaBIOS blinks a
+# VGA text cursor, so two captures of an idle machine differ; the UEFI shell
+# holds still. Without -net none OVMF retries PXE forever and the screen
+# scrolls.
 exec qemu-system-x86_64 \
     -m 128 \
     -display none \
+    -net none \
+    -bios /usr/share/OVMF/OVMF_CODE.fd \
     -vnc "$VNC_ARGS" \
     "$@"


### PR DESCRIPTION
QEMU had no encoding coverage because SeaBIOS blinks a VGA text cursor and no two captures of an idle machine match. Booting OVMF gives a screen that holds still and a shell `type` can drive, so the decoders now run against QEMU's Hextile, ZRLE and Tight — written from the specification rather than shared with the rest of the fleet, a variation they were otherwise never held against. The oracle is a Raw capture of the same screen, firmware having no committed image to compare against.

Note the size constant moves 720x400 → 1280x800.

`Read rectangle encodings out of the log format #511 left behind` fixes main, red at 0a8dfbb: 32 of 84 cases fail across the whole scene grid. Worth taking separately.

Checked by hand: with QEMU restarted immediately beforehand, the widened readiness gate reports `serving (640, 480), expected (1280, 800)` and waits.
