### PR TITLE
Verify basic function against every supported server

### DIFF
--- a/tests/functional/test_scene_player.py
+++ b/tests/functional/test_scene_player.py
@@ -2,14 +2,24 @@
 from __future__ import annotations
 
 import tempfile
+import time
 from pathlib import Path
 from unittest import TestCase
 
 from PIL import Image
 
-from tests.goldens import scenes
+from tests.goldens import click_targets, scenes
 
-from .utils import TIGERVNC, assert_fleet_current, port_open, HOST, run_vncdo
+from .utils import (
+    HOST,
+    SCENE_SERVERS,
+    TIGERVNC,
+    FleetTestCase,
+    VNCServer,
+    assert_fleet_current,
+    port_open,
+    run_vncdo,
+)
 
 
 class TestScenePlayer(TestCase):
@@ -47,3 +57,48 @@ class TestScenePlayer(TestCase):
     def test_a_shifted_key_selects_the_same_scene(self) -> None:
         self.assertEqual(scenes.read_patch(self._capture("key", "0")), "0")
         self.assertEqual(scenes.read_patch(self._capture("key", "S")), "s")
+
+
+CLICKED_SCENE = "s"
+REPAINT_DEADLINE = 10.0
+REPAINT_POLL = 0.3
+
+
+class ClickSelectsAScene:
+    server: VNCServer
+
+    def _capture(self, *args: str) -> Image.Image:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "screen.png"
+            result = run_vncdo(self.server, *args, "pause", "0.3", "capture", str(path))
+            if result.returncode != 0:
+                self.fail(f"{self.server.name}: vncdo failed ({result.returncode}): {result.stderr}")
+            return Image.open(path).copy()
+
+    def test_a_click_selects_the_scene_under_it(self) -> None:
+        self._capture("key", "0")
+        x, y = click_targets.click_target(CLICKED_SCENE)
+        self._capture("move", str(x), str(y), "click", "1")
+
+        # x11vnc polls the X framebuffer rather than being the X server, so a
+        # repaint can reach a client a poll interval after the click.
+        seen = None
+        deadline = time.monotonic() + REPAINT_DEADLINE
+        while time.monotonic() < deadline:
+            seen = scenes.read_patch(self._capture("pause", "0"))
+            if seen == CLICKED_SCENE:
+                return
+            time.sleep(REPAINT_POLL)
+
+        self.fail(
+            f"{self.server.name}: clicking ({x}, {y}) left scene {seen!r} rather "
+            f"than {CLICKED_SCENE!r} after {REPAINT_DEADLINE}s; the button event "
+            "did not reach the server"
+        )
+
+
+for _server in SCENE_SERVERS:
+    _name = "TestClick_" + _server.name.replace("-", "_")
+    globals()[_name] = type(
+        _name, (ClickSelectsAScene, FleetTestCase), {"server": _server, "__module__": __name__}
+    )

--- a/tests/functional/test_server_compat_docker.py
+++ b/tests/functional/test_server_compat_docker.py
@@ -3,19 +3,14 @@
 Run first and cheaply, so `vncdo` breaking outright fails here rather than
 part-way through the suites that take minutes.
 
-TigerVNC is the fast path. libvncserver-example is here because it has no X
-server, so it cannot run the scene player and cannot join the encoding and
-pixel-format grids; without these four cases nothing sends it a key press or
-a pointer event.
-
 Screenshots captured here are kept rather than thrown away: each one is
 written to the screenshots directory (``tests/servers/screenshots`` by
 default, override with ``VNCDOTOOL_SCREENSHOT_DIR``) so that a failing or
 suspicious capture can be looked at directly after the run.
 """
 
-from .utils import LIBVNCSERVER_EXAMPLE, TIGERVNC, register_server_tests
+from .utils import SUPPORTED_SERVERS, FleetTestCase, register_server_tests
 
 # Every scenario shells out to the vncdo CLI (see utils.run_vncdo), so
 # no reactor ever starts in this process and no api.shutdown() is needed.
-register_server_tests([TIGERVNC, LIBVNCSERVER_EXAMPLE], globals())
+register_server_tests(SUPPORTED_SERVERS, globals(), base=FleetTestCase)

--- a/tests/functional/test_websocket.py
+++ b/tests/functional/test_websocket.py
@@ -1,9 +1,9 @@
 """What the WebSocket transport does that the compatibility grids cannot see.
 
-Selenoid and KasmVNC are in SCENE_SERVERS, so every encoding and pixel
-format case already runs over ws:// against them. What is left here is the
-client's own behaviour: refusing an unverifiable wss:// certificate, and
-keeping a password out of the log when the address carries one.
+What is left for this module is the client's own behaviour: refusing an
+unverifiable wss:// certificate, and keeping a password out of the log when
+the address carries one. The per-server grid in test_server_compat_docker.py
+already drives input and captures against every product here.
 """
 from __future__ import annotations
 
@@ -19,7 +19,7 @@ from .utils import (
     HOST,
     QEMU_TLS,
     QEMU_TLS_CA,
-    SCENE_SERVERS,
+    SUPPORTED_SERVERS,
     WEBSOCKET_SERVERS,
     FleetTestCase,
     VNCServer,
@@ -61,15 +61,17 @@ class WebSocketTests:
         )
         return result.stdout + result.stderr
 
+    def assert_survives(self, *args: str) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self.run_ok(*args, "pause", "0.3", "capture", str(Path(tmp) / "after.png"))
+
 
 class BasicWebSocketTests(WebSocketTests):
-    """For a server the scene grids cannot reach, so nothing else drives it."""
-
     def test_a_key_event_is_accepted(self) -> None:
-        self.run_ok("key", "x")
+        self.assert_survives("key", "x")
 
     def test_a_pointer_event_is_accepted(self) -> None:
-        self.run_ok("move", "10", "10")
+        self.assert_survives("move", "10", "10")
 
     def test_captures_a_real_screen(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -101,7 +103,7 @@ class TLSWebSocketTests(WebSocketTests):
 
 def _bases(server: VNCServer) -> tuple:
     bases = []
-    if server not in SCENE_SERVERS:
+    if server not in SUPPORTED_SERVERS:
         bases.append(BasicWebSocketTests)
     if server.address.startswith("wss://"):
         bases.append(TLSWebSocketTests)

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -191,7 +191,6 @@ QEMU_TLS = VNCServer(
     tls_ca=QEMU_TLS_CA,
 )
 
-
 @contextlib.contextmanager
 def selenoid_session() -> Iterator[None]:
     endpoint = f"http://{HOST}:{SELENOID.port}/wd/hub/session"
@@ -240,6 +239,20 @@ WEBSOCKET_SERVERS = [QEMU, QEMU_TLS, SELENOID, KASMVNC]
 # format grids reach them over ws:// and the handshake is exercised by every
 # case rather than by a test of its own.
 SCENE_SERVERS += [SELENOID, KASMVNC]
+
+# One entry per product in README.md's "Supported" class, which is the claim
+# this grid tests. Wider than SCENE_SERVERS, because a server can answer
+# input without being able to display a scene: libvncserver-example has no X
+# server, and qemu shows firmware.
+SUPPORTED_SERVERS = [
+    TIGERVNC,
+    X11VNC,
+    WAYVNC,
+    LIBVNCSERVER_EXAMPLE,
+    KASMVNC,
+    QEMU,
+    SELENOID,
+]
 
 
 # An event sink rather than a rendering server, so it stays out of the smoke
@@ -713,7 +726,7 @@ def start_replay_server(
     testcase.fail(f"vncdo-replay --server never listened on {port}: {server.communicate()[1]}")
 
 
-class _VNCServerTestMixin:
+class _VNCServerVerificationTestMixin:
     """Shared test body, parameterized per-server by register_server_tests().
 
     Deliberately does NOT subclass TestCase, or `unittest discover` would
@@ -723,15 +736,18 @@ class _VNCServerTestMixin:
     server: VNCServer
 
     def setUp(self) -> None:
-        if server_is_up(self.server):
-            return
-        unreachable = (
-            f"{self.server.name} not reachable on {HOST}:{self.server.port} -- "
-            f"{self.server.how_to_start}"
-        )
-        if absent_server_skips(self.server):
-            self.skipTest(unreachable)
-        self.fail(unreachable)
+        if not server_is_up(self.server):
+            unreachable = (
+                f"{self.server.name} not reachable on {HOST}:{self.server.port} -- "
+                f"{self.server.how_to_start}"
+            )
+            if absent_server_skips(self.server):
+                self.skipTest(unreachable)
+            self.fail(unreachable)
+        if self.server is SELENOID:
+            session = selenoid_session()
+            session.__enter__()
+            self.addCleanup(session.__exit__, None, None, None)
 
     def run_vncdo_ok(self, *args: str) -> subprocess.CompletedProcess:
         result = run_vncdo(self.server, *args)
@@ -743,17 +759,31 @@ class _VNCServerTestMixin:
         )
         return result
 
+    def assert_survives(self, *args: str) -> None:
+        """The exit status alone proves nothing: vncdo has sent the event and
+        returned before the server reacts. KasmVNC closes the WebSocket on a
+        PointerEvent, and a bare `move` against it still exits 0 about a
+        second later.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            png = Path(tmp) / "after-input.png"
+            self.run_vncdo_ok(*args, "pause", "0.3", "capture", str(png))
+
     def test_connect(self) -> None:
         """Handshake and auth succeed: `pause 0` still needs a live connection."""
         self.run_vncdo_ok("pause", "0")
 
     def test_keypress(self) -> None:
-        """A key event is accepted without the server dropping the session."""
-        self.run_vncdo_ok("key", "x")
+        """A key event is accepted and the session survives it."""
+        self.assert_survives("key", "x")
 
     def test_mousemove(self) -> None:
-        """A pointer event is accepted without the server dropping the session."""
-        self.run_vncdo_ok("move", "10", "10")
+        """A pointer event is accepted and the session survives it."""
+        self.assert_survives("move", "10", "10")
+
+    def test_click(self) -> None:
+        """A button event is accepted and the session survives it."""
+        self.assert_survives("move", "10", "10", "click", "1")
 
     def test_capture(self) -> None:
         """A framebuffer update is received and encoded to a PNG.
@@ -798,7 +828,9 @@ class _VNCServerTestMixin:
         )
 
 
-def register_server_tests(servers: List[VNCServer], namespace: Dict[str, object]) -> None:
+def register_server_tests(
+    servers: List[VNCServer], namespace: Dict[str, object], base: type = TestCase
+) -> None:
     """Add one TestCase subclass per server to a test module's namespace.
 
     Gives `unittest discover` a separate pass/fail/skip per server instead of
@@ -808,7 +840,7 @@ def register_server_tests(servers: List[VNCServer], namespace: Dict[str, object]
         name = "TestServer_" + server.name.replace("-", "_")
         namespace[name] = type(
             name,
-            (_VNCServerTestMixin, TestCase),
+            (_VNCServerVerificationTestMixin, base),
             # __module__ so test ids name the registering module, not this one.
             {"server": server, "__module__": namespace.get("__name__", __name__)},
         )

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -191,6 +191,7 @@ QEMU_TLS = VNCServer(
     tls_ca=QEMU_TLS_CA,
 )
 
+
 @contextlib.contextmanager
 def selenoid_session() -> Iterator[None]:
     endpoint = f"http://{HOST}:{SELENOID.port}/wd/hub/session"
@@ -240,10 +241,6 @@ WEBSOCKET_SERVERS = [QEMU, QEMU_TLS, SELENOID, KASMVNC]
 # case rather than by a test of its own.
 SCENE_SERVERS += [SELENOID, KASMVNC]
 
-# One entry per product in README.md's "Supported" class, which is the claim
-# this grid tests. Wider than SCENE_SERVERS, because a server can answer
-# input without being able to display a scene: libvncserver-example has no X
-# server, and qemu shows firmware.
 SUPPORTED_SERVERS = [
     TIGERVNC,
     X11VNC,
@@ -726,7 +723,7 @@ def start_replay_server(
     testcase.fail(f"vncdo-replay --server never listened on {port}: {server.communicate()[1]}")
 
 
-class _VNCServerVerificationTestMixin:
+class _VNCServerTestMixin:
     """Shared test body, parameterized per-server by register_server_tests().
 
     Deliberately does NOT subclass TestCase, or `unittest discover` would
@@ -840,7 +837,7 @@ def register_server_tests(
         name = "TestServer_" + server.name.replace("-", "_")
         namespace[name] = type(
             name,
-            (_VNCServerVerificationTestMixin, base),
+            (_VNCServerTestMixin, base),
             # __module__ so test ids name the registering module, not this one.
             {"server": server, "__module__": namespace.get("__name__", __name__)},
         )

--- a/tests/goldens/click_targets.py
+++ b/tests/goldens/click_targets.py
@@ -1,0 +1,26 @@
+"""Imports nothing, so the scene player can run this arithmetic inside the
+fleet images. tests/.dockerignore keeps `goldens/scenes.py` out of those
+images, and the player has to place a cell exactly where the tests outside
+expect it.
+"""
+from typing import Optional, Tuple
+
+SCREEN = (256, 192)
+KEYS = ("0", "c", "d", "f", "g", "p", "s", "x")
+COLUMNS = 4
+ROWS = (len(KEYS) + COLUMNS - 1) // COLUMNS
+CELL = (SCREEN[0] // COLUMNS, SCREEN[1] // ROWS)
+
+
+def click_target(key: str) -> Tuple[int, int]:
+    index = KEYS.index(key)
+    column, row = index % COLUMNS, index // COLUMNS
+    return column * CELL[0] + CELL[0] // 2, row * CELL[1] + CELL[1] // 2
+
+
+def scene_at(x: int, y: int) -> Optional[str]:
+    column, row = x // CELL[0], y // CELL[1]
+    if not 0 <= column < COLUMNS:
+        return None
+    index = row * COLUMNS + column
+    return KEYS[index] if 0 <= index < len(KEYS) else None

--- a/tests/goldens/click_targets.py
+++ b/tests/goldens/click_targets.py
@@ -1,7 +1,6 @@
-"""Imports nothing, so the scene player can run this arithmetic inside the
-fleet images. tests/.dockerignore keeps `goldens/scenes.py` out of those
-images, and the player has to place a cell exactly where the tests outside
-expect it.
+"""tests/.dockerignore excludes `goldens/scenes.py` from the fleet images, so
+this module holds the click layout: both the in-container scene player and
+the tests outside it import it, and neither computes its own copy.
 """
 from typing import Optional, Tuple
 

--- a/tests/goldens/scene_player.py
+++ b/tests/goldens/scene_player.py
@@ -9,6 +9,9 @@ from pathlib import Path
 from PIL import Image
 from Xlib import X, display
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from tests.goldens import click_targets  # noqa: E402
+
 DEFAULT_SCENE_DIR = Path(__file__).resolve().parent / "scenes"
 # Keeps each PutImage request under the server's maximum request length.
 BAND_ROWS = 32
@@ -33,10 +36,11 @@ class ScenePlayer:
             X.InputOutput, X.CopyFromParent,
             background_pixel=screen.black_pixel,
             override_redirect=True,
-            event_mask=X.ExposureMask,
+            event_mask=X.ExposureMask | X.ButtonPressMask,
         )
-        # Without this, key events never reach the container's `xev -root` sink.
-        screen.root.change_attributes(event_mask=X.KeyPressMask)
+        # Without this, key and button events never reach the container's
+        # `xev -root` sink.
+        screen.root.change_attributes(event_mask=X.KeyPressMask | X.ButtonPressMask)
         self.gc = self.window.create_gc()
         self.window.map()
         self.paint()
@@ -55,7 +59,12 @@ class ScenePlayer:
 
     def handle_key(self, keycode: int) -> None:
         keysym = self.display.keycode_to_keysym(keycode, 0)
-        key = self.keysym_to_key(keysym)
+        self.show(self.keysym_to_key(keysym))
+
+    def handle_button(self, x: int, y: int) -> None:
+        self.show(click_targets.scene_at(x, y) or "")
+
+    def show(self, key: str) -> None:
         path = self.scene_dir / f"{key}.png"
         if not key or not path.exists():
             return
@@ -69,6 +78,8 @@ class ScenePlayer:
                 self.paint()
             elif event.type == X.KeyPress:
                 self.handle_key(event.detail)
+            elif event.type == X.ButtonPress:
+                self.handle_button(event.event_x, event.event_y)
 
     @staticmethod
     def keysym_to_key(keysym: int) -> str:

--- a/tests/goldens/scene_player.py
+++ b/tests/goldens/scene_player.py
@@ -10,7 +10,6 @@ from PIL import Image
 from Xlib import X, display
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-from tests.goldens import click_targets  # noqa: E402
 
 DEFAULT_SCENE_DIR = Path(__file__).resolve().parent / "scenes"
 # Keeps each PutImage request under the server's maximum request length.
@@ -62,6 +61,8 @@ class ScenePlayer:
         self.show(self.keysym_to_key(keysym))
 
     def handle_button(self, x: int, y: int) -> None:
+        from tests.goldens import click_targets
+
         self.show(click_targets.scene_at(x, y) or "")
 
     def show(self, key: str) -> None:

--- a/tests/servers/Dockerfile
+++ b/tests/servers/Dockerfile
@@ -25,6 +25,7 @@ RUN mkdir -p /tests && printf '"""Test suite package for vncdotool."""\n' > /tes
 COPY servers/__init__.py /tests/servers/__init__.py
 COPY goldens/__init__.py /tests/goldens/__init__.py
 COPY goldens/scene_player.py /tests/goldens/scene_player.py
+COPY goldens/click_targets.py /tests/goldens/click_targets.py
 COPY goldens/scenes/ /tests/goldens/scenes/
 
 EXPOSE 5900

--- a/tests/unit/test_scenes.py
+++ b/tests/unit/test_scenes.py
@@ -5,7 +5,7 @@ import unittest
 
 from PIL import Image
 
-from tests.goldens import scenes
+from tests.goldens import click_targets, scenes
 from vncdotool import pixelformat
 
 
@@ -83,6 +83,33 @@ class TestScenes(unittest.TestCase):
         self.assertEqual(stamped.tobytes(), expected.tobytes())
 
 
+class TestClickTargets(unittest.TestCase):
+    def test_no_two_scenes_share_a_target(self) -> None:
+        targets = [click_targets.click_target(key) for key in click_targets.KEYS]
+        self.assertEqual(len(set(targets)), len(targets))
+
+    def test_the_catalogues_agree(self) -> None:
+        """The two catalogues list the same scenes, so no cell selects nothing."""
+        self.assertEqual(click_targets.KEYS, tuple(sorted(scenes.SCENES)))
+
+    def test_the_grid_matches_the_scene_geometry(self) -> None:
+        self.assertEqual(click_targets.SCREEN, scenes.SIZE)
+
+
+class ClickTargetRoundTrip:
+    key: str
+
+    def test_a_target_selects_its_own_scene(self) -> None:
+        x, y = click_targets.click_target(self.key)
+        self.assertEqual(click_targets.scene_at(x, y), self.key)
+
+    def test_a_target_is_on_screen(self) -> None:
+        x, y = click_targets.click_target(self.key)
+        width, height = click_targets.SCREEN
+        self.assertTrue(0 <= x < width, f"x {x} outside {width}")
+        self.assertTrue(0 <= y < height, f"y {y} outside {height}")
+
+
 class JpegRoundTrip:
     """The glyph read back off a scene a lossy encoder has been through.
 
@@ -115,6 +142,14 @@ class PatchRoundTrip:
 def load_tests(loader: unittest.TestLoader, tests: unittest.TestSuite, pattern: object) -> unittest.TestSuite:
     suite = unittest.TestSuite()
     suite.addTests(loader.loadTestsFromTestCase(TestScenes))
+    suite.addTests(loader.loadTestsFromTestCase(TestClickTargets))
+    for key in click_targets.KEYS:
+        case = type(
+            f"TestClickTarget_{key}",
+            (ClickTargetRoundTrip, unittest.TestCase),
+            {"key": key},
+        )
+        suite.addTests(loader.loadTestsFromTestCase(case))
     for name in pixelformat.PIXEL_FORMATS:
         for key in scenes.SCENES:
             case = type(


### PR DESCRIPTION
The per-server grid ran against TigerVNC and libvncserver-example alone, so no test had ever sent a pointer event to KasmVNC, Selenoid or wayvnc. It now runs against `SUPPORTED_SERVERS`, one entry per product in README's Supported class, so the set we claim and the set we test are the same list.

Input cases no longer trust the exit status: vncdo returns before the server reacts, so `move 10 10` exits 0 against a server that then drops the session. Each input case uses the connection again afterwards. Clicking is verified rather than survived, the scene player mapping a click to a scene as it already maps a keypress.

KasmVNC fails `test_mousemove`, `test_click` and the click case here. That is the defect the widened grid was meant to find, so **this PR is red on kasmvnc by design**; #512 stacks on this branch and fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
