### PR TITLE
Boot the native QEMU/KVM test server on OVMF

### DIFF
--- a/tests/servers/qemu-kvm/README.md
+++ b/tests/servers/qemu-kvm/README.md
@@ -21,9 +21,14 @@ Why this server is raw rather than a container, when Tier 1 already has a
 ## What the setup has to get right
 
 * **There is no guest, and that is deliberate.** With no `-drive` and no
-  `-kernel`, the machine stops at the firmware's "no bootable device"
-  screen. That is still a real framebuffer served by QEMU's own RFB code,
-  and it costs no guest image to download and no boot to wait for.
+  `-kernel`, the machine stops on the firmware's failed-boot screen. That is
+  still a real framebuffer served by QEMU's own RFB code, and it costs no
+  guest image to download and no boot to wait for.
+
+* **The firmware is OVMF, and the machine has no network.** SeaBIOS, QEMU's
+  default, blinks a VGA text cursor, so two captures of an idle machine
+  differ. Without `-net none` OVMF retries PXE forever and the screen
+  scrolls instead. `setup.sh` installs the `ovmf` package alongside QEMU.
 
 * **`-vnc :0` listens on every interface.** QEMU's VNC server has no
   authentication unless it is started with `password=on` *and* a password is
@@ -65,8 +70,8 @@ negotiation, the encodings and pixel formats it offers, and its
 QEMU-specific pseudo-encodings.
 
 Captures come back with real content rather than the flat black a hosted
-macOS runner gives: the firmware's text screen is 720x400 in the default VGA
-text mode, drawn in a handful of colours.
+macOS runner gives: the firmware's own screen, drawn in a handful of
+colours.
 
 It does not cover a guest. Key and pointer events are accepted by the server
 and delivered to a machine with nothing running on it, so nothing types

--- a/tests/servers/qemu-kvm/setup.sh
+++ b/tests/servers/qemu-kvm/setup.sh
@@ -21,6 +21,13 @@ ACCEL="${VNCDOTOOL_QEMU_ACCEL:-kvm}"
 MEMORY="${VNCDOTOOL_QEMU_MEMORY:-256}"
 
 QEMU=qemu-system-x86_64
+# Ubuntu 24.04's ovmf package ships only the 4M name; Debian bookworm, which
+# the Docker fleet builds on, ships only the plain one.
+OVMF_CANDIDATES=(
+    /usr/share/OVMF/OVMF_CODE_4M.fd
+    /usr/share/OVMF/OVMF_CODE.fd
+)
+BIOS=""
 RUNTIME_DIR="${VNCDOTOOL_QEMU_RUNTIME_DIR:-/tmp/vncdotool-qemu}"
 PIDFILE="$RUNTIME_DIR/qemu.pid"
 LOGFILE="$RUNTIME_DIR/qemu.log"
@@ -28,14 +35,40 @@ LOGFILE="$RUNTIME_DIR/qemu.log"
 # QEMU takes a display number, not a port: :0 is 5900.
 DISPLAY_NUMBER=$((PORT - 5900))
 
+find_ovmf() {
+    local candidate
+    for candidate in "${OVMF_CANDIDATES[@]}"; do
+        if [ -r "$candidate" ]; then
+            echo "$candidate"
+            return
+        fi
+    done
+    return 1
+}
+
 install_qemu() {
-    echo "--- installing $QEMU"
+    echo "--- installing $QEMU and OVMF"
+    local packages=()
     if command -v "$QEMU" >/dev/null 2>&1; then
         echo "$QEMU already installed: $("$QEMU" --version | head -1)"
-        return
+    else
+        packages+=(qemu-system-x86)
     fi
-    sudo apt-get update
-    sudo apt-get install -y --no-install-recommends qemu-system-x86
+    if BIOS="$(find_ovmf)"; then
+        echo "OVMF already installed: $BIOS"
+    else
+        packages+=(ovmf)
+    fi
+    if [ "${#packages[@]}" -gt 0 ]; then
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends "${packages[@]}"
+    fi
+    if [ -z "$BIOS" ] && ! BIOS="$(find_ovmf)"; then
+        echo "no OVMF firmware to boot; looked for:" >&2
+        printf '  %s\n' "${OVMF_CANDIDATES[@]}" >&2
+        return 1
+    fi
+    echo "--- firmware to boot: $BIOS"
 }
 
 grant_kvm_access() {
@@ -79,8 +112,11 @@ start_qemu() {
     echo "--- starting $QEMU on display :$DISPLAY_NUMBER with -accel $ACCEL"
     mkdir -p "$RUNTIME_DIR"
     rm -f "$PIDFILE"
-    # No -drive and no -kernel: with nothing to boot, the machine sits at the
-    # firmware's "no bootable device" screen, which is a real framebuffer.
+    # No -drive and no -kernel: with nothing to boot, the firmware stops on
+    # its failed-boot screen, which is a real framebuffer. OVMF's holds
+    # still; SeaBIOS blinks a VGA text cursor, so two captures of an idle
+    # machine differ. Without -net none OVMF retries PXE forever and the
+    # screen scrolls instead.
     #
     # The 127.0.0.1: prefix is load-bearing. A bare -vnc :0 listens on every
     # interface, and this server has no authentication at all.
@@ -89,6 +125,8 @@ start_qemu() {
         -accel "$ACCEL" \
         -m "$MEMORY" \
         -vga std \
+        -net none \
+        -bios "$BIOS" \
         -vnc "127.0.0.1:$DISPLAY_NUMBER" \
         -pidfile "$PIDFILE" \
         -D "$LOGFILE" \


### PR DESCRIPTION
#513 gave the Docker fleet's QEMU `-bios` OVMF and `-net none`. The native server the "Linux - QEMU/KVM" job starts raw on the runner is a different server and kept SeaBIOS, whose blinking cursor and boot-device cycling make two captures of an idle machine differ everywhere — currently failing `test_capture_does_not_depend_on_where_the_pointer_is`.

The firmware path is probed rather than hardcoded: bookworm's `ovmf` ships `OVMF_CODE.fd`, Ubuntu 24.04's ships only `OVMF_CODE_4M.fd`.

I can't run QEMU/KVM on macOS, so the change is unverified outside CI; the "Linux - QEMU/KVM" job is the check. I did drive `install_qemu` against stubbed candidate paths to confirm all three branches (both names, one name, neither) behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
