### PR TITLE
Trim the qemu-kvm OVMF comments

### DIFF
--- a/tests/servers/qemu-kvm/README.md
+++ b/tests/servers/qemu-kvm/README.md
@@ -25,10 +25,9 @@ Why this server is raw rather than a container, when Tier 1 already has a
   still a real framebuffer served by QEMU's own RFB code, and it costs no
   guest image to download and no boot to wait for.
 
-* **The firmware is OVMF, and the machine has no network.** SeaBIOS, QEMU's
-  default, blinks a VGA text cursor, so two captures of an idle machine
-  differ. Without `-net none` OVMF retries PXE forever and the screen
-  scrolls instead. `setup.sh` installs the `ovmf` package alongside QEMU.
+* **OVMF, not SeaBIOS, and no network.** SeaBIOS blinks a VGA text cursor,
+  so two captures of an idle machine differ. Without `-net none` OVMF
+  retries PXE forever and the screen scrolls instead.
 
 * **`-vnc :0` listens on every interface.** QEMU's VNC server has no
   authentication unless it is started with `password=on` *and* a password is

--- a/tests/servers/qemu-kvm/setup.sh
+++ b/tests/servers/qemu-kvm/setup.sh
@@ -21,8 +21,8 @@ ACCEL="${VNCDOTOOL_QEMU_ACCEL:-kvm}"
 MEMORY="${VNCDOTOOL_QEMU_MEMORY:-256}"
 
 QEMU=qemu-system-x86_64
-# Ubuntu 24.04's ovmf package ships only the 4M name; Debian bookworm, which
-# the Docker fleet builds on, ships only the plain one.
+# ovmf ships OVMF_CODE_4M.fd on Ubuntu 24.04 and OVMF_CODE.fd on Debian
+# bookworm.
 OVMF_CANDIDATES=(
     /usr/share/OVMF/OVMF_CODE_4M.fd
     /usr/share/OVMF/OVMF_CODE.fd
@@ -113,10 +113,11 @@ start_qemu() {
     mkdir -p "$RUNTIME_DIR"
     rm -f "$PIDFILE"
     # No -drive and no -kernel: with nothing to boot, the firmware stops on
-    # its failed-boot screen, which is a real framebuffer. OVMF's holds
-    # still; SeaBIOS blinks a VGA text cursor, so two captures of an idle
-    # machine differ. Without -net none OVMF retries PXE forever and the
-    # screen scrolls instead.
+    # its failed-boot screen, which is a real framebuffer.
+    #
+    # SeaBIOS blinks a VGA text cursor, so two captures of an idle machine
+    # differ. Without -net none OVMF retries PXE forever and the screen
+    # scrolls instead.
     #
     # The 127.0.0.1: prefix is load-bearing. A bare -vnc :0 listens on every
     # interface, and this server has no authentication at all.


### PR DESCRIPTION
Follow-up to #517, which merged before this trim landed: the OVMF comments in `setup.sh` and its README mirror stated OVMF holds still before saying why, and looped the Docker fleet's packaging into a comment that only needs to name two firmware filenames. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
